### PR TITLE
Setup license header for VS Code users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "licenser.license": "Custom",
+  "licenser.customHeader": "\n(C) Copyright IBM Corp. @YEAR@, @YEAR@\n\nSPDX-License-Identifier: Apache-2.0",
+  "licenser.useSingleLineStyle": false
+}
+


### PR DESCRIPTION
leveraging the [ymotongpoo/vsc-licenser](https://github.com/ymotongpoo/vsc-licenser) extension.

I wasn't sure if we wanted this to be committed since it is `IDE` specific,
but I thought that I would at least open up the discussion.