### PR TITLE
Model info support

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -671,7 +671,7 @@ public class CqlEngineWrapper {
 			}
 
 			boolean isForceTranslation = arguments.sourceFormat == LibraryFormat.CQL;
-			CqlTranslationProvider<File> translationProvider = new InJVMCqlTranslationProvider(sourceProvider);
+			CqlTranslationProvider translationProvider = new InJVMCqlTranslationProvider(sourceProvider);
 			if (arguments.modelInfoFile != null && arguments.modelInfoFile.exists()) {
 				translationProvider.convertAndRegisterModelInfo(arguments.modelInfoFile);
 			}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -55,7 +55,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.Console;
 import com.beust.jcommander.internal.DefaultConsole;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.translation.BaseCqlTranslationProvider;
 import com.ibm.cohort.engine.translation.CqlTranslationProvider;
 import com.ibm.cohort.engine.translation.InJVMCqlTranslationProvider;
 
@@ -672,7 +671,10 @@ public class CqlEngineWrapper {
 			}
 
 			boolean isForceTranslation = arguments.sourceFormat == LibraryFormat.CQL;
-			CqlTranslationProvider translationProvider = new InJVMCqlTranslationProvider(sourceProvider, arguments.modelInfoFile);
+			CqlTranslationProvider<File> translationProvider = new InJVMCqlTranslationProvider(sourceProvider);
+			if (arguments.modelInfoFile != null && arguments.modelInfoFile.exists()) {
+				translationProvider.convertAndRegisterModelInfo(arguments.modelInfoFile);
+			}
 			
 			setLibraryLoader(new TranslatingLibraryLoader(sourceProvider, translationProvider, isForceTranslation));
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -622,6 +622,17 @@ public class CqlEngineWrapper {
 		typedValue = new Quantity().withValue(new BigDecimal(parts[0])).withUnit(parts[1]);
 		return typedValue;
 	}
+	
+	protected static void registerModelInfo(File modelInfoFile) {
+		ModelInfo modelInfo = JAXB.unmarshal(modelInfoFile, ModelInfo.class);
+		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
+		// Possibly add support for auto-loading model info files.
+		modelInfo.setTargetVersion("4.0.1");
+		modelInfo.setTargetUrl("http://hl7.org/fhir");
+		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+		ModelInfoProvider modelProvider = () -> modelInfo;
+		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
+	}
 
 	/**
 	 * Simulate main method behavior in a non-static context for use in testing
@@ -676,14 +687,7 @@ public class CqlEngineWrapper {
 			}
 
 			if (arguments.modelInfoFile !=  null && arguments.modelInfoFile.exists()) {
-				ModelInfo modelInfo = JAXB.unmarshal(arguments.modelInfoFile, ModelInfo.class);
-				// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
-				// Possibly add support for auto-loading model info files.
-				modelInfo.setTargetVersion("4.0.1");
-				modelInfo.setTargetUrl("http://hl7.org/fhir");
-				org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-				ModelInfoProvider modelProvider = () -> modelInfo;
-				ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
+				registerModelInfo(arguments.modelInfoFile);
 			}
 
 			boolean isForceTranslation = arguments.sourceFormat == LibraryFormat.CQL;

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -677,7 +677,8 @@ public class CqlEngineWrapper {
 
 			if (arguments.modelInfoFile !=  null && arguments.modelInfoFile.exists()) {
 				ModelInfo modelInfo = JAXB.unmarshal(arguments.modelInfoFile, ModelInfo.class);
-				// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future
+				// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
+				// Possibly add support for auto-loading model info files.
 				modelInfo.setTargetVersion("4.0.1");
 				modelInfo.setTargetUrl("http://hl7.org/fhir");
 				org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -672,11 +672,7 @@ public class CqlEngineWrapper {
 			}
 
 			boolean isForceTranslation = arguments.sourceFormat == LibraryFormat.CQL;
-			CqlTranslationProvider translationProvider = new InJVMCqlTranslationProvider(sourceProvider);
-
-			if (arguments.modelInfoFile !=  null && arguments.modelInfoFile.exists()) {
-				BaseCqlTranslationProvider.registerModelInfo(arguments.modelInfoFile);
-			}
+			CqlTranslationProvider translationProvider = new InJVMCqlTranslationProvider(sourceProvider, arguments.modelInfoFile);
 			
 			setLibraryLoader(new TranslatingLibraryLoader(sourceProvider, translationProvider, isForceTranslation));
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
@@ -6,14 +6,20 @@
 
 package com.ibm.cohort.engine.translation;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.JAXB;
+
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
+import org.cqframework.cql.cql2elm.ModelInfoLoader;
+import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.elm.execution.Library;
+import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import com.ibm.cohort.engine.LibraryFormat;
 
@@ -24,6 +30,17 @@ import com.ibm.cohort.engine.LibraryFormat;
 public abstract class BaseCqlTranslationProvider implements CqlTranslationProvider {
 
 	public static final LibraryFormat DEFAULT_TARGET_FORMAT = LibraryFormat.XML;
+
+	public static void registerModelInfo(File modelInfoFile) {
+		ModelInfo modelInfo = JAXB.unmarshal(modelInfoFile, ModelInfo.class);
+		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
+		// Possibly add support for auto-loading model info files.
+		modelInfo.setTargetVersion("4.0.1");
+		modelInfo.setTargetUrl("http://hl7.org/fhir");
+		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+		ModelInfoProvider modelProvider = () -> modelInfo;
+		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
+	}
 	
 	public List<Options> getDefaultOptions() {
 		List<CqlTranslator.Options> defaults = new ArrayList<>(CqlTranslatorOptions.defaultOptions().getOptions());

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
@@ -6,20 +6,14 @@
 
 package com.ibm.cohort.engine.translation;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.JAXB;
-
 import org.cqframework.cql.cql2elm.CqlTranslator;
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
-import org.cqframework.cql.cql2elm.ModelInfoLoader;
-import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.elm.execution.Library;
-import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import com.ibm.cohort.engine.LibraryFormat;
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
@@ -21,7 +21,7 @@ import com.ibm.cohort.engine.LibraryFormat;
  * Common functionality for use when implementing CQL translator
  * wrapper implementations.
  */
-public abstract class BaseCqlTranslationProvider<T> implements CqlTranslationProvider<T> {
+public abstract class BaseCqlTranslationProvider implements CqlTranslationProvider {
 
 	public static final LibraryFormat DEFAULT_TARGET_FORMAT = LibraryFormat.XML;
 	

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
@@ -21,7 +21,7 @@ import com.ibm.cohort.engine.LibraryFormat;
  * Common functionality for use when implementing CQL translator
  * wrapper implementations.
  */
-public abstract class BaseCqlTranslationProvider implements CqlTranslationProvider {
+public abstract class BaseCqlTranslationProvider<T> implements CqlTranslationProvider<T> {
 
 	public static final LibraryFormat DEFAULT_TARGET_FORMAT = LibraryFormat.XML;
 	

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/BaseCqlTranslationProvider.java
@@ -30,17 +30,6 @@ import com.ibm.cohort.engine.LibraryFormat;
 public abstract class BaseCqlTranslationProvider implements CqlTranslationProvider {
 
 	public static final LibraryFormat DEFAULT_TARGET_FORMAT = LibraryFormat.XML;
-
-	public static void registerModelInfo(File modelInfoFile) {
-		ModelInfo modelInfo = JAXB.unmarshal(modelInfoFile, ModelInfo.class);
-		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
-		// Possibly add support for auto-loading model info files.
-		modelInfo.setTargetVersion("4.0.1");
-		modelInfo.setTargetUrl("http://hl7.org/fhir");
-		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-		ModelInfoProvider modelProvider = () -> modelInfo;
-		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
-	}
 	
 	public List<Options> getDefaultOptions() {
 		List<CqlTranslator.Options> defaults = new ArrayList<>(CqlTranslatorOptions.defaultOptions().getOptions());

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
@@ -6,12 +6,12 @@
 
 package com.ibm.cohort.engine.translation;
 
+import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.List;
 
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
-import org.cqframework.cql.cql2elm.ModelInfoLoader;
-import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.elm.execution.Library;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
@@ -22,7 +22,7 @@ import com.ibm.cohort.engine.LibraryFormat;
  * implementations of a CqlTranslator such as linking directly to the translator
  * JAR or calling out to the CqlTranslationService microservice.
  */
-public interface CqlTranslationProvider<T> {
+public interface CqlTranslationProvider {
 	public Library translate(InputStream cql) throws Exception;
 
 	public Library translate(InputStream cql, List<Options> options) throws Exception;
@@ -31,9 +31,21 @@ public interface CqlTranslationProvider<T> {
 	
 	public void registerModelInfo(ModelInfo modelInfo);
 	
-	public default void convertAndRegisterModelInfo(T modelInfoObject) {
-		registerModelInfo(convertToModelInfo(modelInfoObject));
+	public default void convertAndRegisterModelInfo(InputStream modelInfoInputStream) {
+		registerModelInfo(convertToModelInfo(modelInfoInputStream));
 	}
-	
-	public ModelInfo convertToModelInfo(T modelInfoObject);
+
+	public default void convertAndRegisterModelInfo(File modelInfoFile) {
+		registerModelInfo(convertToModelInfo(modelInfoFile));
+	}
+
+	public default void convertAndRegisterModelInfo(Reader modelInfoReader) {
+		registerModelInfo(convertToModelInfo(modelInfoReader));
+	}
+
+	public ModelInfo convertToModelInfo(InputStream modelInfoInputStream);
+
+	public ModelInfo convertToModelInfo(File modelInfoFile);
+
+	public ModelInfo convertToModelInfo(Reader modelInfoReader);
 }

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
@@ -10,7 +10,10 @@ import java.io.InputStream;
 import java.util.List;
 
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
+import org.cqframework.cql.cql2elm.ModelInfoLoader;
+import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.elm.execution.Library;
+import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import com.ibm.cohort.engine.LibraryFormat;
 
@@ -19,10 +22,26 @@ import com.ibm.cohort.engine.LibraryFormat;
  * implementations of a CqlTranslator such as linking directly to the translator
  * JAR or calling out to the CqlTranslationService microservice.
  */
-public interface CqlTranslationProvider {
+public interface CqlTranslationProvider<T> {
 	public Library translate(InputStream cql) throws Exception;
 
 	public Library translate(InputStream cql, List<Options> options) throws Exception;
 
 	public Library translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
+	
+	public default void registerModelInfo(ModelInfo modelInfo) {
+		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
+		// Possibly add support for auto-loading model info files.
+		modelInfo.setTargetVersion("4.0.1");
+		modelInfo.setTargetUrl("http://hl7.org/fhir");
+		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+		ModelInfoProvider modelProvider = () -> modelInfo;
+		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
+	}
+	
+	public default void convertAndRegisterModelInfo(T modelInfoObject) {
+		registerModelInfo(convertToModelInfo(modelInfoObject));
+	}
+	
+	public ModelInfo convertToModelInfo(T modelInfoObject);
 }

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/CqlTranslationProvider.java
@@ -29,15 +29,7 @@ public interface CqlTranslationProvider<T> {
 
 	public Library translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
 	
-	public default void registerModelInfo(ModelInfo modelInfo) {
-		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
-		// Possibly add support for auto-loading model info files.
-		modelInfo.setTargetVersion("4.0.1");
-		modelInfo.setTargetUrl("http://hl7.org/fhir");
-		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-		ModelInfoProvider modelProvider = () -> modelInfo;
-		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
-	}
+	public void registerModelInfo(ModelInfo modelInfo);
 	
 	public default void convertAndRegisterModelInfo(T modelInfoObject) {
 		registerModelInfo(convertToModelInfo(modelInfoObject));

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
@@ -22,6 +22,8 @@ import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
 import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
+import org.cqframework.cql.cql2elm.ModelInfoLoader;
+import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.elm.execution.Library;
 import org.fhir.ucum.UcumService;
@@ -98,6 +100,17 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider<File
 		}
 
 		return result;
+	}
+	
+	@Override
+	public void registerModelInfo(ModelInfo modelInfo) {
+		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
+		// Possibly add support for auto-loading model info files.
+		modelInfo.setTargetVersion("4.0.1");
+		modelInfo.setTargetUrl("http://hl7.org/fhir");
+		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
+		ModelInfoProvider modelProvider = () -> modelInfo;
+		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
 	}
 
 	@Override

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
@@ -8,6 +8,7 @@ package com.ibm.cohort.engine.translation;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +38,7 @@ import com.ibm.cohort.engine.LibraryFormat;
 /**
  * Uses the CqlTranslator inprocess to convert CQL to ELM. 
  */
-public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider<File> {
+public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 
 	private static final Logger LOG = LoggerFactory.getLogger(InJVMCqlTranslationProvider.class);
 	private ModelManager modelManager;
@@ -114,8 +115,17 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider<File
 	}
 
 	@Override
-	public ModelInfo convertToModelInfo(File modelInfoObject) {
-		return JAXB.unmarshal(modelInfoObject, ModelInfo.class);
+	public ModelInfo convertToModelInfo(InputStream modelInfoInputStream) {
+		return JAXB.unmarshal(modelInfoInputStream, ModelInfo.class);
 	}
 
+	@Override
+	public ModelInfo convertToModelInfo(Reader modelInfoReader) {
+		return JAXB.unmarshal(modelInfoReader, ModelInfo.class);
+	}
+
+	@Override
+	public ModelInfo convertToModelInfo(File modelInfoFile) {
+		return JAXB.unmarshal(modelInfoFile, ModelInfo.class);
+	}
 }

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
@@ -6,6 +6,7 @@
 
 package com.ibm.cohort.engine.translation;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -47,10 +48,17 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 		this.modelManager = modelManager;
 		this.libraryManager = libraryManager;
 	}
-	
+
 	public InJVMCqlTranslationProvider(LibrarySourceProvider provider) {
+		this(provider, null);
+	}
+	
+	public InJVMCqlTranslationProvider(LibrarySourceProvider provider, File modelInfoFile) {
 		this();
 		addLibrarySourceProvider(provider);
+		if (modelInfoFile != null && modelInfoFile.exists()) {
+			BaseCqlTranslationProvider.registerModelInfo(modelInfoFile);
+		}
 	}
 
 	public InJVMCqlTranslationProvider addLibrarySourceProvider(LibrarySourceProvider provider) {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
@@ -22,8 +22,6 @@ import org.cqframework.cql.cql2elm.FhirLibrarySourceProvider;
 import org.cqframework.cql.cql2elm.LibraryBuilder;
 import org.cqframework.cql.cql2elm.LibraryManager;
 import org.cqframework.cql.cql2elm.LibrarySourceProvider;
-import org.cqframework.cql.cql2elm.ModelInfoLoader;
-import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
 import org.cqframework.cql.elm.execution.Library;
 import org.fhir.ucum.UcumService;
@@ -37,22 +35,11 @@ import com.ibm.cohort.engine.LibraryFormat;
 /**
  * Uses the CqlTranslator inprocess to convert CQL to ELM. 
  */
-public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
+public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider<File> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(InJVMCqlTranslationProvider.class);
 	private ModelManager modelManager;
 	private LibraryManager libraryManager;
-
-	public static void registerModelInfo(File modelInfoFile) {
-		ModelInfo modelInfo = JAXB.unmarshal(modelInfoFile, ModelInfo.class);
-		// Force mapping  to FHIR 4.0.1. Consider supporting different versions in the future.
-		// Possibly add support for auto-loading model info files.
-		modelInfo.setTargetVersion("4.0.1");
-		modelInfo.setTargetUrl("http://hl7.org/fhir");
-		org.hl7.elm.r1.VersionedIdentifier modelId = (new org.hl7.elm.r1.VersionedIdentifier()).withId(modelInfo.getName()).withVersion(modelInfo.getVersion());
-		ModelInfoProvider modelProvider = () -> modelInfo;
-		ModelInfoLoader.registerModelInfoProvider(modelId, modelProvider);
-	}
 
 	public InJVMCqlTranslationProvider() {
 		this.modelManager = new ModelManager();
@@ -64,17 +51,10 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 		this.modelManager = modelManager;
 		this.libraryManager = libraryManager;
 	}
-
-	public InJVMCqlTranslationProvider(LibrarySourceProvider provider) {
-		this(provider, null);
-	}
 	
-	public InJVMCqlTranslationProvider(LibrarySourceProvider provider, File modelInfoFile) {
+	public InJVMCqlTranslationProvider(LibrarySourceProvider provider) {
 		this();
 		addLibrarySourceProvider(provider);
-		if (modelInfoFile != null && modelInfoFile.exists()) {
-			registerModelInfo(modelInfoFile);
-		}
 	}
 
 	public InJVMCqlTranslationProvider addLibrarySourceProvider(LibrarySourceProvider provider) {
@@ -118,6 +98,11 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 		}
 
 		return result;
+	}
+
+	@Override
+	public ModelInfo convertToModelInfo(File modelInfoObject) {
+		return JAXB.unmarshal(modelInfoObject, ModelInfo.class);
 	}
 
 }

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEngineWrapperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEngineWrapperTest.java
@@ -35,11 +35,13 @@ import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.hl7.fhir.r4.model.RelatedArtifact.RelatedArtifactType;
+import org.hl7.fhir.r4.model.StringType;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opencds.cqf.cql.engine.runtime.Code;
@@ -731,6 +733,56 @@ public class CqlEngineWrapperTest extends BaseFhirTest {
 				Arrays.asList("123"), (p, e, r) -> {
 					fail("Execution should not reach here");
 				});
+	}
+	
+	@Test
+	public void testCQLTranslationCustomIGWithTargetUrl()  throws Exception{
+		FhirServerConfig fhirConfig = getFhirServerConfig();
+
+		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
+
+		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
+		patient.addExtension(new Extension("http://fakeIg.com/fake-extension", new StringType("fakeValue")));
+		mockFhirResourceRetrieval(patient);
+
+		Library root = getLibrary("test", "cql/ig-test/test.cql");
+		Library helpers = getLibrary("FHIRHelpers", "cql/includes/FHIRHelpers.cql", "text/cql",
+									 "cql/includes/FHIRHelpers.xml", "application/elm+json");
+
+		RelatedArtifact related = new RelatedArtifact();
+		related.setType(RelatedArtifactType.DEPENDSON);
+		related.setResource("/Library/" + helpers.getId());
+		root.addRelatedArtifact(related);
+
+		mockFhirResourceRetrieval(root);
+		mockFhirResourceRetrieval(helpers);
+
+		File tmpFile = new File("target/fhir-stub.json");
+		ObjectMapper om = new ObjectMapper();
+		try (Writer w = new FileWriter(tmpFile)) {
+			w.write(om.writeValueAsString(fhirConfig));
+		}
+
+		try {
+			PrintStream originalOut = System.out;
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			try (PrintStream captureOut = new PrintStream(baos)) {
+				System.setOut(captureOut);
+				CqlEngineWrapper.main(new String[] { "-d", tmpFile.getAbsolutePath(), "-f", root.getId(), "-l",
+						root.getId(), "-v", "1.0.0", "-c", patient.getId(), "-s", "CQL", "-i", "src/test/resources/modelinfo/ig-with-target-modelinfo-0.0.1.xml" });
+			} finally {
+				System.setOut(originalOut);
+			}
+
+			String output = new String(baos.toByteArray());
+			System.out.println(output);
+
+			verify(2, getRequestedFor(urlEqualTo("/Patient/" + patient.getId())));
+			verify(1, getRequestedFor(urlEqualTo("/Library/" + root.getId())));
+			verify(1, getRequestedFor(urlEqualTo("/Library/" + helpers.getId())));
+		} finally {
+			tmpFile.delete();
+		}
 	}
 	
 	@Test

--- a/cohort-engine/src/test/resources/cql/ig-test/test.cql
+++ b/cohort-engine/src/test/resources/cql/ig-test/test.cql
@@ -1,0 +1,10 @@
+library "Test" version '1.0.0'
+
+using "fakeIg" version '0.0.1'
+include "FHIRHelpers" version '4.0.0' called FHIRHelpers
+
+context Patient
+
+define FakeExtensionExists:
+	["FakePatient"] p
+	  return exists({p.fakeExtension})

--- a/cohort-engine/src/test/resources/modelinfo/ig-with-target-modelinfo-0.0.1.xml
+++ b/cohort-engine/src/test/resources/modelinfo/ig-with-target-modelinfo-0.0.1.xml
@@ -1,0 +1,11788 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<modelInfo xmlns="urn:hl7-org:elm-modelinfo:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="fakeIg" version="0.0.1" url="http://fakeIg.com" targetUrl="http://hl7.org/fhir" targetVersion="4.0.1" targetQualifier="fakeIg" patientClassName="FakePatient" patientBirthDatePropertyName="birthDate">
+    <requiredModelInfo name="System" version="1.0.0"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Account" identifier="http://hl7.org/fhir/StructureDefinition/Account" label="Account" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.AccountStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="servicePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="coverage">
+            <elementTypeSpecifier elementType="fakeIg.Account.Coverage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="owner" elementType="fakeIg.Reference"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="guarantor">
+            <elementTypeSpecifier elementType="fakeIg.Account.Guarantor" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf" elementType="fakeIg.Reference"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Account.Coverage" retrievable="false" xsi:type="ClassInfo">
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="priority" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Account.Guarantor" retrievable="false" xsi:type="ClassInfo">
+        <element name="party" elementType="fakeIg.Reference"/>
+        <element name="onHold" elementType="System.Boolean" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AccountStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionCardinalityBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionConditionKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionGroupingBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionParticipantType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionPrecheckBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionRelationshipType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionRequiredBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActionSelectionBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ActivityDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ActivityDefinition" label="ActivityDefinition" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="library" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="kind" elementType="fakeIg.ActivityDefinitionKind"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intent" elementType="fakeIg.RequestIntent"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="timing" target="fakeIg.Timing:null;System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.ActivityDefinition.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="product" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="dosage">
+            <elementTypeSpecifier elementType="fakeIg.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specimenRequirement">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="observationRequirement">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="observationResultRequirement">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="transform" elementType="System.String" target="%value.value"/>
+        <element name="dynamicValue">
+            <elementTypeSpecifier elementType="fakeIg.ActivityDefinition.DynamicValue" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ActivityDefinition.DynamicValue" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ActivityDefinition.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ActivityParticipantType"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActivityDefinitionKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ActivityParticipantType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Address" identifier="http://hl7.org/fhir/StructureDefinition/Address" label="Address" retrievable="false" xsi:type="ClassInfo">
+        <element name="use" elementType="fakeIg.AddressUse"/>
+        <element name="type" elementType="fakeIg.AddressType"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="line" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="city" elementType="System.String" target="%value.value"/>
+        <element name="district" elementType="System.String" target="%value.value"/>
+        <element name="state" elementType="System.String" target="%value.value"/>
+        <element name="postalCode" elementType="System.String" target="%value.value"/>
+        <element name="country" elementType="System.String" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AddressType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AddressUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AdministrativeGender" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="AdverseEvent" identifier="http://hl7.org/fhir/StructureDefinition/AdverseEvent" label="AdverseEvent" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="actuality" elementType="fakeIg.AdverseEventActuality"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="event" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="detected" elementType="System.DateTime" target="%value.value"/>
+        <element name="recordedDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="resultingCondition">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="seriousness" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="severity" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="recorder" elementType="fakeIg.Reference"/>
+        <element name="contributor">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="suspectEntity">
+            <elementTypeSpecifier elementType="fakeIg.AdverseEvent.SuspectEntity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subjectMedicalHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referenceDocument">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="study">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="recorder"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="recorder"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AdverseEvent.SuspectEntity" retrievable="false" xsi:type="ClassInfo">
+        <element name="instance" elementType="fakeIg.Reference"/>
+        <element name="causality">
+            <elementTypeSpecifier elementType="fakeIg.AdverseEvent.SuspectEntity.Causality" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AdverseEvent.SuspectEntity.Causality" retrievable="false" xsi:type="ClassInfo">
+        <element name="assessment" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productRelatedness" elementType="System.String" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AdverseEventActuality" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="Age" identifier="http://hl7.org/fhir/StructureDefinition/Age" label="Age" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AggregationMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="AllergyIntolerance" identifier="http://hl7.org/fhir/StructureDefinition/AllergyIntolerance" label="AllergyIntolerance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="clinicalStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="verificationStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" elementType="fakeIg.AllergyIntoleranceType"/>
+        <element name="category">
+            <elementTypeSpecifier elementType="fakeIg.AllergyIntoleranceCategory" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="criticality" elementType="fakeIg.AllergyIntoleranceCriticality"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="onset" target="System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recordedDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="recorder" elementType="fakeIg.Reference"/>
+        <element name="asserter" elementType="fakeIg.Reference"/>
+        <element name="lastOccurrence" elementType="System.DateTime" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reaction">
+            <elementTypeSpecifier elementType="fakeIg.AllergyIntolerance.Reaction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="recorder"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="asserter"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AllergyIntolerance.Reaction" retrievable="false" xsi:type="ClassInfo">
+        <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="manifestation" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="onset" elementType="System.DateTime" target="%value.value"/>
+        <element name="severity" elementType="fakeIg.AllergyIntoleranceSeverity"/>
+        <element name="exposureRoute" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AllergyIntoleranceCategory" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AllergyIntoleranceCriticality" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AllergyIntoleranceSeverity" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AllergyIntoleranceType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Annotation" identifier="http://hl7.org/fhir/StructureDefinition/Annotation" label="Annotation" retrievable="false" xsi:type="ClassInfo">
+        <element name="author" target="fakeIg.Reference:null;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="time" elementType="System.DateTime" target="%value.value"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Appointment" identifier="http://hl7.org/fhir/StructureDefinition/Appointment" label="Appointment" retrievable="true" primaryCodePath="serviceType" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.AppointmentStatus"/>
+        <element name="cancelationReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="serviceCategory" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="appointmentType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="System.Integer" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="supportingInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="start" elementType="System.DateTime" target="%value.value"/>
+        <element name="end" elementType="System.DateTime" target="%value.value"/>
+        <element name="minutesDuration" elementType="System.Integer" target="%value.value"/>
+        <element name="slot">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="patientInstruction" elementType="System.String" target="%value.value"/>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.Appointment.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="requestedPeriod">
+            <elementTypeSpecifier xsi:type="ListTypeSpecifier">
+                <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </elementTypeSpecifier>
+            </elementTypeSpecifier>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Device" relatedKeyElement="actor"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Appointment.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="actor" elementType="fakeIg.Reference"/>
+        <element name="required" elementType="fakeIg.ParticipantRequired"/>
+        <element name="status" elementType="fakeIg.ParticipationStatus"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="AppointmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/AppointmentResponse" label="AppointmentResponse" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="appointment" elementType="fakeIg.Reference"/>
+        <element name="start" elementType="System.DateTime" target="%value.value"/>
+        <element name="end" elementType="System.DateTime" target="%value.value"/>
+        <element name="participantType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="actor" elementType="fakeIg.Reference"/>
+        <element name="participantStatus" elementType="fakeIg.ParticipantStatus"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Device" relatedKeyElement="actor"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AppointmentStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AssertionDirectionType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AssertionOperatorType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AssertionResponseTypes" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Attachment" identifier="http://hl7.org/fhir/StructureDefinition/Attachment" label="Attachment" retrievable="false" xsi:type="ClassInfo">
+        <element name="contentType" elementType="fakeIg.MimeType"/>
+        <element name="language" elementType="System.String" target="%value.value"/>
+        <element name="data" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="size" elementType="System.Integer" target="%value.value"/>
+        <element name="hash" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="creation" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="AuditEvent" identifier="http://hl7.org/fhir/StructureDefinition/AuditEvent" label="AuditEvent" retrievable="true" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="subtype" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action" elementType="fakeIg.AuditEventAction"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recorded" elementType="System.DateTime" target="%value.value"/>
+        <element name="outcome" elementType="fakeIg.AuditEventOutcome"/>
+        <element name="outcomeDesc" elementType="System.String" target="%value.value"/>
+        <element name="purposeOfEvent" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="agent">
+            <elementTypeSpecifier elementType="fakeIg.AuditEvent.Agent" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="source" elementType="fakeIg.AuditEvent.Source"/>
+        <element name="entity">
+            <elementTypeSpecifier elementType="fakeIg.AuditEvent.Entity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="who"/>
+        <contextRelationship context="Device" relatedKeyElement="who"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AuditEvent.Agent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="role" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="who" elementType="fakeIg.Reference"/>
+        <element name="altId" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="requestor" elementType="System.Boolean" target="%value.value"/>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="policy" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="media" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="network" elementType="fakeIg.AuditEvent.Agent.Network"/>
+        <element name="purposeOfUse" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AuditEvent.Agent.Network" retrievable="false" xsi:type="ClassInfo">
+        <element name="address" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.AuditEventAgentNetworkType"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AuditEvent.Entity" retrievable="false" xsi:type="ClassInfo">
+        <element name="what" elementType="fakeIg.Reference"/>
+        <element name="type" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="role" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="lifecycle" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="securityLabel" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="query" elementType="System.String" target="%value.value"/>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.AuditEvent.Entity.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AuditEvent.Entity.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="AuditEvent.Source" retrievable="false" xsi:type="ClassInfo">
+        <element name="site" elementType="System.String" target="%value.value"/>
+        <element name="observer" elementType="fakeIg.Reference"/>
+        <element name="type" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AuditEventAction" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AuditEventAgentNetworkType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="AuditEventOutcome" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="BackboneElement" identifier="http://hl7.org/fhir/StructureDefinition/BackboneElement" label="BackboneElement" retrievable="false" xsi:type="ClassInfo">
+        <element name="modifierExtension">
+            <elementTypeSpecifier elementType="fakeIg.Extension" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Basic" identifier="http://hl7.org/fhir/StructureDefinition/Basic" label="Basic" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="created" elementType="System.Date" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Resource" namespace="fakeIg" name="Binary" identifier="http://hl7.org/fhir/StructureDefinition/Binary" label="Binary" retrievable="true" xsi:type="ClassInfo">
+        <element name="contentType" elementType="fakeIg.MimeType"/>
+        <element name="securityContext" elementType="fakeIg.Reference"/>
+        <element name="data" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="BindingStrength" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="BiologicallyDerivedProduct" identifier="http://hl7.org/fhir/StructureDefinition/BiologicallyDerivedProduct" label="BiologicallyDerivedProduct" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="productCategory" elementType="fakeIg.BiologicallyDerivedProductCategory"/>
+        <element name="productCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="fakeIg.BiologicallyDerivedProductStatus"/>
+        <element name="request">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Integer" target="%value.value"/>
+        <element name="parent">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="collection" elementType="fakeIg.BiologicallyDerivedProduct.Collection"/>
+        <element name="processing">
+            <elementTypeSpecifier elementType="fakeIg.BiologicallyDerivedProduct.Processing" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="manipulation" elementType="fakeIg.BiologicallyDerivedProduct.Manipulation"/>
+        <element name="storage">
+            <elementTypeSpecifier elementType="fakeIg.BiologicallyDerivedProduct.Storage" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="BiologicallyDerivedProduct.Collection" retrievable="false" xsi:type="ClassInfo">
+        <element name="collector" elementType="fakeIg.Reference"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+        <element name="collected" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="BiologicallyDerivedProduct.Manipulation" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="time" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="BiologicallyDerivedProduct.Processing" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="procedure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="additive" elementType="fakeIg.Reference"/>
+        <element name="time" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="BiologicallyDerivedProduct.Storage" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="temperature" elementType="System.Decimal" target="%value.value"/>
+        <element name="scale" elementType="fakeIg.BiologicallyDerivedProductStorageScale"/>
+        <element name="duration">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="BiologicallyDerivedProductCategory" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="BiologicallyDerivedProductStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="BiologicallyDerivedProductStorageScale" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="BodyStructure" identifier="http://hl7.org/fhir/StructureDefinition/BodyStructure" label="BodyStructure" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="morphology" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="location" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="locationQualifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="image">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Resource" namespace="fakeIg" name="Bundle" identifier="http://hl7.org/fhir/StructureDefinition/Bundle" label="Bundle" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="fakeIg.BundleType"/>
+        <element name="timestamp" elementType="System.DateTime" target="%value.value"/>
+        <element name="total" elementType="System.Integer" target="%value.value"/>
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.Bundle.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="entry">
+            <elementTypeSpecifier elementType="fakeIg.Bundle.Entry" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="signature" elementType="fakeIg.Signature"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Bundle.Entry" retrievable="false" xsi:type="ClassInfo">
+        <element name="link">
+            <elementTypeSpecifier namespace="fakeIg" name="Bundle.Link" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="fullUrl" elementType="System.String" target="%value.value"/>
+        <element name="resource" elementType="fakeIg.Resource"/>
+        <element name="search" elementType="fakeIg.Bundle.Entry.Search"/>
+        <element name="request" elementType="fakeIg.Bundle.Entry.Request"/>
+        <element name="response" elementType="fakeIg.Bundle.Entry.Response"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Bundle.Entry.Request" retrievable="false" xsi:type="ClassInfo">
+        <element name="method" elementType="fakeIg.HTTPVerb"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="ifNoneMatch" elementType="System.String" target="%value.value"/>
+        <element name="ifModifiedSince" elementType="System.DateTime" target="%value.value"/>
+        <element name="ifMatch" elementType="System.String" target="%value.value"/>
+        <element name="ifNoneExist" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Bundle.Entry.Response" retrievable="false" xsi:type="ClassInfo">
+        <element name="status" elementType="System.String" target="%value.value"/>
+        <element name="location" elementType="System.String" target="%value.value"/>
+        <element name="etag" elementType="System.String" target="%value.value"/>
+        <element name="lastModified" elementType="System.DateTime" target="%value.value"/>
+        <element name="outcome" elementType="fakeIg.Resource"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Bundle.Entry.Search" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.SearchEntryMode"/>
+        <element name="score" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Bundle.Link" retrievable="false" xsi:type="ClassInfo">
+        <element name="relation" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="BundleType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CapabilityStatement" identifier="http://hl7.org/fhir/StructureDefinition/CapabilityStatement" label="CapabilityStatement" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="kind" elementType="fakeIg.CapabilityStatementKind"/>
+        <element name="instantiates" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="imports" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="software" elementType="fakeIg.CapabilityStatement.Software"/>
+        <element name="implementation" elementType="fakeIg.CapabilityStatement.Implementation"/>
+        <element name="fhirVersion" elementType="fakeIg.FHIRVersion"/>
+        <element name="format">
+            <elementTypeSpecifier elementType="fakeIg.MimeType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patchFormat">
+            <elementTypeSpecifier elementType="fakeIg.MimeType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="implementationGuide" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="rest">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="messaging">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Messaging" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="document">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Document" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Document" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.DocumentMode"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Implementation" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="custodian" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Messaging" retrievable="false" xsi:type="ClassInfo">
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Messaging.Endpoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reliableCache" elementType="System.Integer" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="supportedMessage">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Messaging.SupportedMessage" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Messaging.Endpoint" retrievable="false" xsi:type="ClassInfo">
+        <element name="protocol" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="address" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Messaging.SupportedMessage" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.EventCapabilityMode"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.RestfulCapabilityMode"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="security" elementType="fakeIg.CapabilityStatement.Rest.Security"/>
+        <element name="resource">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest.Resource" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="interaction">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest.Interaction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="searchParam">
+            <elementTypeSpecifier namespace="fakeIg" name="CapabilityStatement.Rest.Resource.SearchParam" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="operation">
+            <elementTypeSpecifier namespace="fakeIg" name="CapabilityStatement.Rest.Resource.Operation" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="compartment" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Interaction" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.SystemRestfulInteraction"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Resource" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ResourceType"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+        <element name="supportedProfile" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="interaction">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest.Resource.Interaction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="versioning" elementType="fakeIg.ResourceVersionPolicy"/>
+        <element name="readHistory" elementType="System.Boolean" target="%value.value"/>
+        <element name="updateCreate" elementType="System.Boolean" target="%value.value"/>
+        <element name="conditionalCreate" elementType="System.Boolean" target="%value.value"/>
+        <element name="conditionalRead" elementType="fakeIg.ConditionalReadStatus"/>
+        <element name="conditionalUpdate" elementType="System.Boolean" target="%value.value"/>
+        <element name="conditionalDelete" elementType="fakeIg.ConditionalDeleteStatus"/>
+        <element name="referencePolicy">
+            <elementTypeSpecifier elementType="fakeIg.ReferenceHandlingPolicy" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="searchInclude" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="searchRevInclude" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="searchParam">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest.Resource.SearchParam" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="operation">
+            <elementTypeSpecifier elementType="fakeIg.CapabilityStatement.Rest.Resource.Operation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Resource.Interaction" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.TypeRestfulInteraction"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Resource.Operation" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Resource.SearchParam" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.SearchParamType"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Rest.Security" retrievable="false" xsi:type="ClassInfo">
+        <element name="cors" elementType="System.Boolean" target="%value.value"/>
+        <element name="service" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CapabilityStatement.Software" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="releaseDate" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CapabilityStatementKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CarePlan" identifier="http://hl7.org/fhir/StructureDefinition/CarePlan" label="CarePlan" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="replaces">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.CarePlanStatus"/>
+        <element name="intent" elementType="fakeIg.CarePlanIntent"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="contributor">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="careTeam">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="addresses">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="goal">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="activity">
+            <elementTypeSpecifier elementType="fakeIg.CarePlan.Activity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CarePlan.Activity" retrievable="false" xsi:type="ClassInfo">
+        <element name="outcomeCodeableConcept" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outcomeReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="progress">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reference" elementType="fakeIg.Reference"/>
+        <element name="detail" elementType="fakeIg.CarePlan.Activity.Detail"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CarePlan.Activity.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="kind" elementType="fakeIg.CarePlanActivityKind"/>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="goal">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.CarePlanActivityStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="scheduled" target="fakeIg.Timing:null;;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="product" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dailyAmount" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CarePlanActivityKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CarePlanActivityStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CarePlanIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CarePlanStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CareTeam" identifier="http://hl7.org/fhir/StructureDefinition/CareTeam" label="CareTeam" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.CareTeamStatus"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.CareTeam.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="managingOrganization">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="member"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="member"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CareTeam.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="role" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="member" elementType="fakeIg.Reference"/>
+        <element name="onBehalfOf" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CareTeamStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CatalogEntry" identifier="http://hl7.org/fhir/StructureDefinition/CatalogEntry" label="CatalogEntry" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="orderable" elementType="System.Boolean" target="%value.value"/>
+        <element name="referencedItem" elementType="fakeIg.Reference"/>
+        <element name="additionalIdentifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="classification" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="validityPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="validTo" elementType="System.DateTime" target="%value.value"/>
+        <element name="lastUpdated" elementType="System.DateTime" target="%value.value"/>
+        <element name="additionalCharacteristic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="additionalClassification" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedEntry">
+            <elementTypeSpecifier elementType="fakeIg.CatalogEntry.RelatedEntry" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CatalogEntry.RelatedEntry" retrievable="false" xsi:type="ClassInfo">
+        <element name="relationtype" elementType="fakeIg.CatalogEntryRelationType"/>
+        <element name="item" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CatalogEntryRelationType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ChargeItem" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItem" label="ChargeItem" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definitionUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definitionCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ChargeItemStatus"/>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="context" elementType="fakeIg.Reference"/>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.ChargeItem.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="performingOrganization" elementType="fakeIg.Reference"/>
+        <element name="requestingOrganization" elementType="fakeIg.Reference"/>
+        <element name="costCenter" elementType="fakeIg.Reference"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="bodysite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="factorOverride" elementType="System.Decimal" target="%value.value"/>
+        <element name="priceOverride" elementType="System.Decimal" target="%value.value"/>
+        <element name="overrideReason" elementType="System.String" target="%value.value"/>
+        <element name="enterer" elementType="fakeIg.Reference"/>
+        <element name="enteredDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="reason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="service">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="product" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="account">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="enterer"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Encounter" relatedKeyElement="context"/>
+        <contextRelationship context="Device" relatedKeyElement="enterer"/>
+        <contextRelationship context="Device" relatedKeyElement="actor"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="enterer"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ChargeItem.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ChargeItemDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ChargeItemDefinition" label="ChargeItemDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="derivedFromUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="replaces" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="instance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="applicability">
+            <elementTypeSpecifier elementType="fakeIg.ChargeItemDefinition.Applicability" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="propertyGroup">
+            <elementTypeSpecifier elementType="fakeIg.ChargeItemDefinition.PropertyGroup" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ChargeItemDefinition.Applicability" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ChargeItemDefinition.PropertyGroup" retrievable="false" xsi:type="ClassInfo">
+        <element name="applicability">
+            <elementTypeSpecifier namespace="fakeIg" name="ChargeItemDefinition.Applicability" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="priceComponent">
+            <elementTypeSpecifier elementType="fakeIg.ChargeItemDefinition.PropertyGroup.PriceComponent" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ChargeItemDefinition.PropertyGroup.PriceComponent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ChargeItemDefinitionPriceComponentType"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ChargeItemDefinitionPriceComponentType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ChargeItemStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Claim" identifier="http://hl7.org/fhir/StructureDefinition/Claim" label="Claim" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ClaimStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="use" elementType="fakeIg.Use"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="billablePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="enterer" elementType="fakeIg.Reference"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="fundsReserve" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="related">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Related" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prescription" elementType="fakeIg.Reference"/>
+        <element name="originalPrescription" elementType="fakeIg.Reference"/>
+        <element name="payee" elementType="fakeIg.Claim.Payee"/>
+        <element name="referral" elementType="fakeIg.Reference"/>
+        <element name="facility" elementType="fakeIg.Reference"/>
+        <element name="careTeam">
+            <elementTypeSpecifier elementType="fakeIg.Claim.CareTeam" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Claim.SupportingInfo" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosis">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Diagnosis" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="procedure">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Procedure" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Insurance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="accident" elementType="fakeIg.Claim.Accident"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="total" elementType="System.Decimal" target="%value.value"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="enterer"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="party"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="party"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Accident" retrievable="false" xsi:type="ClassInfo">
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="location" target="fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.CareTeam" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="responsible" elementType="System.Boolean" target="%value.value"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="qualification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="diagnosis" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="onAdmission" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="packageCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Insurance" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="focal" elementType="System.Boolean" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="businessArrangement" elementType="System.String" target="%value.value"/>
+        <element name="preAuthRef" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="claimResponse" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="careTeamSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosisSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="procedureSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="informationSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subSite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="encounter">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Item.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subDetail">
+            <elementTypeSpecifier elementType="fakeIg.Claim.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Payee" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="party" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Procedure" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="procedure" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.Related" retrievable="false" xsi:type="ClassInfo">
+        <element name="claim" elementType="fakeIg.Reference"/>
+        <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reference" elementType="fakeIg.Identifier"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Claim.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="timing" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="value" target="System.Boolean:%value.value;System.String:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ClaimResponse" identifier="http://hl7.org/fhir/StructureDefinition/ClaimResponse" label="ClaimResponse" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ClaimResponseStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="use" elementType="fakeIg.Use"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="requestor" elementType="fakeIg.Reference"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.RemittanceOutcome"/>
+        <element name="disposition" elementType="System.String" target="%value.value"/>
+        <element name="preAuthRef" elementType="System.String" target="%value.value"/>
+        <element name="preAuthPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="payeeType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="addItem">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.AddItem" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="total">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Total" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="payment" elementType="fakeIg.ClaimResponse.Payment"/>
+        <element name="fundsReserve" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="formCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="form" elementType="fakeIg.Attachment"/>
+        <element name="processNote">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.ProcessNote" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communicationRequest">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Insurance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="error">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Error" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="requestor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.AddItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="itemSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detailSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subdetailSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provider">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subSite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.AddItem.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.AddItem.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="subDetail">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.AddItem.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.AddItem.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Error" retrievable="false" xsi:type="ClassInfo">
+        <element name="itemSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="detailSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="subDetailSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Insurance" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="focal" elementType="System.Boolean" target="%value.value"/>
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="businessArrangement" elementType="System.String" target="%value.value"/>
+        <element name="claimResponse" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="itemSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Item.Adjudication" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Item.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Item.Adjudication" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="detailSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="subDetail">
+            <elementTypeSpecifier elementType="fakeIg.ClaimResponse.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="subDetailSequence" elementType="System.Integer" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ClaimResponse.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Payment" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="adjustment" elementType="System.Decimal" target="%value.value"/>
+        <element name="adjustmentReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+        <element name="number" elementType="System.Integer" target="%value.value"/>
+        <element name="type" elementType="fakeIg.NoteType"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClaimResponse.Total" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ClaimResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ClaimStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ClinicalImpression" identifier="http://hl7.org/fhir/StructureDefinition/ClinicalImpression" label="ClinicalImpression" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ClinicalImpressionStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="effective" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="assessor" elementType="fakeIg.Reference"/>
+        <element name="previous" elementType="fakeIg.Reference"/>
+        <element name="problem">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="investigation">
+            <elementTypeSpecifier elementType="fakeIg.ClinicalImpression.Investigation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="protocol" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="summary" elementType="System.String" target="%value.value"/>
+        <element name="finding">
+            <elementTypeSpecifier elementType="fakeIg.ClinicalImpression.Finding" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prognosisCodeableConcept" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prognosisReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="assessor"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClinicalImpression.Finding" retrievable="false" xsi:type="ClassInfo">
+        <element name="itemCodeableConcept" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="itemReference" elementType="fakeIg.Reference"/>
+        <element name="basis" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ClinicalImpression.Investigation" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ClinicalImpressionStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CodeSearchSupport" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CodeSystem" identifier="http://hl7.org/fhir/StructureDefinition/CodeSystem" label="CodeSystem" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="caseSensitive" elementType="System.Boolean" target="%value.value"/>
+        <element name="valueSet" elementType="System.String" target="%value.value"/>
+        <element name="hierarchyMeaning" elementType="fakeIg.CodeSystemHierarchyMeaning"/>
+        <element name="compositional" elementType="System.Boolean" target="%value.value"/>
+        <element name="versionNeeded" elementType="System.Boolean" target="%value.value"/>
+        <element name="content" elementType="fakeIg.CodeSystemContentMode"/>
+        <element name="supplements" elementType="System.String" target="%value.value"/>
+        <element name="count" elementType="System.Integer" target="%value.value"/>
+        <element name="filter">
+            <elementTypeSpecifier elementType="fakeIg.CodeSystem.Filter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property">
+            <elementTypeSpecifier elementType="fakeIg.CodeSystem.Property" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="concept">
+            <elementTypeSpecifier elementType="fakeIg.CodeSystem.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CodeSystem.Concept" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="designation">
+            <elementTypeSpecifier elementType="fakeIg.CodeSystem.Concept.Designation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property">
+            <elementTypeSpecifier elementType="fakeIg.CodeSystem.Concept.Property" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="concept">
+            <elementTypeSpecifier namespace="fakeIg" name="CodeSystem.Concept" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CodeSystem.Concept.Designation" retrievable="false" xsi:type="ClassInfo">
+        <element name="language" elementType="System.String" target="%value.value"/>
+        <element name="use" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CodeSystem.Concept.Property" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);System.String:%value.value;System.Integer:%value.value;System.Boolean:%value.value;System.DateTime:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CodeSystem.Filter" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="operator">
+            <elementTypeSpecifier elementType="fakeIg.FilterOperator" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CodeSystem.Property" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="uri" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.PropertyType"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CodeSystemContentMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CodeSystemHierarchyMeaning" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="CodeableConcept" identifier="http://hl7.org/fhir/StructureDefinition/CodeableConcept" label="CodeableConcept" retrievable="false" xsi:type="ClassInfo">
+        <element name="coding" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="text" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Coding" identifier="http://hl7.org/fhir/StructureDefinition/Coding" label="Coding" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="userSelected" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Communication" identifier="http://hl7.org/fhir/StructureDefinition/Communication" label="Communication" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="inResponseTo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.CommunicationStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="fakeIg.CommunicationPriority"/>
+        <element name="medium" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="topic" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="about">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="sent" elementType="System.DateTime" target="%value.value"/>
+        <element name="received" elementType="System.DateTime" target="%value.value"/>
+        <element name="recipient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sender" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="payload">
+            <elementTypeSpecifier elementType="fakeIg.Communication.Payload" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="sender"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="recipient"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="sender"/>
+        <contextRelationship context="Device" relatedKeyElement="recipient"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="sender"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Communication.Payload" retrievable="false" xsi:type="ClassInfo">
+        <element name="content" target="System.String:%value.value;fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CommunicationPriority" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CommunicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/CommunicationRequest" label="CommunicationRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="replaces">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="groupIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.CommunicationRequestStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="fakeIg.CommunicationPriority"/>
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="medium" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="about">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="payload">
+            <elementTypeSpecifier elementType="fakeIg.CommunicationRequest.Payload" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="occurrence" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="recipient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sender" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="sender"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="recipient"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="requester"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="sender"/>
+        <contextRelationship context="Device" relatedKeyElement="recipient"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="sender"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="requester"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CommunicationRequest.Payload" retrievable="false" xsi:type="ClassInfo">
+        <element name="content" target="System.String:%value.value;fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CommunicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CommunicationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CompartmentCode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CompartmentDefinition" identifier="http://hl7.org/fhir/StructureDefinition/CompartmentDefinition" label="CompartmentDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="fakeIg.CompartmentType"/>
+        <element name="search" elementType="System.Boolean" target="%value.value"/>
+        <element name="resource">
+            <elementTypeSpecifier elementType="fakeIg.CompartmentDefinition.Resource" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CompartmentDefinition.Resource" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.ResourceType"/>
+        <element name="param" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CompartmentType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Composition" identifier="http://hl7.org/fhir/StructureDefinition/Composition" label="Composition" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.CompositionStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="confidentiality" elementType="fakeIg.DocumentConfidentiality"/>
+        <element name="attester">
+            <elementTypeSpecifier elementType="fakeIg.Composition.Attester" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="custodian" elementType="fakeIg.Reference"/>
+        <element name="relatesTo">
+            <elementTypeSpecifier elementType="fakeIg.Composition.RelatesTo" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="event">
+            <elementTypeSpecifier elementType="fakeIg.Composition.Event" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="section">
+            <elementTypeSpecifier elementType="fakeIg.Composition.Section" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="subject"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="party"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Composition.Attester" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.CompositionAttestationMode"/>
+        <element name="time" elementType="System.DateTime" target="%value.value"/>
+        <element name="party" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Composition.Event" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Composition.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.DocumentRelationshipType"/>
+        <element name="target" target="fakeIg.Identifier:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Composition.Section" retrievable="false" xsi:type="ClassInfo">
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="focus" elementType="fakeIg.Reference"/>
+        <element name="text" elementType="fakeIg.Narrative"/>
+        <element name="mode" elementType="fakeIg.SectionMode"/>
+        <element name="orderedBy" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="entry">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="emptyReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="section">
+            <elementTypeSpecifier namespace="fakeIg" name="Composition.Section" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CompositionAttestationMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CompositionStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ConceptMap" identifier="http://hl7.org/fhir/StructureDefinition/ConceptMap" label="ConceptMap" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="source" target="System.String:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="target" target="System.String:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="group">
+            <elementTypeSpecifier elementType="fakeIg.ConceptMap.Group" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ConceptMap.Group" retrievable="false" xsi:type="ClassInfo">
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="sourceVersion" elementType="System.String" target="%value.value"/>
+        <element name="target" elementType="System.String" target="%value.value"/>
+        <element name="targetVersion" elementType="System.String" target="%value.value"/>
+        <element name="element">
+            <elementTypeSpecifier elementType="fakeIg.ConceptMap.Group.Element" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="unmapped" elementType="fakeIg.ConceptMap.Group.Unmapped"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ConceptMap.Group.Element" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.ConceptMap.Group.Element.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ConceptMap.Group.Element.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="equivalence" elementType="fakeIg.ConceptMapEquivalence"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="dependsOn">
+            <elementTypeSpecifier elementType="fakeIg.ConceptMap.Group.Element.Target.DependsOn" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="product">
+            <elementTypeSpecifier namespace="fakeIg" name="ConceptMap.Group.Element.Target.DependsOn" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ConceptMap.Group.Element.Target.DependsOn" retrievable="false" xsi:type="ClassInfo">
+        <element name="property" elementType="System.String" target="%value.value"/>
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ConceptMap.Group.Unmapped" retrievable="false" xsi:type="ClassInfo">
+        <element name="mode" elementType="fakeIg.ConceptMapGroupUnmappedMode"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConceptMapEquivalence" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConceptMapGroupUnmappedMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Condition" identifier="http://hl7.org/fhir/StructureDefinition/Condition" label="Condition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="clinicalStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="verificationStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="severity" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="bodySite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="onset" target="System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="abatement" target="System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recordedDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="recorder" elementType="fakeIg.Reference"/>
+        <element name="asserter" elementType="fakeIg.Reference"/>
+        <element name="stage">
+            <elementTypeSpecifier elementType="fakeIg.Condition.Stage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="evidence">
+            <elementTypeSpecifier elementType="fakeIg.Condition.Evidence" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="asserter"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="asserter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Condition.Evidence" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Condition.Stage" retrievable="false" xsi:type="ClassInfo">
+        <element name="summary" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="assessment">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConditionalDeleteStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConditionalReadStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Consent" identifier="http://hl7.org/fhir/StructureDefinition/Consent" label="Consent" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ConsentState"/>
+        <element name="scope" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="dateTime" elementType="System.DateTime" target="%value.value"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="organization">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="source" target="fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="policy">
+            <elementTypeSpecifier elementType="fakeIg.Consent.Policy" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="policyRule" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="verification">
+            <elementTypeSpecifier elementType="fakeIg.Consent.Verification" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provision" elementType="fakeIg.Consent.Provision"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Consent.Policy" retrievable="false" xsi:type="ClassInfo">
+        <element name="authority" elementType="System.String" target="%value.value"/>
+        <element name="uri" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Consent.Provision" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ConsentProvisionType"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="actor">
+            <elementTypeSpecifier elementType="fakeIg.Consent.Provision.Actor" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="securityLabel" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="class" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dataPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="data">
+            <elementTypeSpecifier elementType="fakeIg.Consent.Provision.Data" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provision">
+            <elementTypeSpecifier namespace="fakeIg" name="Consent.Provision" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Consent.Provision.Actor" retrievable="false" xsi:type="ClassInfo">
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reference" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Consent.Provision.Data" retrievable="false" xsi:type="ClassInfo">
+        <element name="meaning" elementType="fakeIg.ConsentDataMeaning"/>
+        <element name="reference" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Consent.Verification" retrievable="false" xsi:type="ClassInfo">
+        <element name="verified" elementType="System.Boolean" target="%value.value"/>
+        <element name="verifiedWith" elementType="fakeIg.Reference"/>
+        <element name="verificationDate" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConsentDataMeaning" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConsentProvisionType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConsentState" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ConstraintSeverity" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ContactDetail" identifier="http://hl7.org/fhir/StructureDefinition/ContactDetail" label="ContactDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ContactPoint" identifier="http://hl7.org/fhir/StructureDefinition/ContactPoint" label="ContactPoint" retrievable="false" xsi:type="ClassInfo">
+        <element name="system" elementType="fakeIg.ContactPointSystem"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="use" elementType="fakeIg.ContactPointUse"/>
+        <element name="rank" elementType="System.Integer" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ContactPointSystem" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ContactPointUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Contract" identifier="http://hl7.org/fhir/StructureDefinition/Contract" label="Contract" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.ContractStatus"/>
+        <element name="legalState" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="instantiatesCanonical" elementType="fakeIg.Reference"/>
+        <element name="instantiatesUri" elementType="System.String" target="%value.value"/>
+        <element name="contentDerivative" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="applies">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="expirationType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="authority">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="domain">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="site">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="scope" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="topic" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contentDefinition" elementType="fakeIg.Contract.ContentDefinition"/>
+        <element name="term">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relevantHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="signer">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Signer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="friendly">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Friendly" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="legal">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Legal" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="rule">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Rule" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="legallyBinding" target="fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.ContentDefinition" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="publisher" elementType="fakeIg.Reference"/>
+        <element name="publicationDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="publicationStatus" elementType="fakeIg.ContractPublicationStatus"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Friendly" retrievable="false" xsi:type="ClassInfo">
+        <element name="content" target="fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Legal" retrievable="false" xsi:type="ClassInfo">
+        <element name="content" target="fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Rule" retrievable="false" xsi:type="ClassInfo">
+        <element name="content" target="fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Signer" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="party" elementType="fakeIg.Reference"/>
+        <element name="signature">
+            <elementTypeSpecifier elementType="fakeIg.Signature" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="applies">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="securityLabel">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.SecurityLabel" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="offer" elementType="fakeIg.Contract.Term.Offer"/>
+        <element name="asset">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Asset" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="group">
+            <elementTypeSpecifier namespace="fakeIg" name="Contract.Term" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Action.Subject" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="intent" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="linkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="context" elementType="fakeIg.Reference"/>
+        <element name="contextLinkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="requester">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="requesterLinkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="performerType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="performerRole" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="performerLinkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reason" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonLinkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="securityLabelNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Action.Subject" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Asset" retrievable="false" xsi:type="ClassInfo">
+        <element name="scope" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="typeReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subtype" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relationship" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="context">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Asset.Context" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition" elementType="System.String" target="%value.value"/>
+        <element name="periodType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="ListTypeSpecifier">
+                <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </elementTypeSpecifier>
+            </elementTypeSpecifier>
+        </element>
+        <element name="usePeriod">
+            <elementTypeSpecifier xsi:type="ListTypeSpecifier">
+                <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </elementTypeSpecifier>
+            </elementTypeSpecifier>
+        </element>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="linkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="answer">
+            <elementTypeSpecifier namespace="fakeIg" name="Contract.Term.Offer.Answer" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="securityLabelNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="valuedItem">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Asset.ValuedItem" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Asset.Context" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference" elementType="fakeIg.Reference"/>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="text" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Asset.ValuedItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="entity" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="effectiveTime" elementType="System.DateTime" target="%value.value"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="points" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="payment" elementType="System.String" target="%value.value"/>
+        <element name="paymentDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="responsible" elementType="fakeIg.Reference"/>
+        <element name="recipient" elementType="fakeIg.Reference"/>
+        <element name="linkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="securityLabelNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Offer" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="party">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Offer.Party" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="topic" elementType="fakeIg.Reference"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="decision" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="decisionMode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="answer">
+            <elementTypeSpecifier elementType="fakeIg.Contract.Term.Offer.Answer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="linkId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="securityLabelNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Offer.Answer" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.Offer.Party" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Contract.Term.SecurityLabel" retrievable="false" xsi:type="ClassInfo">
+        <element name="number" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="classification" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="category" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="control" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ContractPublicationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ContractStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Contributor" identifier="http://hl7.org/fhir/StructureDefinition/Contributor" label="Contributor" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ContributorType"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ContributorType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="Count" identifier="http://hl7.org/fhir/StructureDefinition/Count" label="Count" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Coverage" identifier="http://hl7.org/fhir/StructureDefinition/Coverage" label="Coverage" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.CoverageStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="policyHolder" elementType="fakeIg.Reference"/>
+        <element name="subscriber" elementType="fakeIg.Reference"/>
+        <element name="subscriberId" elementType="System.String" target="%value.value"/>
+        <element name="beneficiary" elementType="fakeIg.Reference"/>
+        <element name="dependent" elementType="System.String" target="%value.value"/>
+        <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="payor">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="class">
+            <elementTypeSpecifier elementType="fakeIg.Coverage.Class" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="order" elementType="System.Integer" target="%value.value"/>
+        <element name="network" elementType="System.String" target="%value.value"/>
+        <element name="costToBeneficiary">
+            <elementTypeSpecifier elementType="fakeIg.Coverage.CostToBeneficiary" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subrogation" elementType="System.Boolean" target="%value.value"/>
+        <element name="contract">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="policyHolder"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="subscriber"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="payor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Coverage.Class" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Coverage.CostToBeneficiary" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="exception">
+            <elementTypeSpecifier elementType="fakeIg.Coverage.CostToBeneficiary.Exception" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Coverage.CostToBeneficiary.Exception" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CoverageEligibilityRequest" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityRequest" label="CoverageEligibilityRequest" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EligibilityRequestStatus"/>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="purpose">
+            <elementTypeSpecifier elementType="fakeIg.EligibilityRequestPurpose" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="enterer" elementType="fakeIg.Reference"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="facility" elementType="fakeIg.Reference"/>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityRequest.SupportingInfo" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityRequest.Insurance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityRequest.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="enterer"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityRequest.Insurance" retrievable="false" xsi:type="ClassInfo">
+        <element name="focal" elementType="System.Boolean" target="%value.value"/>
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="businessArrangement" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityRequest.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="supportingInfoSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="facility" elementType="fakeIg.Reference"/>
+        <element name="diagnosis">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityRequest.Item.Diagnosis" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityRequest.Item.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+        <element name="diagnosis" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityRequest.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="information" elementType="fakeIg.Reference"/>
+        <element name="appliesToAll" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="CoverageEligibilityResponse" identifier="http://hl7.org/fhir/StructureDefinition/CoverageEligibilityResponse" label="CoverageEligibilityResponse" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EligibilityResponseStatus"/>
+        <element name="purpose">
+            <elementTypeSpecifier elementType="fakeIg.EligibilityResponsePurpose" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="requestor" elementType="fakeIg.Reference"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.RemittanceOutcome"/>
+        <element name="disposition" elementType="System.String" target="%value.value"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityResponse.Insurance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="preAuthRef" elementType="System.String" target="%value.value"/>
+        <element name="form" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="error">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityResponse.Error" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="requestor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityResponse.Error" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityResponse.Insurance" retrievable="false" xsi:type="ClassInfo">
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="inforce" elementType="System.Boolean" target="%value.value"/>
+        <element name="benefitPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityResponse.Insurance.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityResponse.Insurance.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="excluded" elementType="System.Boolean" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="network" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unit" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="term" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="benefit">
+            <elementTypeSpecifier elementType="fakeIg.CoverageEligibilityResponse.Insurance.Item.Benefit" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="authorizationRequired" elementType="System.Boolean" target="%value.value"/>
+        <element name="authorizationSupporting" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="authorizationUrl" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="CoverageEligibilityResponse.Insurance.Item.Benefit" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="allowed" target="System.Integer:%value.value;System.String:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="used" target="System.Integer:%value.value;System.String:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CoverageStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="CurrencyCode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.ElementDefinition" namespace="fakeIg" name="DataElement constraint on ElementDefinition data type" identifier="http://hl7.org/fhir/StructureDefinition/elementdefinition-de" label="DataElement constraint on ElementDefinition data type" retrievable="false" xsi:type="ClassInfo">
+        <element name="Question" target="%parent.extension[url='http://hl7.org/fhir/StructureDefinition/elementdefinition-question'].value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="AllowedUnits" elementType="fakeIg.allowedUnits" target="System.Concept:FHIRHelpers.ToConcept(%parent.extension[url='http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits'].value);System.String:%parent.extension[url='http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits'].value.value"/>
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="sliceName" elementType="System.String" target="%value.value"/>
+        <element name="sliceIsConstraining" elementType="System.Boolean" target="%value.value"/>
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="code" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="requirements" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="base" elementType="fakeIg.ElementDefinition.Base"/>
+        <element name="type">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Type" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="defaultValue" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="meaningWhenMissing" elementType="System.String" target="%value.value"/>
+        <element name="orderMeaning" elementType="System.String" target="%value.value"/>
+        <element name="example">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Example" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="minValue" target="System.Date:%value.value;System.DateTime:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="maxValue" target="System.Date:%value.value;System.DateTime:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="maxLength" elementType="System.Integer" target="%value.value"/>
+        <element name="condition" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="constraint">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Constraint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="mustSupport" elementType="System.Boolean" target="%value.value"/>
+        <element name="isModifierReason" elementType="System.String" target="%value.value"/>
+        <element name="binding" elementType="fakeIg.ElementDefinition.Binding"/>
+        <element name="mapping">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Mapping" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="DataRequirement" identifier="http://hl7.org/fhir/StructureDefinition/DataRequirement" label="DataRequirement" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.FHIRAllTypes"/>
+        <element name="profile" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="mustSupport" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="codeFilter">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement.CodeFilter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dateFilter">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement.DateFilter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="limit" elementType="System.Integer" target="%value.value"/>
+        <element name="sort">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement.Sort" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="DataRequirement.CodeFilter" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="searchParam" elementType="System.String" target="%value.value"/>
+        <element name="valueSet" elementType="System.String" target="%value.value"/>
+        <element name="code" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="DataRequirement.DateFilter" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="searchParam" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="DataRequirement.Sort" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="direction" elementType="fakeIg.SortDirection"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DayOfWeek" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DaysOfWeek" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DetectedIssue" identifier="http://hl7.org/fhir/StructureDefinition/DetectedIssue" label="DetectedIssue" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.DetectedIssueStatus"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="severity" elementType="fakeIg.DetectedIssueSeverity"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="identified" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="implicated">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="evidence">
+            <elementTypeSpecifier elementType="fakeIg.DetectedIssue.Evidence" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail" elementType="System.String" target="%value.value"/>
+        <element name="reference" elementType="System.String" target="%value.value"/>
+        <element name="mitigation">
+            <elementTypeSpecifier elementType="fakeIg.DetectedIssue.Mitigation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DetectedIssue.Evidence" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DetectedIssue.Mitigation" retrievable="false" xsi:type="ClassInfo">
+        <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DetectedIssueSeverity" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DetectedIssueStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Device" identifier="http://hl7.org/fhir/StructureDefinition/Device" label="Device" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definition" elementType="fakeIg.Reference"/>
+        <element name="udiCarrier">
+            <elementTypeSpecifier elementType="fakeIg.Device.UdiCarrier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.FHIRDeviceStatus"/>
+        <element name="statusReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="distinctIdentifier" elementType="System.String" target="%value.value"/>
+        <element name="manufacturer" elementType="System.String" target="%value.value"/>
+        <element name="manufactureDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="expirationDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="lotNumber" elementType="System.String" target="%value.value"/>
+        <element name="serialNumber" elementType="System.String" target="%value.value"/>
+        <element name="deviceName">
+            <elementTypeSpecifier elementType="fakeIg.Device.DeviceName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="modelNumber" elementType="System.String" target="%value.value"/>
+        <element name="partNumber" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="specialization">
+            <elementTypeSpecifier elementType="fakeIg.Device.Specialization" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version">
+            <elementTypeSpecifier elementType="fakeIg.Device.Version" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property">
+            <elementTypeSpecifier elementType="fakeIg.Device.Property" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="owner" elementType="fakeIg.Reference"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="safety" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="parent" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Device.DeviceName" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.DeviceNameType"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Device.Property" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="valueQuantity" target="FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="valueCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Device.Specialization" retrievable="false" xsi:type="ClassInfo">
+        <element name="systemType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Device.UdiCarrier" retrievable="false" xsi:type="ClassInfo">
+        <element name="deviceIdentifier" elementType="System.String" target="%value.value"/>
+        <element name="issuer" elementType="System.String" target="%value.value"/>
+        <element name="jurisdiction" elementType="System.String" target="%value.value"/>
+        <element name="carrierAIDC" elementType="System.String" target="%value.value"/>
+        <element name="carrierHRF" elementType="System.String" target="%value.value"/>
+        <element name="entryType" elementType="fakeIg.UDIEntryType"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Device.Version" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="component" elementType="fakeIg.Identifier"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DeviceDefinition" identifier="http://hl7.org/fhir/StructureDefinition/DeviceDefinition" label="DeviceDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="udiDeviceIdentifier">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.UdiDeviceIdentifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="manufacturer" target="System.String:%value.value;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="deviceName">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.DeviceName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="modelNumber" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="specialization">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.Specialization" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="safety" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="shelfLifeStorage">
+            <elementTypeSpecifier elementType="fakeIg.ProductShelfLife" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="physicalCharacteristics" elementType="fakeIg.ProdCharacteristic"/>
+        <element name="languageCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="capability">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.Capability" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.Property" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="owner" elementType="fakeIg.Reference"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="onlineInformation" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="parentDevice" elementType="fakeIg.Reference"/>
+        <element name="material">
+            <elementTypeSpecifier elementType="fakeIg.DeviceDefinition.Material" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.Capability" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.DeviceName" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.DeviceNameType"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.Material" retrievable="false" xsi:type="ClassInfo">
+        <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="alternate" elementType="System.Boolean" target="%value.value"/>
+        <element name="allergenicIndicator" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.Property" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="valueQuantity" target="FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="valueCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.Specialization" retrievable="false" xsi:type="ClassInfo">
+        <element name="systemType" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceDefinition.UdiDeviceIdentifier" retrievable="false" xsi:type="ClassInfo">
+        <element name="deviceIdentifier" elementType="System.String" target="%value.value"/>
+        <element name="issuer" elementType="System.String" target="%value.value"/>
+        <element name="jurisdiction" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DeviceMetric" identifier="http://hl7.org/fhir/StructureDefinition/DeviceMetric" label="DeviceMetric" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unit" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+        <element name="parent" elementType="fakeIg.Reference"/>
+        <element name="operationalStatus" elementType="fakeIg.DeviceMetricOperationalStatus"/>
+        <element name="color" elementType="fakeIg.DeviceMetricColor"/>
+        <element name="category" elementType="fakeIg.DeviceMetricCategory"/>
+        <element name="measurementPeriod" elementType="fakeIg.Timing"/>
+        <element name="calibration">
+            <elementTypeSpecifier elementType="fakeIg.DeviceMetric.Calibration" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceMetric.Calibration" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.DeviceMetricCalibrationType"/>
+        <element name="state" elementType="fakeIg.DeviceMetricCalibrationState"/>
+        <element name="time" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceMetricCalibrationState" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceMetricCalibrationType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceMetricCategory" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceMetricColor" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceMetricOperationalStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceNameType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DeviceRequest" identifier="http://hl7.org/fhir/StructureDefinition/DeviceRequest" label="DeviceRequest" retrievable="true" primaryCodePath="codeCodeableConcept" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priorRequest">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="groupIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.DeviceRequestStatus"/>
+        <element name="intent" elementType="fakeIg.RequestIntent"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="code" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.DeviceRequest.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="performerType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relevantHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="requester"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="code as Reference)"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="requester"/>
+        <contextRelationship context="Device" relatedKeyElement="performer"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DeviceRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Boolean:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DeviceUseStatement" identifier="http://hl7.org/fhir/StructureDefinition/DeviceUseStatement" label="DeviceUseStatement" retrievable="true" primaryCodePath="device.code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.DeviceUseStatementStatus"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="derivedFrom">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="timing" target="fakeIg.Timing:null;;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recordedOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+        <element name="device" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Device" relatedKeyElement="device"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DeviceUseStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DiagnosticReport" identifier="http://hl7.org/fhir/StructureDefinition/DiagnosticReport" label="DiagnosticReport" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.DiagnosticReportStatus"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="effective" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="resultsInterpreter">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specimen">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="result">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="imagingStudy">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="media">
+            <elementTypeSpecifier elementType="fakeIg.DiagnosticReport.Media" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="conclusion" elementType="System.String" target="%value.value"/>
+        <element name="conclusionCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="presentedForm">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DiagnosticReport.Media" retrievable="false" xsi:type="ClassInfo">
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="link" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DiagnosticReportStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DiscriminatorType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="Distance" identifier="http://hl7.org/fhir/StructureDefinition/Distance" label="Distance" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DocumentConfidentiality" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DocumentManifest" identifier="http://hl7.org/fhir/StructureDefinition/DocumentManifest" label="DocumentManifest" retrievable="true" xsi:type="ClassInfo">
+        <element name="masterIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.DocumentReferenceStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="recipient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="content">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="related">
+            <elementTypeSpecifier elementType="fakeIg.DocumentManifest.Related" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="subject"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="recipient"/>
+        <contextRelationship context="Encounter" relatedKeyElement="ref"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DocumentManifest.Related" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="ref" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DocumentMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="DocumentReference" identifier="http://hl7.org/fhir/StructureDefinition/DocumentReference" label="DocumentReference" retrievable="true" xsi:type="ClassInfo">
+        <element name="masterIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.DocumentReferenceStatus"/>
+        <element name="docStatus" elementType="fakeIg.ReferredDocumentStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="authenticator" elementType="fakeIg.Reference"/>
+        <element name="custodian" elementType="fakeIg.Reference"/>
+        <element name="relatesTo">
+            <elementTypeSpecifier elementType="fakeIg.DocumentReference.RelatesTo" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="securityLabel" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="content">
+            <elementTypeSpecifier elementType="fakeIg.DocumentReference.Content" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="context" elementType="fakeIg.DocumentReference.Context"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="subject"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="authenticator"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DocumentReference.Content" retrievable="false" xsi:type="ClassInfo">
+        <element name="attachment" elementType="fakeIg.Attachment"/>
+        <element name="format" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DocumentReference.Context" retrievable="false" xsi:type="ClassInfo">
+        <element name="encounter">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="event" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="facilityType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="practiceSetting" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="sourcePatientInfo" elementType="fakeIg.Reference"/>
+        <element name="related">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="DocumentReference.RelatesTo" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.DocumentRelationshipType"/>
+        <element name="target" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DocumentReferenceStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="DocumentRelationshipType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Resource" namespace="fakeIg" name="DomainResource" identifier="http://hl7.org/fhir/StructureDefinition/DomainResource" label="DomainResource" retrievable="true" xsi:type="ClassInfo">
+        <element name="text" elementType="fakeIg.Narrative"/>
+        <element name="contained">
+            <elementTypeSpecifier elementType="fakeIg.Resource" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="extension">
+            <elementTypeSpecifier elementType="fakeIg.Extension" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="modifierExtension">
+            <elementTypeSpecifier elementType="fakeIg.Extension" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Dosage" identifier="http://hl7.org/fhir/StructureDefinition/Dosage" label="Dosage" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="additionalInstruction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patientInstruction" elementType="System.String" target="%value.value"/>
+        <element name="timing" elementType="fakeIg.Timing"/>
+        <element name="asNeeded" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="site" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="route" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="doseAndRate">
+            <elementTypeSpecifier elementType="fakeIg.Dosage.DoseAndRate" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="maxDosePerPeriod" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="maxDosePerAdministration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="maxDosePerLifetime" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Dosage.DoseAndRate" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="dose" target="System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="rate" target="System.Ratio:FHIRHelpers.ToRatio(%value);;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="Duration" identifier="http://hl7.org/fhir/StructureDefinition/Duration" label="Duration" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EffectEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/EffectEvidenceSynthesis" label="EffectEvidenceSynthesis" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="synthesisType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="studyType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="population" elementType="fakeIg.Reference"/>
+        <element name="exposure" elementType="fakeIg.Reference"/>
+        <element name="exposureAlternative" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.Reference"/>
+        <element name="sampleSize" elementType="fakeIg.EffectEvidenceSynthesis.SampleSize"/>
+        <element name="resultsByExposure">
+            <elementTypeSpecifier elementType="fakeIg.EffectEvidenceSynthesis.ResultsByExposure" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="effectEstimate">
+            <elementTypeSpecifier elementType="fakeIg.EffectEvidenceSynthesis.EffectEstimate" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="certainty">
+            <elementTypeSpecifier elementType="fakeIg.EffectEvidenceSynthesis.Certainty" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.Certainty" retrievable="false" xsi:type="ClassInfo">
+        <element name="rating" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="certaintySubcomponent">
+            <elementTypeSpecifier elementType="fakeIg.EffectEvidenceSynthesis.Certainty.CertaintySubcomponent" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="rating" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.EffectEstimate" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="variantState" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="unitOfMeasure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="precisionEstimate">
+            <elementTypeSpecifier elementType="fakeIg.EffectEvidenceSynthesis.EffectEstimate.PrecisionEstimate" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.EffectEstimate.PrecisionEstimate" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="level" elementType="System.Decimal" target="%value.value"/>
+        <element name="from" elementType="System.Decimal" target="%value.value"/>
+        <element name="to" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.ResultsByExposure" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="exposureState" elementType="fakeIg.ExposureState"/>
+        <element name="variantState" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="riskEvidenceSynthesis" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EffectEvidenceSynthesis.SampleSize" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="numberOfStudies" elementType="System.Integer" target="%value.value"/>
+        <element name="numberOfParticipants" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo namespace="fakeIg" name="Element" identifier="http://hl7.org/fhir/StructureDefinition/Element" label="Element" retrievable="false" xsi:type="ClassInfo">
+        <element name="id" elementType="System.String" target="%value.value"/>
+        <element name="extension">
+            <elementTypeSpecifier elementType="fakeIg.Extension" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ElementDefinition" label="ElementDefinition" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="representation">
+            <elementTypeSpecifier elementType="fakeIg.PropertyRepresentation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sliceName" elementType="System.String" target="%value.value"/>
+        <element name="sliceIsConstraining" elementType="System.Boolean" target="%value.value"/>
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="code" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="slicing" elementType="fakeIg.ElementDefinition.Slicing"/>
+        <element name="short" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="requirements" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="base" elementType="fakeIg.ElementDefinition.Base"/>
+        <element name="contentReference" elementType="System.String" target="%value.value"/>
+        <element name="type">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Type" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="defaultValue" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="meaningWhenMissing" elementType="System.String" target="%value.value"/>
+        <element name="orderMeaning" elementType="System.String" target="%value.value"/>
+        <element name="fixed" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="pattern" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="example">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Example" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="minValue" target="System.Date:%value.value;System.DateTime:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="maxValue" target="System.Date:%value.value;System.DateTime:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Integer:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="maxLength" elementType="System.Integer" target="%value.value"/>
+        <element name="condition" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="constraint">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Constraint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="mustSupport" elementType="System.Boolean" target="%value.value"/>
+        <element name="isModifier" elementType="System.Boolean" target="%value.value"/>
+        <element name="isModifierReason" elementType="System.String" target="%value.value"/>
+        <element name="isSummary" elementType="System.Boolean" target="%value.value"/>
+        <element name="binding" elementType="fakeIg.ElementDefinition.Binding"/>
+        <element name="mapping">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Mapping" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Base" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Binding" retrievable="false" xsi:type="ClassInfo">
+        <element name="strength" elementType="fakeIg.BindingStrength"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="valueSet" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Constraint" retrievable="false" xsi:type="ClassInfo">
+        <element name="key" elementType="System.String" target="%value.value"/>
+        <element name="requirements" elementType="System.String" target="%value.value"/>
+        <element name="severity" elementType="fakeIg.ConstraintSeverity"/>
+        <element name="human" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="xpath" elementType="System.String" target="%value.value"/>
+        <element name="source" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Example" retrievable="false" xsi:type="ClassInfo">
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Mapping" retrievable="false" xsi:type="ClassInfo">
+        <element name="identity" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="fakeIg.MimeType"/>
+        <element name="map" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Slicing" retrievable="false" xsi:type="ClassInfo">
+        <element name="discriminator">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition.Slicing.Discriminator" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="ordered" elementType="System.Boolean" target="%value.value"/>
+        <element name="rules" elementType="fakeIg.SlicingRules"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Slicing.Discriminator" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.DiscriminatorType"/>
+        <element name="path" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ElementDefinition.Type" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="targetProfile" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="versioning" elementType="fakeIg.ReferenceVersionRules"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EligibilityRequestPurpose" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EligibilityRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EligibilityResponsePurpose" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EligibilityResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EnableWhenBehavior" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Encounter" identifier="http://hl7.org/fhir/StructureDefinition/Encounter" label="Encounter" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EncounterStatus"/>
+        <element name="statusHistory">
+            <elementTypeSpecifier elementType="fakeIg.Encounter.StatusHistory" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="classHistory">
+            <elementTypeSpecifier elementType="fakeIg.Encounter.ClassHistory" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="episodeOfCare">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.Encounter.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="appointment">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="length" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosis">
+            <elementTypeSpecifier elementType="fakeIg.Encounter.Diagnosis" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="account">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="hospitalization" elementType="fakeIg.Encounter.Hospitalization"/>
+        <element name="location">
+            <elementTypeSpecifier elementType="fakeIg.Encounter.Location" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceProvider" elementType="fakeIg.Reference"/>
+        <element name="partOf" elementType="fakeIg.Reference"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="where(resolve() is Practitioner)"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="individual"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="individual"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.ClassHistory" retrievable="false" xsi:type="ClassInfo">
+        <element name="class" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+        <element name="condition" elementType="fakeIg.Reference"/>
+        <element name="use" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="rank" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.Hospitalization" retrievable="false" xsi:type="ClassInfo">
+        <element name="preAdmissionIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="origin" elementType="fakeIg.Reference"/>
+        <element name="admitSource" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reAdmission" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="dietPreference" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialCourtesy" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialArrangement" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="destination" elementType="fakeIg.Reference"/>
+        <element name="dischargeDisposition" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.Location" retrievable="false" xsi:type="ClassInfo">
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="status" elementType="fakeIg.EncounterLocationStatus"/>
+        <element name="physicalType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="individual" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Encounter.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+        <element name="status" elementType="fakeIg.EncounterStatus"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EncounterLocationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EncounterStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Endpoint" identifier="http://hl7.org/fhir/StructureDefinition/Endpoint" label="Endpoint" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EndpointStatus"/>
+        <element name="connectionType" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="payloadType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="payloadMimeType">
+            <elementTypeSpecifier elementType="fakeIg.MimeType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address" elementType="System.String" target="%value.value"/>
+        <element name="header" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EndpointStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EnrollmentRequest" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentRequest" label="EnrollmentRequest" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EnrollmentRequestStatus"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="candidate" elementType="fakeIg.Reference"/>
+        <element name="coverage" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EnrollmentRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EnrollmentResponse" identifier="http://hl7.org/fhir/StructureDefinition/EnrollmentResponse" label="EnrollmentResponse" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EnrollmentResponseStatus"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.RemittanceOutcome"/>
+        <element name="disposition" elementType="System.String" target="%value.value"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="organization" elementType="fakeIg.Reference"/>
+        <element name="requestProvider" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EnrollmentResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EpisodeOfCare" identifier="http://hl7.org/fhir/StructureDefinition/EpisodeOfCare" label="EpisodeOfCare" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.EpisodeOfCareStatus"/>
+        <element name="statusHistory">
+            <elementTypeSpecifier elementType="fakeIg.EpisodeOfCare.StatusHistory" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosis">
+            <elementTypeSpecifier elementType="fakeIg.EpisodeOfCare.Diagnosis" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="referralRequest">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="careManager" elementType="fakeIg.Reference"/>
+        <element name="team">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="account">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="where(resolve() is Practitioner)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EpisodeOfCare.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+        <element name="condition" elementType="fakeIg.Reference"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="rank" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EpisodeOfCare.StatusHistory" retrievable="false" xsi:type="ClassInfo">
+        <element name="status" elementType="fakeIg.EpisodeOfCareStatus"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EpisodeOfCareStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EventCapabilityMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EventDefinition" identifier="http://hl7.org/fhir/StructureDefinition/EventDefinition" label="EventDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="trigger">
+            <elementTypeSpecifier elementType="fakeIg.TriggerDefinition" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EventTiming" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Evidence" identifier="http://hl7.org/fhir/StructureDefinition/Evidence" label="Evidence" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="shortTitle" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="exposureBackground" elementType="fakeIg.Reference"/>
+        <element name="exposureVariant">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outcome">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="EvidenceVariable" identifier="http://hl7.org/fhir/StructureDefinition/EvidenceVariable" label="EvidenceVariable" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="shortTitle" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="fakeIg.EvidenceVariableType"/>
+        <element name="characteristic">
+            <elementTypeSpecifier elementType="fakeIg.EvidenceVariable.Characteristic" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="EvidenceVariable.Characteristic" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="definition" target="fakeIg.Reference:null;System.String:%value.value;System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Expression:null;fakeIg.DataRequirement:null;fakeIg.TriggerDefinition:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="usageContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="exclude" elementType="System.Boolean" target="%value.value"/>
+        <element name="participantEffective" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="timeFromStart" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="groupMeasure" elementType="fakeIg.GroupMeasure"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="EvidenceVariableType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ExampleScenario" identifier="http://hl7.org/fhir/StructureDefinition/ExampleScenario" label="ExampleScenario" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="actor">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Actor" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instance">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Instance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="process">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Process" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="workflow" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Actor" retrievable="false" xsi:type="ClassInfo">
+        <element name="actorId" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.ExampleScenarioActorType"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Instance" retrievable="false" xsi:type="ClassInfo">
+        <element name="resourceId" elementType="System.String" target="%value.value"/>
+        <element name="resourceType" elementType="fakeIg.FHIRResourceType"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="version">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Instance.Version" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="containedInstance">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Instance.ContainedInstance" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Instance.ContainedInstance" retrievable="false" xsi:type="ClassInfo">
+        <element name="resourceId" elementType="System.String" target="%value.value"/>
+        <element name="versionId" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Instance.Version" retrievable="false" xsi:type="ClassInfo">
+        <element name="versionId" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Process" retrievable="false" xsi:type="ClassInfo">
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="preConditions" elementType="System.String" target="%value.value"/>
+        <element name="postConditions" elementType="System.String" target="%value.value"/>
+        <element name="step">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Process.Step" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Process.Step" retrievable="false" xsi:type="ClassInfo">
+        <element name="process">
+            <elementTypeSpecifier namespace="fakeIg" name="ExampleScenario.Process" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="pause" elementType="System.Boolean" target="%value.value"/>
+        <element name="operation" elementType="fakeIg.ExampleScenario.Process.Step.Operation"/>
+        <element name="alternative">
+            <elementTypeSpecifier elementType="fakeIg.ExampleScenario.Process.Step.Alternative" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Process.Step.Alternative" retrievable="false" xsi:type="ClassInfo">
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="step">
+            <elementTypeSpecifier namespace="fakeIg" name="ExampleScenario.Process.Step" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExampleScenario.Process.Step.Operation" retrievable="false" xsi:type="ClassInfo">
+        <element name="number" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="initiator" elementType="System.String" target="%value.value"/>
+        <element name="receiver" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="initiatorActive" elementType="System.Boolean" target="%value.value"/>
+        <element name="receiverActive" elementType="System.Boolean" target="%value.value"/>
+        <element name="request" elementType="fakeIg.ExampleScenario.Instance.ContainedInstance"/>
+        <element name="response" elementType="fakeIg.ExampleScenario.Instance.ContainedInstance"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ExampleScenarioActorType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ExplanationOfBenefit" identifier="http://hl7.org/fhir/StructureDefinition/ExplanationOfBenefit" label="ExplanationOfBenefit" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ExplanationOfBenefitStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="use" elementType="fakeIg.Use"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="billablePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="enterer" elementType="fakeIg.Reference"/>
+        <element name="insurer" elementType="fakeIg.Reference"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="fundsReserveRequested" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="fundsReserve" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="related">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Related" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prescription" elementType="fakeIg.Reference"/>
+        <element name="originalPrescription" elementType="fakeIg.Reference"/>
+        <element name="payee" elementType="fakeIg.ExplanationOfBenefit.Payee"/>
+        <element name="referral" elementType="fakeIg.Reference"/>
+        <element name="facility" elementType="fakeIg.Reference"/>
+        <element name="claim" elementType="fakeIg.Reference"/>
+        <element name="claimResponse" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.RemittanceOutcome"/>
+        <element name="disposition" elementType="System.String" target="%value.value"/>
+        <element name="preAuthRef" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="preAuthRefPeriod">
+            <elementTypeSpecifier xsi:type="ListTypeSpecifier">
+                <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </elementTypeSpecifier>
+            </elementTypeSpecifier>
+        </element>
+        <element name="careTeam">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.CareTeam" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.SupportingInfo" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosis">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Diagnosis" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="procedure">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Procedure" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="precedence" elementType="System.Integer" target="%value.value"/>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Insurance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="accident" elementType="fakeIg.ExplanationOfBenefit.Accident"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="addItem">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.AddItem" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="total">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Total" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="payment" elementType="fakeIg.ExplanationOfBenefit.Payment"/>
+        <element name="formCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="form" elementType="fakeIg.Attachment"/>
+        <element name="processNote">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.ProcessNote" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="benefitPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="benefitBalance">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.BenefitBalance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="enterer"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="party"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="Device" relatedKeyElement="udi"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="party"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Accident" retrievable="false" xsi:type="ClassInfo">
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="location" target="fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.AddItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="itemSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detailSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subDetailSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="provider">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subSite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.AddItem.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.AddItem.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="subDetail">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.AddItem.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.AddItem.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.BenefitBalance" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="excluded" elementType="System.Boolean" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="network" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unit" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="term" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="financial">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.BenefitBalance.Financial" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.BenefitBalance.Financial" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="allowed" target="System.Integer:%value.value;System.String:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="used" target="System.Integer:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.CareTeam" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="responsible" elementType="System.Boolean" target="%value.value"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="qualification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Diagnosis" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="diagnosis" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="onAdmission" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="packageCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Insurance" retrievable="false" xsi:type="ClassInfo">
+        <element name="focal" elementType="System.Boolean" target="%value.value"/>
+        <element name="coverage" elementType="fakeIg.Reference"/>
+        <element name="preAuthRef" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="careTeamSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diagnosisSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="procedureSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="informationSequence" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviced" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="location" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Address:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subSite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="encounter">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Item.Adjudication" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Item.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Item.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="subDetail">
+            <elementTypeSpecifier elementType="fakeIg.ExplanationOfBenefit.Item.Detail.SubDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Item.Detail.SubDetail" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="revenue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productOrService" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="unitPrice" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="net" elementType="System.Decimal" target="%value.value"/>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="noteNumber" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="adjudication">
+            <elementTypeSpecifier namespace="fakeIg" name="ExplanationOfBenefit.Item.Adjudication" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Payee" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="party" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Payment" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="adjustment" elementType="System.Decimal" target="%value.value"/>
+        <element name="adjustmentReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Procedure" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="procedure" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="udi">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+        <element name="number" elementType="System.Integer" target="%value.value"/>
+        <element name="type" elementType="fakeIg.NoteType"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Related" retrievable="false" xsi:type="ClassInfo">
+        <element name="claim" elementType="fakeIg.Reference"/>
+        <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reference" elementType="fakeIg.Identifier"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.SupportingInfo" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="timing" target="System.Date:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="value" target="System.Boolean:%value.value;System.String:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Attachment:null;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="reason" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ExplanationOfBenefit.Total" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ExplanationOfBenefitStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ExposureState" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Expression" identifier="http://hl7.org/fhir/StructureDefinition/Expression" label="Expression" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="reference" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Extension" identifier="http://hl7.org/fhir/StructureDefinition/Extension" label="Extension" retrievable="false" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ExtensionContextType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRAllTypes" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRDefinedType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRDeviceStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRResourceType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRSubstanceStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FHIRVersion" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FamilyHistoryStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="FamilyMemberHistory" identifier="http://hl7.org/fhir/StructureDefinition/FamilyMemberHistory" label="FamilyMemberHistory" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.FamilyHistoryStatus"/>
+        <element name="dataAbsentReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="sex" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="born" target="System.Date:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="age" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="estimatedAge" elementType="System.Boolean" target="%value.value"/>
+        <element name="deceased" target="System.Boolean:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Date:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition">
+            <elementTypeSpecifier elementType="fakeIg.FamilyMemberHistory.Condition" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="FamilyMemberHistory.Condition" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="contributedToDeath" elementType="System.Boolean" target="%value.value"/>
+        <element name="onset" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FilterOperator" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Flag" identifier="http://hl7.org/fhir/StructureDefinition/Flag" label="Flag" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.FlagStatus"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FlagStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Goal" identifier="http://hl7.org/fhir/StructureDefinition/Goal" label="Goal" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="lifecycleStatus" elementType="fakeIg.GoalLifecycleStatus"/>
+        <element name="achievementStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="start" target="System.Date:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.Goal.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="statusDate" elementType="System.Date" target="%value.value"/>
+        <element name="statusReason" elementType="System.String" target="%value.value"/>
+        <element name="expressedBy" elementType="fakeIg.Reference"/>
+        <element name="addresses">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outcomeCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outcomeReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Goal.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="detail" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Ratio:FHIRHelpers.ToRatio(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="due" target="System.Date:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GoalLifecycleStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GraphCompartmentRule" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GraphCompartmentUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="GraphDefinition" identifier="http://hl7.org/fhir/StructureDefinition/GraphDefinition" label="GraphDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="start" elementType="fakeIg.ResourceType"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.GraphDefinition.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="GraphDefinition.Link" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="sliceName" elementType="System.String" target="%value.value"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.GraphDefinition.Link.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="GraphDefinition.Link.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ResourceType"/>
+        <element name="params" elementType="System.String" target="%value.value"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+        <element name="compartment">
+            <elementTypeSpecifier elementType="fakeIg.GraphDefinition.Link.Target.Compartment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="link">
+            <elementTypeSpecifier namespace="fakeIg" name="GraphDefinition.Link" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="GraphDefinition.Link.Target.Compartment" retrievable="false" xsi:type="ClassInfo">
+        <element name="use" elementType="fakeIg.GraphCompartmentUse"/>
+        <element name="code" elementType="fakeIg.CompartmentCode"/>
+        <element name="rule" elementType="fakeIg.GraphCompartmentRule"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Group" identifier="http://hl7.org/fhir/StructureDefinition/Group" label="Group" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="fakeIg.GroupType"/>
+        <element name="actual" elementType="System.Boolean" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="quantity" elementType="System.Integer" target="%value.value"/>
+        <element name="managingEntity" elementType="fakeIg.Reference"/>
+        <element name="characteristic">
+            <elementTypeSpecifier elementType="fakeIg.Group.Characteristic" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="member">
+            <elementTypeSpecifier elementType="fakeIg.Group.Member" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="entity"/>
+        <contextRelationship context="Device" relatedKeyElement="entity"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Group.Characteristic" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Boolean:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="exclude" elementType="System.Boolean" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Group.Member" retrievable="false" xsi:type="ClassInfo">
+        <element name="entity" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="inactive" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GroupMeasure" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GroupType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="GuidanceResponse" identifier="http://hl7.org/fhir/StructureDefinition/GuidanceResponse" label="GuidanceResponse" retrievable="true" primaryCodePath="module" xsi:type="ClassInfo">
+        <element name="requestIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="module" target="System.String:%value.value;System.String:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="status" elementType="fakeIg.GuidanceResponseStatus"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="occurrenceDateTime" elementType="System.DateTime" target="%value.value"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="evaluationMessage">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outputParameters" elementType="fakeIg.Reference"/>
+        <element name="result" elementType="fakeIg.Reference"/>
+        <element name="dataRequirement">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GuidanceResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GuidePageGeneration" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="GuideParameterCode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="HTTPVerb" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="HealthcareService" identifier="http://hl7.org/fhir/StructureDefinition/HealthcareService" label="HealthcareService" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="providedBy" elementType="fakeIg.Reference"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="extraDetails" elementType="System.String" target="%value.value"/>
+        <element name="photo" elementType="fakeIg.Attachment"/>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="coverageArea">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceProvisionCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="eligibility">
+            <elementTypeSpecifier elementType="fakeIg.HealthcareService.Eligibility" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="program" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="characteristic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communication" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referralMethod" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="appointmentRequired" elementType="System.Boolean" target="%value.value"/>
+        <element name="availableTime">
+            <elementTypeSpecifier elementType="fakeIg.HealthcareService.AvailableTime" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="notAvailable">
+            <elementTypeSpecifier elementType="fakeIg.HealthcareService.NotAvailable" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="availabilityExceptions" elementType="System.String" target="%value.value"/>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="HealthcareService.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+        <element name="daysOfWeek">
+            <elementTypeSpecifier elementType="fakeIg.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="allDay" elementType="System.Boolean" target="%value.value"/>
+        <element name="availableStartTime" elementType="System.Time" target="%value.value"/>
+        <element name="availableEndTime" elementType="System.Time" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="HealthcareService.Eligibility" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="HealthcareService.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="during">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="HumanName" identifier="http://hl7.org/fhir/StructureDefinition/HumanName" label="HumanName" retrievable="false" xsi:type="ClassInfo">
+        <element name="use" elementType="fakeIg.NameUse"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="family" elementType="System.String" target="%value.value"/>
+        <element name="given" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prefix" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="suffix" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Identifier" identifier="http://hl7.org/fhir/StructureDefinition/Identifier" label="Identifier" retrievable="false" xsi:type="ClassInfo">
+        <element name="use" elementType="fakeIg.IdentifierUse"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="assigner" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="IdentifierUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="IdentityAssuranceLevel" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ImagingStudy" identifier="http://hl7.org/fhir/StructureDefinition/ImagingStudy" label="ImagingStudy" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ImagingStudyStatus"/>
+        <element name="modality" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="started" elementType="System.DateTime" target="%value.value"/>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referrer" elementType="fakeIg.Reference"/>
+        <element name="interpreter">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="numberOfSeries" elementType="System.Integer" target="%value.value"/>
+        <element name="numberOfInstances" elementType="System.Integer" target="%value.value"/>
+        <element name="procedureReference" elementType="fakeIg.Reference"/>
+        <element name="procedureCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="series">
+            <elementTypeSpecifier elementType="fakeIg.ImagingStudy.Series" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImagingStudy.Series" retrievable="false" xsi:type="ClassInfo">
+        <element name="uid" elementType="System.String" target="%value.value"/>
+        <element name="number" elementType="System.Integer" target="%value.value"/>
+        <element name="modality" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="numberOfInstances" elementType="System.Integer" target="%value.value"/>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="laterality" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="specimen">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="started" elementType="System.DateTime" target="%value.value"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.ImagingStudy.Series.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instance">
+            <elementTypeSpecifier elementType="fakeIg.ImagingStudy.Series.Instance" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImagingStudy.Series.Instance" retrievable="false" xsi:type="ClassInfo">
+        <element name="uid" elementType="System.String" target="%value.value"/>
+        <element name="sopClass" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="number" elementType="System.Integer" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImagingStudy.Series.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ImagingStudyStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Immunization" identifier="http://hl7.org/fhir/StructureDefinition/Immunization" label="Immunization" retrievable="true" primaryCodePath="vaccineCode" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ImmunizationStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="vaccineCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="occurrence" target="System.DateTime:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recorded" elementType="System.DateTime" target="%value.value"/>
+        <element name="primarySource" elementType="System.Boolean" target="%value.value"/>
+        <element name="reportOrigin" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="manufacturer" elementType="fakeIg.Reference"/>
+        <element name="lotNumber" elementType="System.String" target="%value.value"/>
+        <element name="expirationDate" elementType="System.Date" target="%value.value"/>
+        <element name="site" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="route" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="doseQuantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Immunization.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="isSubpotent" elementType="System.Boolean" target="%value.value"/>
+        <element name="subpotentReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="education">
+            <elementTypeSpecifier elementType="fakeIg.Immunization.Education" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="programEligibility" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="fundingSource" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reaction">
+            <elementTypeSpecifier elementType="fakeIg.Immunization.Reaction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="protocolApplied">
+            <elementTypeSpecifier elementType="fakeIg.Immunization.ProtocolApplied" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Immunization.Education" retrievable="false" xsi:type="ClassInfo">
+        <element name="documentType" elementType="System.String" target="%value.value"/>
+        <element name="reference" elementType="System.String" target="%value.value"/>
+        <element name="publicationDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="presentationDate" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Immunization.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Immunization.ProtocolApplied" retrievable="false" xsi:type="ClassInfo">
+        <element name="series" elementType="System.String" target="%value.value"/>
+        <element name="authority" elementType="fakeIg.Reference"/>
+        <element name="targetDisease" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="doseNumber" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="seriesDoses" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Immunization.Reaction" retrievable="false" xsi:type="ClassInfo">
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="detail" elementType="fakeIg.Reference"/>
+        <element name="reported" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ImmunizationEvaluation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationEvaluation" label="ImmunizationEvaluation" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ImmunizationEvaluationStatus"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="authority" elementType="fakeIg.Reference"/>
+        <element name="targetDisease" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="immunizationEvent" elementType="fakeIg.Reference"/>
+        <element name="doseStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="doseStatusReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="series" elementType="System.String" target="%value.value"/>
+        <element name="doseNumber" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="seriesDoses" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ImmunizationEvaluationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ImmunizationRecommendation" identifier="http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation" label="ImmunizationRecommendation" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="authority" elementType="fakeIg.Reference"/>
+        <element name="recommendation">
+            <elementTypeSpecifier elementType="fakeIg.ImmunizationRecommendation.Recommendation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImmunizationRecommendation.Recommendation" retrievable="false" xsi:type="ClassInfo">
+        <element name="vaccineCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="targetDisease" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="contraindicatedVaccineCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="forecastStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="forecastReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dateCriterion">
+            <elementTypeSpecifier elementType="fakeIg.ImmunizationRecommendation.Recommendation.DateCriterion" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="series" elementType="System.String" target="%value.value"/>
+        <element name="doseNumber" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="seriesDoses" target="System.Integer:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="supportingImmunization">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingPatientInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImmunizationRecommendation.Recommendation.DateCriterion" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ImmunizationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ImplementationGuide" identifier="http://hl7.org/fhir/StructureDefinition/ImplementationGuide" label="ImplementationGuide" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="packageId" elementType="System.String" target="%value.value"/>
+        <element name="license" elementType="fakeIg.SPDXLicense"/>
+        <element name="fhirVersion">
+            <elementTypeSpecifier elementType="fakeIg.FHIRVersion" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dependsOn">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.DependsOn" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="global">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Global" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definition" elementType="fakeIg.ImplementationGuide.Definition"/>
+        <element name="manifest" elementType="fakeIg.ImplementationGuide.Manifest"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition" retrievable="false" xsi:type="ClassInfo">
+        <element name="grouping">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Definition.Grouping" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="resource">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Definition.Resource" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="page" elementType="fakeIg.ImplementationGuide.Definition.Page"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Definition.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="template">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Definition.Template" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition.Grouping" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition.Page" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" target="System.String:%value.value;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="generation" elementType="fakeIg.GuidePageGeneration"/>
+        <element name="page">
+            <elementTypeSpecifier namespace="fakeIg" name="ImplementationGuide.Definition.Page" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.GuideParameterCode"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition.Resource" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference" elementType="fakeIg.Reference"/>
+        <element name="fhirVersion">
+            <elementTypeSpecifier elementType="fakeIg.FHIRVersion" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="example" target="System.Boolean:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="groupingId" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Definition.Template" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="scope" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.DependsOn" retrievable="false" xsi:type="ClassInfo">
+        <element name="uri" elementType="System.String" target="%value.value"/>
+        <element name="packageId" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Global" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ResourceType"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Manifest" retrievable="false" xsi:type="ClassInfo">
+        <element name="rendering" elementType="System.String" target="%value.value"/>
+        <element name="resource">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Manifest.Resource" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="page">
+            <elementTypeSpecifier elementType="fakeIg.ImplementationGuide.Manifest.Page" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="image" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="other" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Manifest.Page" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="anchor" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ImplementationGuide.Manifest.Resource" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference" elementType="fakeIg.Reference"/>
+        <element name="example" target="System.Boolean:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="relativePath" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="InsurancePlan" identifier="http://hl7.org/fhir/StructureDefinition/InsurancePlan" label="InsurancePlan" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="ownedBy" elementType="fakeIg.Reference"/>
+        <element name="administeredBy" elementType="fakeIg.Reference"/>
+        <element name="coverageArea">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Contact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="network">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="coverage">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Coverage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="plan">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Plan" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Contact" retrievable="false" xsi:type="ClassInfo">
+        <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="name" elementType="fakeIg.HumanName"/>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address" elementType="fakeIg.Address"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Coverage" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="network">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="benefit">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Coverage.Benefit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Coverage.Benefit" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="requirement" elementType="System.String" target="%value.value"/>
+        <element name="limit">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Coverage.Benefit.Limit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Coverage.Benefit.Limit" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Plan" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="coverageArea">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="network">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="generalCost">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Plan.GeneralCost" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specificCost">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Plan.SpecificCost" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Plan.GeneralCost" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="groupSize" elementType="System.Integer" target="%value.value"/>
+        <element name="cost" elementType="System.Decimal" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Plan.SpecificCost" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="benefit">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Plan.SpecificCost.Benefit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Plan.SpecificCost.Benefit" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="cost">
+            <elementTypeSpecifier elementType="fakeIg.InsurancePlan.Plan.SpecificCost.Benefit.Cost" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="InsurancePlan.Plan.SpecificCost.Benefit.Cost" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="applicability" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="qualifiers" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="value" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Invoice" identifier="http://hl7.org/fhir/StructureDefinition/Invoice" label="Invoice" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.InvoiceStatus"/>
+        <element name="cancelledReason" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="recipient" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.Invoice.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="issuer" elementType="fakeIg.Reference"/>
+        <element name="account" elementType="fakeIg.Reference"/>
+        <element name="lineItem">
+            <elementTypeSpecifier elementType="fakeIg.Invoice.LineItem" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="totalPriceComponent">
+            <elementTypeSpecifier namespace="fakeIg" name="Invoice.LineItem.PriceComponent" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="totalNet" elementType="System.Decimal" target="%value.value"/>
+        <element name="totalGross" elementType="System.Decimal" target="%value.value"/>
+        <element name="paymentTerms" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Device" relatedKeyElement="actor"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="recipient"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Invoice.LineItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="sequence" elementType="System.Integer" target="%value.value"/>
+        <element name="chargeItem" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="priceComponent">
+            <elementTypeSpecifier elementType="fakeIg.Invoice.LineItem.PriceComponent" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Invoice.LineItem.PriceComponent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.InvoicePriceComponentType"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Invoice.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="InvoicePriceComponentType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="InvoiceStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="IssueSeverity" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="IssueType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Library" identifier="http://hl7.org/fhir/StructureDefinition/Library" label="Library" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.ParameterDefinition" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dataRequirement">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="content">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="LinkType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Linkage" identifier="http://hl7.org/fhir/StructureDefinition/Linkage" label="Linkage" retrievable="true" xsi:type="ClassInfo">
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.Linkage.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Linkage.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.LinkageType"/>
+        <element name="resource" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="LinkageType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="List" identifier="http://hl7.org/fhir/StructureDefinition/List" label="List" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ListStatus"/>
+        <element name="mode" elementType="fakeIg.ListMode"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+        <element name="orderedBy" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="entry">
+            <elementTypeSpecifier elementType="fakeIg.List.Entry" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="emptyReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="source"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="source"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="List.Entry" retrievable="false" xsi:type="ClassInfo">
+        <element name="flag" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="deleted" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="item" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ListMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ListStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Location" identifier="http://hl7.org/fhir/StructureDefinition/Location" label="Location" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.LocationStatus"/>
+        <element name="operationalStatus" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="mode" elementType="fakeIg.LocationMode"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address" elementType="fakeIg.Address"/>
+        <element name="physicalType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="position" elementType="fakeIg.Location.Position"/>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="partOf" elementType="fakeIg.Reference"/>
+        <element name="hoursOfOperation">
+            <elementTypeSpecifier elementType="fakeIg.Location.HoursOfOperation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="availabilityExceptions" elementType="System.String" target="%value.value"/>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Location.HoursOfOperation" retrievable="false" xsi:type="ClassInfo">
+        <element name="daysOfWeek">
+            <elementTypeSpecifier elementType="fakeIg.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="allDay" elementType="System.Boolean" target="%value.value"/>
+        <element name="openingTime" elementType="System.Time" target="%value.value"/>
+        <element name="closingTime" elementType="System.Time" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Location.Position" retrievable="false" xsi:type="ClassInfo">
+        <element name="longitude" elementType="System.Decimal" target="%value.value"/>
+        <element name="latitude" elementType="System.Decimal" target="%value.value"/>
+        <element name="altitude" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="LocationMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="LocationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MarketingStatus" identifier="http://hl7.org/fhir/StructureDefinition/MarketingStatus" label="MarketingStatus" retrievable="false" xsi:type="ClassInfo">
+        <element name="country" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="jurisdiction" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="dateRange">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="restoreDate" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Measure" identifier="http://hl7.org/fhir/StructureDefinition/Measure" label="Measure" retrievable="true" primaryCodePath="topic" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="library" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="disclaimer" elementType="System.String" target="%value.value"/>
+        <element name="scoring" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="compositeScoring" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="riskAdjustment" elementType="System.String" target="%value.value"/>
+        <element name="rateAggregation" elementType="System.String" target="%value.value"/>
+        <element name="rationale" elementType="System.String" target="%value.value"/>
+        <element name="clinicalRecommendationStatement" elementType="System.String" target="%value.value"/>
+        <element name="improvementNotation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="definition" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="guidance" elementType="System.String" target="%value.value"/>
+        <element name="group">
+            <elementTypeSpecifier elementType="fakeIg.Measure.Group" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supplementalData">
+            <elementTypeSpecifier elementType="fakeIg.Measure.SupplementalData" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Measure.Group" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.Measure.Group.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="stratifier">
+            <elementTypeSpecifier elementType="fakeIg.Measure.Group.Stratifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Measure.Group.Population" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="criteria" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Measure.Group.Stratifier" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="criteria" elementType="fakeIg.Expression"/>
+        <element name="component">
+            <elementTypeSpecifier elementType="fakeIg.Measure.Group.Stratifier.Component" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Measure.Group.Stratifier.Component" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="criteria" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Measure.SupplementalData" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="usage" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="criteria" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MeasureReport" identifier="http://hl7.org/fhir/StructureDefinition/MeasureReport" label="MeasureReport" retrievable="true" primaryCodePath="measure.topic" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MeasureReportStatus"/>
+        <element name="type" elementType="fakeIg.MeasureReportType"/>
+        <element name="measure" elementType="System.String" target="%value.value"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="reporter" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="improvementNotation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="group">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="evaluatedResource">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="measureScore" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="stratifier">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group.Stratifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group.Population" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="count" elementType="System.Integer" target="%value.value"/>
+        <element name="subjectResults" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group.Stratifier" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="stratum">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group.Stratifier.Stratum" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group.Stratifier.Stratum" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="component">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group.Stratifier.Stratum.Component" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.MeasureReport.Group.Stratifier.Stratum.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="measureScore" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group.Stratifier.Stratum.Component" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MeasureReport.Group.Stratifier.Stratum.Population" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="count" elementType="System.Integer" target="%value.value"/>
+        <element name="subjectResults" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MeasureReportStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MeasureReportType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Media" identifier="http://hl7.org/fhir/StructureDefinition/Media" label="Media" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MediaStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="modality" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="view" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="created" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="operator" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="deviceName" elementType="System.String" target="%value.value"/>
+        <element name="device" elementType="fakeIg.Reference"/>
+        <element name="height" elementType="System.Integer" target="%value.value"/>
+        <element name="width" elementType="System.Integer" target="%value.value"/>
+        <element name="frames" elementType="System.Integer" target="%value.value"/>
+        <element name="duration" elementType="System.Decimal" target="%value.value"/>
+        <element name="content" elementType="fakeIg.Attachment"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="subject"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="operator"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MediaStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Medication" identifier="http://hl7.org/fhir/StructureDefinition/Medication" label="Medication" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="fakeIg.MedicationStatus"/>
+        <element name="manufacturer" elementType="fakeIg.Reference"/>
+        <element name="form" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="ingredient">
+            <elementTypeSpecifier elementType="fakeIg.Medication.Ingredient" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="batch" elementType="fakeIg.Medication.Batch"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Medication.Batch" retrievable="false" xsi:type="ClassInfo">
+        <element name="lotNumber" elementType="System.String" target="%value.value"/>
+        <element name="expirationDate" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Medication.Ingredient" retrievable="false" xsi:type="ClassInfo">
+        <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="isActive" elementType="System.Boolean" target="%value.value"/>
+        <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicationAdministration" identifier="http://hl7.org/fhir/StructureDefinition/MedicationAdministration" label="MedicationAdministration" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiates" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MedicationAdministrationStatus"/>
+        <element name="statusReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="context" elementType="fakeIg.Reference"/>
+        <element name="supportingInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="effective" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.MedicationAdministration.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="device">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dosage" elementType="fakeIg.MedicationAdministration.Dosage"/>
+        <element name="eventHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Encounter" relatedKeyElement="context"/>
+        <contextRelationship context="Device" relatedKeyElement="device"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationAdministration.Dosage" retrievable="false" xsi:type="ClassInfo">
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="site" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="route" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="dose" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="rate" target="System.Ratio:FHIRHelpers.ToRatio(%value);System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationAdministration.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationAdministrationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicationDispense" identifier="http://hl7.org/fhir/StructureDefinition/MedicationDispense" label="MedicationDispense" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MedicationDispenseStatus"/>
+        <element name="statusReason" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="context" elementType="fakeIg.Reference"/>
+        <element name="supportingInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.MedicationDispense.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="authorizingPrescription">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="daysSupply" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="whenPrepared" elementType="System.DateTime" target="%value.value"/>
+        <element name="whenHandedOver" elementType="System.DateTime" target="%value.value"/>
+        <element name="destination" elementType="fakeIg.Reference"/>
+        <element name="receiver">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dosageInstruction">
+            <elementTypeSpecifier elementType="fakeIg.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="substitution" elementType="fakeIg.MedicationDispense.Substitution"/>
+        <element name="detectedIssue">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="eventHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="receiver"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationDispense.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationDispense.Substitution" retrievable="false" xsi:type="ClassInfo">
+        <element name="wasSubstituted" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="responsibleParty">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationDispenseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicationKnowledge" identifier="http://hl7.org/fhir/StructureDefinition/MedicationKnowledge" label="MedicationKnowledge" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="fakeIg.MedicationKnowledgeStatus"/>
+        <element name="manufacturer" elementType="fakeIg.Reference"/>
+        <element name="doseForm" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="synonym" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedMedicationKnowledge">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.RelatedMedicationKnowledge" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="associatedMedication">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="productType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="monograph">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Monograph" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="ingredient">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Ingredient" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="preparationInstruction" elementType="System.String" target="%value.value"/>
+        <element name="intendedRoute" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="cost">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Cost" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="monitoringProgram">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.MonitoringProgram" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="administrationGuidelines">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.AdministrationGuidelines" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="medicineClassification">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.MedicineClassification" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="packaging" elementType="fakeIg.MedicationKnowledge.Packaging"/>
+        <element name="drugCharacteristic">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.DrugCharacteristic" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contraindication">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="regulatory">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Regulatory" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="kinetics">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Kinetics" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.AdministrationGuidelines" retrievable="false" xsi:type="ClassInfo">
+        <element name="dosage">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.AdministrationGuidelines.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="indication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="patientCharacteristics">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.AdministrationGuidelines.PatientCharacteristics" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.AdministrationGuidelines.Dosage" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="dosage">
+            <elementTypeSpecifier elementType="fakeIg.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.AdministrationGuidelines.PatientCharacteristics" retrievable="false" xsi:type="ClassInfo">
+        <element name="characteristic" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="value" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Cost" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="cost" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.DrugCharacteristic" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Ingredient" retrievable="false" xsi:type="ClassInfo">
+        <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="isActive" elementType="System.Boolean" target="%value.value"/>
+        <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Kinetics" retrievable="false" xsi:type="ClassInfo">
+        <element name="areaUnderCurve" target="FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="lethalDose50" target="FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier elementType="System.Quantity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="halfLifePeriod" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.MedicineClassification" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="classification" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.MonitoringProgram" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Monograph" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Packaging" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Regulatory" retrievable="false" xsi:type="ClassInfo">
+        <element name="regulatoryAuthority" elementType="fakeIg.Reference"/>
+        <element name="substitution">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Regulatory.Substitution" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="schedule">
+            <elementTypeSpecifier elementType="fakeIg.MedicationKnowledge.Regulatory.Schedule" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="maxDispense" elementType="fakeIg.MedicationKnowledge.Regulatory.MaxDispense"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Regulatory.MaxDispense" retrievable="false" xsi:type="ClassInfo">
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="period" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Regulatory.Schedule" retrievable="false" xsi:type="ClassInfo">
+        <element name="schedule" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.Regulatory.Substitution" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="allowed" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationKnowledge.RelatedMedicationKnowledge" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationKnowledgeStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicationRequest" identifier="http://hl7.org/fhir/StructureDefinition/MedicationRequest" label="MedicationRequest" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MedicationRequestStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intent" elementType="fakeIg.MedicationRequestIntent"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="fakeIg.MedicationRequestPriority"/>
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="reported" target="System.Boolean:%value.value;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="supportingInformation">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="performerType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="recorder" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="groupIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="courseOfTherapyType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dosageInstruction">
+            <elementTypeSpecifier elementType="fakeIg.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dispenseRequest" elementType="fakeIg.MedicationRequest.DispenseRequest"/>
+        <element name="substitution" elementType="fakeIg.MedicationRequest.Substitution"/>
+        <element name="priorPrescription" elementType="fakeIg.Reference"/>
+        <element name="detectedIssue">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="eventHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="requester"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationRequest.DispenseRequest" retrievable="false" xsi:type="ClassInfo">
+        <element name="initialFill" elementType="fakeIg.MedicationRequest.DispenseRequest.InitialFill"/>
+        <element name="dispenseInterval" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="validityPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="numberOfRepeatsAllowed" elementType="System.Integer" target="%value.value"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="expectedSupplyDuration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationRequest.DispenseRequest.InitialFill" retrievable="false" xsi:type="ClassInfo">
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicationRequest.Substitution" retrievable="false" xsi:type="ClassInfo">
+        <element name="allowed" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicationStatement" identifier="http://hl7.org/fhir/StructureDefinition/MedicationStatement" label="MedicationStatement" retrievable="true" primaryCodePath="medication" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.MedicationStatementStatus"/>
+        <element name="statusReason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="context" elementType="fakeIg.Reference"/>
+        <element name="effective" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dateAsserted" elementType="System.DateTime" target="%value.value"/>
+        <element name="informationSource" elementType="fakeIg.Reference"/>
+        <element name="derivedFrom">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="dosage">
+            <elementTypeSpecifier elementType="fakeIg.Dosage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="informationSource"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="informationSource"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationStatementStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MedicationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProduct" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProduct" label="MedicinalProduct" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="domain" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="combinedPharmaceuticalDoseForm" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="legalStatusOfSupply" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="additionalMonitoringIndicator" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="specialMeasures" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="paediatricUseIndicator" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productClassification" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="marketingStatus">
+            <elementTypeSpecifier elementType="fakeIg.MarketingStatus" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="pharmaceuticalProduct">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="packagedMedicinalProduct">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="attachedDocument">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="masterFile">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="clinicalTrial">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProduct.Name" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="crossReference">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="manufacturingBusinessOperation">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProduct.ManufacturingBusinessOperation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialDesignation">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProduct.SpecialDesignation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProduct.ManufacturingBusinessOperation" retrievable="false" xsi:type="ClassInfo">
+        <element name="operationType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="authorisationReferenceNumber" elementType="fakeIg.Identifier"/>
+        <element name="effectiveDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="confidentialityIndicator" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="manufacturer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="regulator" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProduct.Name" retrievable="false" xsi:type="ClassInfo">
+        <element name="productName" elementType="System.String" target="%value.value"/>
+        <element name="namePart">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProduct.Name.NamePart" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="countryLanguage">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProduct.Name.CountryLanguage" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProduct.Name.CountryLanguage" retrievable="false" xsi:type="ClassInfo">
+        <element name="country" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="jurisdiction" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProduct.Name.NamePart" retrievable="false" xsi:type="ClassInfo">
+        <element name="part" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProduct.SpecialDesignation" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intendedUse" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="indication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="species" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductAuthorization" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductAuthorization" label="MedicinalProductAuthorization" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="country" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="statusDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="restoreDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="validityPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dataExclusivityPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dateOfFirstAuthorization" elementType="System.DateTime" target="%value.value"/>
+        <element name="internationalBirthDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="legalBasis" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="jurisdictionalAuthorization">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductAuthorization.JurisdictionalAuthorization" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="holder" elementType="fakeIg.Reference"/>
+        <element name="regulator" elementType="fakeIg.Reference"/>
+        <element name="procedure" elementType="fakeIg.MedicinalProductAuthorization.Procedure"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductAuthorization.JurisdictionalAuthorization" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="country" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="legalStatusOfSupply" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="validityPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductAuthorization.Procedure" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" target="System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="application">
+            <elementTypeSpecifier namespace="fakeIg" name="MedicinalProductAuthorization.Procedure" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductContraindication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductContraindication" label="MedicinalProductContraindication" retrievable="true" xsi:type="ClassInfo">
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="disease" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="diseaseStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="comorbidity" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="therapeuticIndication">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="otherTherapy">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductContraindication.OtherTherapy" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductContraindication.OtherTherapy" retrievable="false" xsi:type="ClassInfo">
+        <element name="therapyRelationshipType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductIndication" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIndication" label="MedicinalProductIndication" retrievable="true" xsi:type="ClassInfo">
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="diseaseSymptomProcedure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="diseaseStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="comorbidity" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="intendedEffect" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="otherTherapy">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductIndication.OtherTherapy" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="undesirableEffect">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductIndication.OtherTherapy" retrievable="false" xsi:type="ClassInfo">
+        <element name="therapyRelationshipType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="medication" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductIngredient" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductIngredient" label="MedicinalProductIngredient" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="allergenicIndicator" elementType="System.Boolean" target="%value.value"/>
+        <element name="manufacturer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specifiedSubstance">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductIngredient.SpecifiedSubstance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="substance" elementType="fakeIg.MedicinalProductIngredient.Substance"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductIngredient.SpecifiedSubstance" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="group" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="confidentiality" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="strength">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductIngredient.SpecifiedSubstance.Strength" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductIngredient.SpecifiedSubstance.Strength" retrievable="false" xsi:type="ClassInfo">
+        <element name="presentation" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="presentationLowLimit" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="concentration" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="concentrationLowLimit" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="measurementPoint" elementType="System.String" target="%value.value"/>
+        <element name="country" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referenceStrength">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductIngredient.SpecifiedSubstance.Strength.ReferenceStrength" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductIngredient.SpecifiedSubstance.Strength.ReferenceStrength" retrievable="false" xsi:type="ClassInfo">
+        <element name="substance" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="strength" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="strengthLowLimit" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="measurementPoint" elementType="System.String" target="%value.value"/>
+        <element name="country" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductIngredient.Substance" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="strength">
+            <elementTypeSpecifier namespace="fakeIg" name="MedicinalProductIngredient.SpecifiedSubstance.Strength" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductInteraction" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductInteraction" label="MedicinalProductInteraction" retrievable="true" xsi:type="ClassInfo">
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="interactant">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductInteraction.Interactant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="effect" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="incidence" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="management" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductInteraction.Interactant" retrievable="false" xsi:type="ClassInfo">
+        <element name="item" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductManufactured" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductManufactured" label="MedicinalProductManufactured" retrievable="true" xsi:type="ClassInfo">
+        <element name="manufacturedDoseForm" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unitOfPresentation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="manufacturer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="ingredient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="physicalCharacteristics" elementType="fakeIg.ProdCharacteristic"/>
+        <element name="otherCharacteristics" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductPackaged" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPackaged" label="MedicinalProductPackaged" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="legalStatusOfSupply" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="marketingStatus">
+            <elementTypeSpecifier elementType="fakeIg.MarketingStatus" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="marketingAuthorization" elementType="fakeIg.Reference"/>
+        <element name="manufacturer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="batchIdentifier">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPackaged.BatchIdentifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="packageItem">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPackaged.PackageItem" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPackaged.BatchIdentifier" retrievable="false" xsi:type="ClassInfo">
+        <element name="outerPackaging" elementType="fakeIg.Identifier"/>
+        <element name="immediatePackaging" elementType="fakeIg.Identifier"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPackaged.PackageItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="material" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="alternateMaterial" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="device">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="manufacturedItem">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="packageItem">
+            <elementTypeSpecifier namespace="fakeIg" name="MedicinalProductPackaged.PackageItem" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="physicalCharacteristics" elementType="fakeIg.ProdCharacteristic"/>
+        <element name="otherCharacteristics" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="shelfLifeStorage">
+            <elementTypeSpecifier elementType="fakeIg.ProductShelfLife" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="manufacturer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductPharmaceutical" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductPharmaceutical" label="MedicinalProductPharmaceutical" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="administrableDoseForm" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unitOfPresentation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="ingredient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="device">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="characteristics">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPharmaceutical.Characteristics" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="routeOfAdministration">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPharmaceutical.RouteOfAdministration" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPharmaceutical.Characteristics" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPharmaceutical.RouteOfAdministration" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="firstDose" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="maxSingleDose" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="maxDosePerDay" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="maxDosePerTreatmentPeriod" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="maxTreatmentPeriod" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="targetSpecies">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="withdrawalPeriod">
+            <elementTypeSpecifier elementType="fakeIg.MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies.WithdrawalPeriod" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MedicinalProductPharmaceutical.RouteOfAdministration.TargetSpecies.WithdrawalPeriod" retrievable="false" xsi:type="ClassInfo">
+        <element name="tissue" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="supportingInformation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MedicinalProductUndesirableEffect" identifier="http://hl7.org/fhir/StructureDefinition/MedicinalProductUndesirableEffect" label="MedicinalProductUndesirableEffect" retrievable="true" xsi:type="ClassInfo">
+        <element name="subject">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="symptomConditionEffect" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="classification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="frequencyOfOccurrence" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="population">
+            <elementTypeSpecifier elementType="fakeIg.Population" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MessageDefinition" identifier="http://hl7.org/fhir/StructureDefinition/MessageDefinition" label="MessageDefinition" retrievable="true" primaryCodePath="event" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="replaces" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="base" elementType="System.String" target="%value.value"/>
+        <element name="parent" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="event" target="System.Code:FHIRHelpers.ToCode(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="category" elementType="fakeIg.MessageSignificanceCategory"/>
+        <element name="focus">
+            <elementTypeSpecifier elementType="fakeIg.MessageDefinition.Focus" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="responseRequired" elementType="fakeIg.Messageheader_Response_Request"/>
+        <element name="allowedResponse">
+            <elementTypeSpecifier elementType="fakeIg.MessageDefinition.AllowedResponse" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="graph" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MessageDefinition.AllowedResponse" retrievable="false" xsi:type="ClassInfo">
+        <element name="message" elementType="System.String" target="%value.value"/>
+        <element name="situation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MessageDefinition.Focus" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="fakeIg.ResourceType"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MessageHeader" identifier="http://hl7.org/fhir/StructureDefinition/MessageHeader" label="MessageHeader" retrievable="true" xsi:type="ClassInfo">
+        <element name="event" target="System.Code:FHIRHelpers.ToCode(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="destination">
+            <elementTypeSpecifier elementType="fakeIg.MessageHeader.Destination" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sender" elementType="fakeIg.Reference"/>
+        <element name="enterer" elementType="fakeIg.Reference"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="source" elementType="fakeIg.MessageHeader.Source"/>
+        <element name="responsible" elementType="fakeIg.Reference"/>
+        <element name="reason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="response" elementType="fakeIg.MessageHeader.Response"/>
+        <element name="focus">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="receiver"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="responsible"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="enterer"/>
+        <contextRelationship context="Device" relatedKeyElement="target"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MessageHeader.Destination" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="target" elementType="fakeIg.Reference"/>
+        <element name="endpoint" elementType="System.String" target="%value.value"/>
+        <element name="receiver" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MessageHeader.Response" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="fakeIg.ResponseType"/>
+        <element name="details" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MessageHeader.Source" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="software" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="contact" elementType="fakeIg.ContactPoint"/>
+        <element name="endpoint" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MessageSignificanceCategory" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="Messageheader_Response_Request" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Meta" identifier="http://hl7.org/fhir/StructureDefinition/Meta" label="Meta" retrievable="false" xsi:type="ClassInfo">
+        <element name="versionId" elementType="System.String" target="%value.value"/>
+        <element name="lastUpdated" elementType="System.DateTime" target="%value.value"/>
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="profile" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="security" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="tag" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="MimeType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="MolecularSequence" identifier="http://hl7.org/fhir/StructureDefinition/MolecularSequence" label="MolecularSequence" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="fakeIg.SequenceType"/>
+        <element name="coordinateSystem" elementType="System.Integer" target="%value.value"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="specimen" elementType="fakeIg.Reference"/>
+        <element name="device" elementType="fakeIg.Reference"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="referenceSeq" elementType="fakeIg.MolecularSequence.ReferenceSeq"/>
+        <element name="variant">
+            <elementTypeSpecifier elementType="fakeIg.MolecularSequence.Variant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="observedSeq" elementType="System.String" target="%value.value"/>
+        <element name="quality">
+            <elementTypeSpecifier elementType="fakeIg.MolecularSequence.Quality" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="readCoverage" elementType="System.Integer" target="%value.value"/>
+        <element name="repository">
+            <elementTypeSpecifier elementType="fakeIg.MolecularSequence.Repository" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="pointer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="structureVariant">
+            <elementTypeSpecifier elementType="fakeIg.MolecularSequence.StructureVariant" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.Quality" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.QualityType"/>
+        <element name="standardSequence" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="start" elementType="System.Integer" target="%value.value"/>
+        <element name="end" elementType="System.Integer" target="%value.value"/>
+        <element name="score" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="truthTP" elementType="System.Decimal" target="%value.value"/>
+        <element name="queryTP" elementType="System.Decimal" target="%value.value"/>
+        <element name="truthFN" elementType="System.Decimal" target="%value.value"/>
+        <element name="queryFP" elementType="System.Decimal" target="%value.value"/>
+        <element name="gtFP" elementType="System.Decimal" target="%value.value"/>
+        <element name="precision" elementType="System.Decimal" target="%value.value"/>
+        <element name="recall" elementType="System.Decimal" target="%value.value"/>
+        <element name="fScore" elementType="System.Decimal" target="%value.value"/>
+        <element name="roc" elementType="fakeIg.MolecularSequence.Quality.Roc"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.Quality.Roc" retrievable="false" xsi:type="ClassInfo">
+        <element name="score" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="numTP" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="numFP" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="numFN" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="precision" target="%value.value">
+            <elementTypeSpecifier elementType="System.Decimal" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sensitivity" target="%value.value">
+            <elementTypeSpecifier elementType="System.Decimal" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="fMeasure" target="%value.value">
+            <elementTypeSpecifier elementType="System.Decimal" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.ReferenceSeq" retrievable="false" xsi:type="ClassInfo">
+        <element name="chromosome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="genomeBuild" elementType="System.String" target="%value.value"/>
+        <element name="orientation" elementType="fakeIg.OrientationType"/>
+        <element name="referenceSeqId" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="referenceSeqPointer" elementType="fakeIg.Reference"/>
+        <element name="referenceSeqString" elementType="System.String" target="%value.value"/>
+        <element name="strand" elementType="fakeIg.StrandType"/>
+        <element name="windowStart" elementType="System.Integer" target="%value.value"/>
+        <element name="windowEnd" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.Repository" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.RepositoryType"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="datasetId" elementType="System.String" target="%value.value"/>
+        <element name="variantsetId" elementType="System.String" target="%value.value"/>
+        <element name="readsetId" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.StructureVariant" retrievable="false" xsi:type="ClassInfo">
+        <element name="variantType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="exact" elementType="System.Boolean" target="%value.value"/>
+        <element name="length" elementType="System.Integer" target="%value.value"/>
+        <element name="outer" elementType="fakeIg.MolecularSequence.StructureVariant.Outer"/>
+        <element name="inner" elementType="fakeIg.MolecularSequence.StructureVariant.Inner"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.StructureVariant.Inner" retrievable="false" xsi:type="ClassInfo">
+        <element name="start" elementType="System.Integer" target="%value.value"/>
+        <element name="end" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.StructureVariant.Outer" retrievable="false" xsi:type="ClassInfo">
+        <element name="start" elementType="System.Integer" target="%value.value"/>
+        <element name="end" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="MolecularSequence.Variant" retrievable="false" xsi:type="ClassInfo">
+        <element name="start" elementType="System.Integer" target="%value.value"/>
+        <element name="end" elementType="System.Integer" target="%value.value"/>
+        <element name="observedAllele" elementType="System.String" target="%value.value"/>
+        <element name="referenceAllele" elementType="System.String" target="%value.value"/>
+        <element name="cigar" elementType="System.String" target="%value.value"/>
+        <element name="variantPointer" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Money" identifier="http://hl7.org/fhir/StructureDefinition/Money" label="Money" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="currency" elementType="fakeIg.CurrencyCode"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="MoneyQuantity" identifier="http://hl7.org/fhir/StructureDefinition/MoneyQuantity" label="MoneyQuantity" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="comparator" elementType="fakeIg.QuantityComparator"/>
+        <element name="unit" elementType="System.String" target="%value.value"/>
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NameUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="NamingSystem" identifier="http://hl7.org/fhir/StructureDefinition/NamingSystem" label="NamingSystem" retrievable="true" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="kind" elementType="fakeIg.NamingSystemType"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="responsible" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="uniqueId">
+            <elementTypeSpecifier elementType="fakeIg.NamingSystem.UniqueId" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NamingSystem.UniqueId" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.NamingSystemIdentifierType"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="preferred" elementType="System.Boolean" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NamingSystemIdentifierType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NamingSystemType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Narrative" identifier="http://hl7.org/fhir/StructureDefinition/Narrative" label="Narrative" retrievable="false" xsi:type="ClassInfo">
+        <element name="status" elementType="fakeIg.NarrativeStatus"/>
+        <element name="div" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NarrativeStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NoteType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NutritiionOrderIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="NutritionOrder" identifier="http://hl7.org/fhir/StructureDefinition/NutritionOrder" label="NutritionOrder" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiates" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.NutritionOrderStatus"/>
+        <element name="intent" elementType="fakeIg.NutritiionOrderIntent"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="dateTime" elementType="System.DateTime" target="%value.value"/>
+        <element name="orderer" elementType="fakeIg.Reference"/>
+        <element name="allergyIntolerance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="foodPreferenceModifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="excludeFoodModifier" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="oralDiet" elementType="fakeIg.NutritionOrder.OralDiet"/>
+        <element name="supplement">
+            <elementTypeSpecifier elementType="fakeIg.NutritionOrder.Supplement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="enteralFormula" elementType="fakeIg.NutritionOrder.EnteralFormula"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="orderer"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.EnteralFormula" retrievable="false" xsi:type="ClassInfo">
+        <element name="baseFormulaType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="baseFormulaProductName" elementType="System.String" target="%value.value"/>
+        <element name="additiveType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="additiveProductName" elementType="System.String" target="%value.value"/>
+        <element name="caloricDensity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="routeofAdministration" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="administration">
+            <elementTypeSpecifier elementType="fakeIg.NutritionOrder.EnteralFormula.Administration" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="maxVolumeToDeliver" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="administrationInstruction" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.EnteralFormula.Administration" retrievable="false" xsi:type="ClassInfo">
+        <element name="schedule" elementType="fakeIg.Timing"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="rate" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Ratio:FHIRHelpers.ToRatio(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.OralDiet" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="schedule">
+            <elementTypeSpecifier elementType="fakeIg.Timing" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="nutrient">
+            <elementTypeSpecifier elementType="fakeIg.NutritionOrder.OralDiet.Nutrient" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="texture">
+            <elementTypeSpecifier elementType="fakeIg.NutritionOrder.OralDiet.Texture" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="fluidConsistencyType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instruction" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.OralDiet.Nutrient" retrievable="false" xsi:type="ClassInfo">
+        <element name="modifier" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.OralDiet.Texture" retrievable="false" xsi:type="ClassInfo">
+        <element name="modifier" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="foodType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="NutritionOrder.Supplement" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="productName" elementType="System.String" target="%value.value"/>
+        <element name="schedule">
+            <elementTypeSpecifier elementType="fakeIg.Timing" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="instruction" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="NutritionOrderStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Observation" identifier="http://hl7.org/fhir/StructureDefinition/Observation" label="Observation" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ObservationStatus"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="focus">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="effective" target="System.DateTime:%value.value;;fakeIg.Timing:null;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.SampledData:null;System.Time:%value.value;System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dataAbsentReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="interpretation" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="specimen" elementType="fakeIg.Reference"/>
+        <element name="device" elementType="fakeIg.Reference"/>
+        <element name="referenceRange">
+            <elementTypeSpecifier elementType="fakeIg.Observation.ReferenceRange" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="hasMember">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="derivedFrom">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="component">
+            <elementTypeSpecifier elementType="fakeIg.Observation.Component" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+        <contextRelationship context="Device" relatedKeyElement="device"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Observation.Component" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.SampledData:null;System.Time:%value.value;System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="dataAbsentReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="interpretation" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referenceRange">
+            <elementTypeSpecifier namespace="fakeIg" name="Observation.ReferenceRange" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Observation.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+        <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="high" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="appliesTo" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="age">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="text" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ObservationDataType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ObservationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ObservationDefinition" label="ObservationDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="permittedDataType">
+            <elementTypeSpecifier elementType="fakeIg.ObservationDataType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="multipleResultsAllowed" elementType="System.Boolean" target="%value.value"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="preferredReportName" elementType="System.String" target="%value.value"/>
+        <element name="quantitativeDetails" elementType="fakeIg.ObservationDefinition.QuantitativeDetails"/>
+        <element name="qualifiedInterval">
+            <elementTypeSpecifier elementType="fakeIg.ObservationDefinition.QualifiedInterval" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="validCodedValueSet" elementType="fakeIg.Reference"/>
+        <element name="normalCodedValueSet" elementType="fakeIg.Reference"/>
+        <element name="abnormalCodedValueSet" elementType="fakeIg.Reference"/>
+        <element name="criticalCodedValueSet" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ObservationDefinition.QualifiedInterval" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="fakeIg.ObservationRangeCategory"/>
+        <element name="range">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="context" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="appliesTo" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="age">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="gestationalAge">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="condition" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ObservationDefinition.QuantitativeDetails" retrievable="false" xsi:type="ClassInfo">
+        <element name="customaryUnit" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="unit" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="conversionFactor" elementType="System.Decimal" target="%value.value"/>
+        <element name="decimalPrecision" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ObservationRangeCategory" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ObservationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="OperationDefinition" identifier="http://hl7.org/fhir/StructureDefinition/OperationDefinition" label="OperationDefinition" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="kind" elementType="fakeIg.OperationKind"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="affectsState" elementType="System.Boolean" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="base" elementType="System.String" target="%value.value"/>
+        <element name="resource">
+            <elementTypeSpecifier elementType="fakeIg.ResourceType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="system" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="System.Boolean" target="%value.value"/>
+        <element name="instance" elementType="System.Boolean" target="%value.value"/>
+        <element name="inputProfile" elementType="System.String" target="%value.value"/>
+        <element name="outputProfile" elementType="System.String" target="%value.value"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.OperationDefinition.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="overload">
+            <elementTypeSpecifier elementType="fakeIg.OperationDefinition.Overload" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="OperationDefinition.Overload" retrievable="false" xsi:type="ClassInfo">
+        <element name="parameterName" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="OperationDefinition.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="use" elementType="fakeIg.OperationParameterUse"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.FHIRAllTypes"/>
+        <element name="targetProfile" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="searchType" elementType="fakeIg.SearchParamType"/>
+        <element name="binding" elementType="fakeIg.OperationDefinition.Parameter.Binding"/>
+        <element name="referencedFrom">
+            <elementTypeSpecifier elementType="fakeIg.OperationDefinition.Parameter.ReferencedFrom" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="part">
+            <elementTypeSpecifier namespace="fakeIg" name="OperationDefinition.Parameter" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="OperationDefinition.Parameter.Binding" retrievable="false" xsi:type="ClassInfo">
+        <element name="strength" elementType="fakeIg.BindingStrength"/>
+        <element name="valueSet" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="OperationDefinition.Parameter.ReferencedFrom" retrievable="false" xsi:type="ClassInfo">
+        <element name="source" elementType="System.String" target="%value.value"/>
+        <element name="sourceId" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="OperationKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="OperationOutcome" identifier="http://hl7.org/fhir/StructureDefinition/OperationOutcome" label="OperationOutcome" retrievable="true" primaryCodePath="issue.code" xsi:type="ClassInfo">
+        <element name="issue">
+            <elementTypeSpecifier elementType="fakeIg.OperationOutcome.Issue" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="OperationOutcome.Issue" retrievable="false" xsi:type="ClassInfo">
+        <element name="severity" elementType="fakeIg.IssueSeverity"/>
+        <element name="code" elementType="fakeIg.IssueType"/>
+        <element name="details" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="diagnostics" elementType="System.String" target="%value.value"/>
+        <element name="location" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="expression" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="OperationParameterUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Organization" identifier="http://hl7.org/fhir/StructureDefinition/Organization" label="Organization" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="alias" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf" elementType="fakeIg.Reference"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.Organization.Contact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Organization.Contact" retrievable="false" xsi:type="ClassInfo">
+        <element name="purpose" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="name" elementType="fakeIg.HumanName"/>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address" elementType="fakeIg.Address"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="OrganizationAffiliation" identifier="http://hl7.org/fhir/StructureDefinition/OrganizationAffiliation" label="OrganizationAffiliation" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="organization" elementType="fakeIg.Reference"/>
+        <element name="participatingOrganization" elementType="fakeIg.Reference"/>
+        <element name="network">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="healthcareService">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="OrientationType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="ParameterDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ParameterDefinition" label="ParameterDefinition" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="use" elementType="fakeIg.ParameterUse"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.FHIRAllTypes"/>
+        <element name="profile" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ParameterUse" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Resource" namespace="fakeIg" name="Parameters" identifier="http://hl7.org/fhir/StructureDefinition/Parameters" label="Parameters" retrievable="true" xsi:type="ClassInfo">
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.Parameters.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Parameters.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="resource" elementType="fakeIg.Resource"/>
+        <element name="part">
+            <elementTypeSpecifier namespace="fakeIg" name="Parameters.Parameter" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ParticipantRequired" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ParticipantStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ParticipationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="FakeExtension" identifier="http://fakeIg.com/fake-extension" label="Fake Extension" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="FakePatient" identifier="http://fakeIg.com/fake-patient" target="Patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+        <element name="fakeExtension" elementType="fakeIg.FakeExtension" target="%parent.extension[url='http://fakeIg.com/fake-extension']"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.HumanName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="birthDate" elementType="System.Date" target="%value.value"/>
+        <element name="deceased" target="System.Boolean:%value.value;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="maritalStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="multipleBirth" target="System.Boolean:%value.value;System.Integer:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="photo">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Contact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communication">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Communication" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="generalPractitioner">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="generalPractitioner"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="other"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Patient" identifier="http://hl7.org/fhir/StructureDefinition/Patient" label="Patient" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.HumanName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="birthDate" elementType="System.Date" target="%value.value"/>
+        <element name="deceased" target="System.Boolean:%value.value;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="maritalStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="multipleBirth" target="System.Boolean:%value.value;System.Integer:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="photo">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Contact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communication">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Communication" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="generalPractitioner">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.Patient.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="generalPractitioner"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="other"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Patient.Communication" retrievable="false" xsi:type="ClassInfo">
+        <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="preferred" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Patient.Contact" retrievable="false" xsi:type="ClassInfo">
+        <element name="relationship" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name" elementType="fakeIg.HumanName"/>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address" elementType="fakeIg.Address"/>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="organization" elementType="fakeIg.Reference"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Patient.Link" retrievable="false" xsi:type="ClassInfo">
+        <element name="other" elementType="fakeIg.Reference"/>
+        <element name="type" elementType="fakeIg.LinkType"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="PaymentNotice" identifier="http://hl7.org/fhir/StructureDefinition/PaymentNotice" label="PaymentNotice" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PaymentNoticeStatus"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="response" elementType="fakeIg.Reference"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="provider" elementType="fakeIg.Reference"/>
+        <element name="payment" elementType="fakeIg.Reference"/>
+        <element name="paymentDate" elementType="System.Date" target="%value.value"/>
+        <element name="payee" elementType="fakeIg.Reference"/>
+        <element name="recipient" elementType="fakeIg.Reference"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="paymentStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="provider"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="PaymentNoticeStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="PaymentReconciliation" identifier="http://hl7.org/fhir/StructureDefinition/PaymentReconciliation" label="PaymentReconciliation" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PaymentReconciliationStatus"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="paymentIssuer" elementType="fakeIg.Reference"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="requestor" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.RemittanceOutcome"/>
+        <element name="disposition" elementType="System.String" target="%value.value"/>
+        <element name="paymentDate" elementType="System.Date" target="%value.value"/>
+        <element name="paymentAmount" elementType="System.Decimal" target="%value.value"/>
+        <element name="paymentIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="detail">
+            <elementTypeSpecifier elementType="fakeIg.PaymentReconciliation.Detail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="formCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="processNote">
+            <elementTypeSpecifier elementType="fakeIg.PaymentReconciliation.ProcessNote" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="requestor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PaymentReconciliation.Detail" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="predecessor" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="request" elementType="fakeIg.Reference"/>
+        <element name="submitter" elementType="fakeIg.Reference"/>
+        <element name="response" elementType="fakeIg.Reference"/>
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="responsible" elementType="fakeIg.Reference"/>
+        <element name="payee" elementType="fakeIg.Reference"/>
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PaymentReconciliation.ProcessNote" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.NoteType"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="PaymentReconciliationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Period" identifier="http://hl7.org/fhir/StructureDefinition/Period" label="Period" retrievable="false" xsi:type="ClassInfo">
+        <element name="start" elementType="System.DateTime" target="%value.value"/>
+        <element name="end" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Person" identifier="http://hl7.org/fhir/StructureDefinition/Person" label="Person" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.HumanName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="birthDate" elementType="System.Date" target="%value.value"/>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="photo" elementType="fakeIg.Attachment"/>
+        <element name="managingOrganization" elementType="fakeIg.Reference"/>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.Person.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="where(resolve() is Practitioner)"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="target"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Person.Link" retrievable="false" xsi:type="ClassInfo">
+        <element name="target" elementType="fakeIg.Reference"/>
+        <element name="assurance" elementType="fakeIg.IdentityAssuranceLevel"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="PlanDefinition" identifier="http://hl7.org/fhir/StructureDefinition/PlanDefinition" label="PlanDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="library" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="goal">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Goal" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="prefix" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="textEquivalent" elementType="System.String" target="%value.value"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="goalId" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="trigger">
+            <elementTypeSpecifier elementType="fakeIg.TriggerDefinition" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Action.Condition" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="input">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="output">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedAction">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Action.RelatedAction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="timing" target="System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Quantity:FHIRHelpers.ToQuantity(%value);;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Action.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="groupingBehavior" elementType="fakeIg.ActionGroupingBehavior"/>
+        <element name="selectionBehavior" elementType="fakeIg.ActionSelectionBehavior"/>
+        <element name="requiredBehavior" elementType="fakeIg.ActionRequiredBehavior"/>
+        <element name="precheckBehavior" elementType="fakeIg.ActionPrecheckBehavior"/>
+        <element name="cardinalityBehavior" elementType="fakeIg.ActionCardinalityBehavior"/>
+        <element name="definition" target="System.String:%value.value;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="transform" elementType="System.String" target="%value.value"/>
+        <element name="dynamicValue">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Action.DynamicValue" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action">
+            <elementTypeSpecifier namespace="fakeIg" name="PlanDefinition.Action" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Action.Condition" retrievable="false" xsi:type="ClassInfo">
+        <element name="kind" elementType="fakeIg.ActionConditionKind"/>
+        <element name="expression" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Action.DynamicValue" retrievable="false" xsi:type="ClassInfo">
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Action.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ActionParticipantType"/>
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Action.RelatedAction" retrievable="false" xsi:type="ClassInfo">
+        <element name="actionId" elementType="System.String" target="%value.value"/>
+        <element name="relationship" elementType="fakeIg.ActionRelationshipType"/>
+        <element name="offset" target="System.Quantity:FHIRHelpers.ToQuantity(%value);">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Goal" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="priority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="start" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="addresses" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.PlanDefinition.Goal.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PlanDefinition.Goal.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="measure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="detail" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="due" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Population" identifier="http://hl7.org/fhir/StructureDefinition/Population" label="Population" retrievable="false" xsi:type="ClassInfo">
+        <element name="age" target="System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="gender" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="race" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="physiologicalCondition" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Practitioner" identifier="http://hl7.org/fhir/StructureDefinition/Practitioner" label="Practitioner" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.HumanName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="birthDate" elementType="System.Date" target="%value.value"/>
+        <element name="photo">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="qualification">
+            <elementTypeSpecifier elementType="fakeIg.Practitioner.Qualification" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communication" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Practitioner.Qualification" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="issuer" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="PractitionerRole" identifier="http://hl7.org/fhir/StructureDefinition/PractitionerRole" label="PractitionerRole" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="practitioner" elementType="fakeIg.Reference"/>
+        <element name="organization" elementType="fakeIg.Reference"/>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="healthcareService">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="availableTime">
+            <elementTypeSpecifier elementType="fakeIg.PractitionerRole.AvailableTime" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="notAvailable">
+            <elementTypeSpecifier elementType="fakeIg.PractitionerRole.NotAvailable" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="availabilityExceptions" elementType="System.String" target="%value.value"/>
+        <element name="endpoint">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="practitioner"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PractitionerRole.AvailableTime" retrievable="false" xsi:type="ClassInfo">
+        <element name="daysOfWeek">
+            <elementTypeSpecifier elementType="fakeIg.DaysOfWeek" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="allDay" elementType="System.Boolean" target="%value.value"/>
+        <element name="availableStartTime" elementType="System.Time" target="%value.value"/>
+        <element name="availableEndTime" elementType="System.Time" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="PractitionerRole.NotAvailable" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="during">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Procedure" identifier="http://hl7.org/fhir/StructureDefinition/Procedure" label="Procedure" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ProcedureStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="performed" target="System.DateTime:%value.value;;System.String:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recorder" elementType="fakeIg.Reference"/>
+        <element name="asserter" elementType="fakeIg.Reference"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Procedure.Performer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="report">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="complication" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="complicationDetail">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="followUp" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="focalDevice">
+            <elementTypeSpecifier elementType="fakeIg.Procedure.FocalDevice" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="usedReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="usedCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Procedure.FocalDevice" retrievable="false" xsi:type="ClassInfo">
+        <element name="action" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="manipulated" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Procedure.Performer" retrievable="false" xsi:type="ClassInfo">
+        <element name="function" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="actor" elementType="fakeIg.Reference"/>
+        <element name="onBehalfOf" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ProcedureStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ProdCharacteristic" identifier="http://hl7.org/fhir/StructureDefinition/ProdCharacteristic" label="ProdCharacteristic" retrievable="false" xsi:type="ClassInfo">
+        <element name="height" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="width" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="depth" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="weight" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="nominalVolume" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="externalDiameter" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="shape" elementType="System.String" target="%value.value"/>
+        <element name="color" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="imprint" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="image">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="scoring" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ProductShelfLife" identifier="http://hl7.org/fhir/StructureDefinition/ProductShelfLife" label="ProductShelfLife" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="period" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="specialPrecautionsForStorage" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="PropertyRepresentation" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="PropertyType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Provenance" identifier="http://hl7.org/fhir/StructureDefinition/Provenance" label="Provenance" retrievable="true" xsi:type="ClassInfo">
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="occurred" target="System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recorded" elementType="System.DateTime" target="%value.value"/>
+        <element name="policy" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="reason" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="activity" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="agent">
+            <elementTypeSpecifier elementType="fakeIg.Provenance.Agent" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="entity">
+            <elementTypeSpecifier elementType="fakeIg.Provenance.Entity" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="signature">
+            <elementTypeSpecifier elementType="fakeIg.Signature" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="who"/>
+        <contextRelationship context="Device" relatedKeyElement="who"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="who"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Provenance.Agent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="role" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="who" elementType="fakeIg.Reference"/>
+        <element name="onBehalfOf" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Provenance.Entity" retrievable="false" xsi:type="ClassInfo">
+        <element name="role" elementType="fakeIg.ProvenanceEntityRole"/>
+        <element name="what" elementType="fakeIg.Reference"/>
+        <element name="agent">
+            <elementTypeSpecifier namespace="fakeIg" name="Provenance.Agent" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ProvenanceEntityRole" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="PublicationStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="QualityType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Quantity" identifier="http://hl7.org/fhir/StructureDefinition/Quantity" label="Quantity" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="comparator" elementType="fakeIg.QuantityComparator"/>
+        <element name="unit" elementType="System.String" target="%value.value"/>
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="QuantityComparator" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Questionnaire" identifier="http://hl7.org/fhir/StructureDefinition/Questionnaire" label="Questionnaire" retrievable="true" primaryCodePath="name" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="derivedFrom" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subjectType">
+            <elementTypeSpecifier elementType="fakeIg.ResourceType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="code" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.Questionnaire.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Questionnaire.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="linkId" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="code" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prefix" elementType="System.String" target="%value.value"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="fakeIg.QuestionnaireItemType"/>
+        <element name="enableWhen">
+            <elementTypeSpecifier elementType="fakeIg.Questionnaire.Item.EnableWhen" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="enableBehavior" elementType="fakeIg.EnableWhenBehavior"/>
+        <element name="required" elementType="System.Boolean" target="%value.value"/>
+        <element name="repeats" elementType="System.Boolean" target="%value.value"/>
+        <element name="readOnly" elementType="System.Boolean" target="%value.value"/>
+        <element name="maxLength" elementType="System.Integer" target="%value.value"/>
+        <element name="answerValueSet" elementType="System.String" target="%value.value"/>
+        <element name="answerOption">
+            <elementTypeSpecifier elementType="fakeIg.Questionnaire.Item.AnswerOption" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="initial">
+            <elementTypeSpecifier elementType="fakeIg.Questionnaire.Item.Initial" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier namespace="fakeIg" name="Questionnaire.Item" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Questionnaire.Item.AnswerOption" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" target="System.Integer:%value.value;System.Date:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="initialSelected" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Questionnaire.Item.EnableWhen" retrievable="false" xsi:type="ClassInfo">
+        <element name="question" elementType="System.String" target="%value.value"/>
+        <element name="operator" elementType="fakeIg.QuestionnaireItemOperator"/>
+        <element name="answer" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Questionnaire.Item.Initial" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="QuestionnaireItemOperator" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="QuestionnaireItemType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="QuestionnaireResponse" identifier="http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse" label="QuestionnaireResponse" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="questionnaire" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.QuestionnaireResponseStatus"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="authored" elementType="System.DateTime" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="source" elementType="fakeIg.Reference"/>
+        <element name="item">
+            <elementTypeSpecifier elementType="fakeIg.QuestionnaireResponse.Item" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="source"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="source"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="QuestionnaireResponse.Item" retrievable="false" xsi:type="ClassInfo">
+        <element name="linkId" elementType="System.String" target="%value.value"/>
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="text" elementType="System.String" target="%value.value"/>
+        <element name="answer">
+            <elementTypeSpecifier elementType="fakeIg.QuestionnaireResponse.Item.Answer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier namespace="fakeIg" name="QuestionnaireResponse.Item" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="QuestionnaireResponse.Item.Answer" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" target="System.Boolean:%value.value;System.Decimal:%value.value;System.Integer:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Time:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Attachment:null;System.Code:FHIRHelpers.ToCode(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="item">
+            <elementTypeSpecifier namespace="fakeIg" name="QuestionnaireResponse.Item" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="QuestionnaireResponseStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Range" identifier="http://hl7.org/fhir/StructureDefinition/Range" label="Range" retrievable="false" xsi:type="ClassInfo">
+        <element name="low" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="high" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Ratio" identifier="http://hl7.org/fhir/StructureDefinition/Ratio" label="Ratio" retrievable="false" xsi:type="ClassInfo">
+        <element name="numerator" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="denominator" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Reference" identifier="http://hl7.org/fhir/StructureDefinition/Reference" label="Reference" retrievable="false" xsi:type="ClassInfo">
+        <element name="reference" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ReferenceHandlingPolicy" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ReferenceVersionRules" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ReferredDocumentStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="RelatedArtifact" identifier="http://hl7.org/fhir/StructureDefinition/RelatedArtifact" label="RelatedArtifact" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.RelatedArtifactType"/>
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="citation" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="document" elementType="fakeIg.Attachment"/>
+        <element name="resource" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RelatedArtifactType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="RelatedPerson" identifier="http://hl7.org/fhir/StructureDefinition/RelatedPerson" label="RelatedPerson" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="relationship" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.HumanName" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="telecom">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="gender" elementType="fakeIg.AdministrativeGender"/>
+        <element name="birthDate" elementType="System.Date" target="%value.value"/>
+        <element name="address">
+            <elementTypeSpecifier elementType="fakeIg.Address" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="photo">
+            <elementTypeSpecifier elementType="fakeIg.Attachment" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="communication">
+            <elementTypeSpecifier elementType="fakeIg.RelatedPerson.Communication" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RelatedPerson.Communication" retrievable="false" xsi:type="ClassInfo">
+        <element name="language" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="preferred" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RemittanceOutcome" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RepositoryType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="RequestGroup" identifier="http://hl7.org/fhir/StructureDefinition/RequestGroup" label="RequestGroup" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="replaces">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="groupIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.RequestStatus"/>
+        <element name="intent" elementType="fakeIg.RequestIntent"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="author" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.RequestGroup.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="participant"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="author"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="author"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="participant"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RequestGroup.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="prefix" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="textEquivalent" elementType="System.String" target="%value.value"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="code" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition">
+            <elementTypeSpecifier elementType="fakeIg.RequestGroup.Action.Condition" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedAction">
+            <elementTypeSpecifier elementType="fakeIg.RequestGroup.Action.RelatedAction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="timing" target="System.DateTime:%value.value;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Quantity:FHIRHelpers.ToQuantity(%value);;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="groupingBehavior" elementType="fakeIg.ActionGroupingBehavior"/>
+        <element name="selectionBehavior" elementType="fakeIg.ActionSelectionBehavior"/>
+        <element name="requiredBehavior" elementType="fakeIg.ActionRequiredBehavior"/>
+        <element name="precheckBehavior" elementType="fakeIg.ActionPrecheckBehavior"/>
+        <element name="cardinalityBehavior" elementType="fakeIg.ActionCardinalityBehavior"/>
+        <element name="resource" elementType="fakeIg.Reference"/>
+        <element name="action">
+            <elementTypeSpecifier namespace="fakeIg" name="RequestGroup.Action" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RequestGroup.Action.Condition" retrievable="false" xsi:type="ClassInfo">
+        <element name="kind" elementType="fakeIg.ActionConditionKind"/>
+        <element name="expression" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RequestGroup.Action.RelatedAction" retrievable="false" xsi:type="ClassInfo">
+        <element name="actionId" elementType="System.String" target="%value.value"/>
+        <element name="relationship" elementType="fakeIg.ActionRelationshipType"/>
+        <element name="offset" target="System.Quantity:FHIRHelpers.ToQuantity(%value);">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RequestIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RequestPriority" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ResearchDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchDefinition" label="ResearchDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="shortTitle" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="comment" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="library" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="population" elementType="fakeIg.Reference"/>
+        <element name="exposure" elementType="fakeIg.Reference"/>
+        <element name="exposureAlternative" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ResearchElementDefinition" identifier="http://hl7.org/fhir/StructureDefinition/ResearchElementDefinition" label="ResearchElementDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="shortTitle" elementType="System.String" target="%value.value"/>
+        <element name="subtitle" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="subject" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="comment" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="usage" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="library" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="fakeIg.ResearchElementType"/>
+        <element name="variableType" elementType="fakeIg.VariableType"/>
+        <element name="characteristic">
+            <elementTypeSpecifier elementType="fakeIg.ResearchElementDefinition.Characteristic" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ResearchElementDefinition.Characteristic" retrievable="false" xsi:type="ClassInfo">
+        <element name="definition" target="System.Concept:FHIRHelpers.ToConcept(%value);System.String:%value.value;fakeIg.Expression:null;fakeIg.DataRequirement:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="usageContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="exclude" elementType="System.Boolean" target="%value.value"/>
+        <element name="unitOfMeasure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="studyEffectiveDescription" elementType="System.String" target="%value.value"/>
+        <element name="studyEffective" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="studyEffectiveTimeFromStart" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="studyEffectiveGroupMeasure" elementType="fakeIg.GroupMeasure"/>
+        <element name="participantEffectiveDescription" elementType="System.String" target="%value.value"/>
+        <element name="participantEffective" target="System.DateTime:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="participantEffectiveTimeFromStart" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="participantEffectiveGroupMeasure" elementType="fakeIg.GroupMeasure"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResearchElementType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ResearchStudy" identifier="http://hl7.org/fhir/StructureDefinition/ResearchStudy" label="ResearchStudy" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="protocol">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ResearchStudyStatus"/>
+        <element name="primaryPurposeType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="phase" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="focus" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="keyword" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="location" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="enrollment">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="sponsor" elementType="fakeIg.Reference"/>
+        <element name="principalInvestigator" elementType="fakeIg.Reference"/>
+        <element name="site">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonStopped" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="arm">
+            <elementTypeSpecifier elementType="fakeIg.ResearchStudy.Arm" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="objective">
+            <elementTypeSpecifier elementType="fakeIg.ResearchStudy.Objective" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="principalInvestigator"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ResearchStudy.Arm" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ResearchStudy.Objective" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResearchStudyStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ResearchSubject" identifier="http://hl7.org/fhir/StructureDefinition/ResearchSubject" label="ResearchSubject" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.ResearchSubjectStatus"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="study" elementType="fakeIg.Reference"/>
+        <element name="individual" elementType="fakeIg.Reference"/>
+        <element name="assignedArm" elementType="System.String" target="%value.value"/>
+        <element name="actualArm" elementType="System.String" target="%value.value"/>
+        <element name="consent" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResearchSubjectStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo namespace="fakeIg" name="Resource" identifier="http://hl7.org/fhir/StructureDefinition/Resource" label="Resource" retrievable="true" xsi:type="ClassInfo">
+        <element name="id" elementType="System.String" target="%value.value"/>
+        <element name="meta" elementType="fakeIg.Meta"/>
+        <element name="implicitRules" elementType="System.String" target="%value.value"/>
+        <element name="language" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResourceType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResourceVersionPolicy" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ResponseType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RestfulCapabilityMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="RiskAssessment" identifier="http://hl7.org/fhir/StructureDefinition/RiskAssessment" label="RiskAssessment" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn" elementType="fakeIg.Reference"/>
+        <element name="parent" elementType="fakeIg.Reference"/>
+        <element name="status" elementType="fakeIg.RiskAssessmentStatus"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="occurrence" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="condition" elementType="fakeIg.Reference"/>
+        <element name="performer" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basis">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="prediction">
+            <elementTypeSpecifier elementType="fakeIg.RiskAssessment.Prediction" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="mitigation" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Device" relatedKeyElement="performer"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskAssessment.Prediction" retrievable="false" xsi:type="ClassInfo">
+        <element name="outcome" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="probability" target="System.Decimal:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="qualitativeRisk" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="relativeRisk" elementType="System.Decimal" target="%value.value"/>
+        <element name="when" target="">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="rationale" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="RiskAssessmentStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="RiskEvidenceSynthesis" identifier="http://hl7.org/fhir/StructureDefinition/RiskEvidenceSynthesis" label="RiskEvidenceSynthesis" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="approvalDate" elementType="System.Date" target="%value.value"/>
+        <element name="lastReviewDate" elementType="System.Date" target="%value.value"/>
+        <element name="effectivePeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="topic" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="editor">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reviewer">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="endorser">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relatedArtifact">
+            <elementTypeSpecifier elementType="fakeIg.RelatedArtifact" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="synthesisType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="studyType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="population" elementType="fakeIg.Reference"/>
+        <element name="exposure" elementType="fakeIg.Reference"/>
+        <element name="outcome" elementType="fakeIg.Reference"/>
+        <element name="sampleSize" elementType="fakeIg.RiskEvidenceSynthesis.SampleSize"/>
+        <element name="riskEstimate" elementType="fakeIg.RiskEvidenceSynthesis.RiskEstimate"/>
+        <element name="certainty">
+            <elementTypeSpecifier elementType="fakeIg.RiskEvidenceSynthesis.Certainty" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskEvidenceSynthesis.Certainty" retrievable="false" xsi:type="ClassInfo">
+        <element name="rating" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="certaintySubcomponent">
+            <elementTypeSpecifier elementType="fakeIg.RiskEvidenceSynthesis.Certainty.CertaintySubcomponent" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskEvidenceSynthesis.Certainty.CertaintySubcomponent" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="rating" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskEvidenceSynthesis.RiskEstimate" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="unitOfMeasure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="denominatorCount" elementType="System.Integer" target="%value.value"/>
+        <element name="numeratorCount" elementType="System.Integer" target="%value.value"/>
+        <element name="precisionEstimate">
+            <elementTypeSpecifier elementType="fakeIg.RiskEvidenceSynthesis.RiskEstimate.PrecisionEstimate" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskEvidenceSynthesis.RiskEstimate.PrecisionEstimate" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="level" elementType="System.Decimal" target="%value.value"/>
+        <element name="from" elementType="System.Decimal" target="%value.value"/>
+        <element name="to" elementType="System.Decimal" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="RiskEvidenceSynthesis.SampleSize" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="numberOfStudies" elementType="System.Integer" target="%value.value"/>
+        <element name="numberOfParticipants" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SPDXLicense" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="SampledData" identifier="http://hl7.org/fhir/StructureDefinition/SampledData" label="SampledData" retrievable="false" xsi:type="ClassInfo">
+        <element name="origin" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="period" elementType="System.Decimal" target="%value.value"/>
+        <element name="factor" elementType="System.Decimal" target="%value.value"/>
+        <element name="lowerLimit" elementType="System.Decimal" target="%value.value"/>
+        <element name="upperLimit" elementType="System.Decimal" target="%value.value"/>
+        <element name="dimensions" elementType="System.Integer" target="%value.value"/>
+        <element name="data" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Schedule" identifier="http://hl7.org/fhir/StructureDefinition/Schedule" label="Schedule" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="active" elementType="System.Boolean" target="%value.value"/>
+        <element name="serviceCategory" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="actor">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="planningHorizon">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="actor"/>
+        <contextRelationship context="Device" relatedKeyElement="actor"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="actor"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SearchComparator" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SearchEntryMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SearchModifierCode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SearchParamType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SearchParameter" identifier="http://hl7.org/fhir/StructureDefinition/SearchParameter" label="SearchParameter" retrievable="true" primaryCodePath="target" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="derivedFrom" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="base">
+            <elementTypeSpecifier elementType="fakeIg.ResourceType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="fakeIg.SearchParamType"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="xpath" elementType="System.String" target="%value.value"/>
+        <element name="xpathUsage" elementType="fakeIg.XPathUsageType"/>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.ResourceType" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="multipleOr" elementType="System.Boolean" target="%value.value"/>
+        <element name="multipleAnd" elementType="System.Boolean" target="%value.value"/>
+        <element name="comparator">
+            <elementTypeSpecifier elementType="fakeIg.SearchComparator" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="modifier">
+            <elementTypeSpecifier elementType="fakeIg.SearchModifierCode" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="chain" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="component">
+            <elementTypeSpecifier elementType="fakeIg.SearchParameter.Component" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SearchParameter.Component" retrievable="false" xsi:type="ClassInfo">
+        <element name="definition" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SectionMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SequenceType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ServiceRequest" identifier="http://hl7.org/fhir/StructureDefinition/ServiceRequest" label="ServiceRequest" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesUri" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="replaces">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="requisition" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.ServiceRequestStatus"/>
+        <element name="intent" elementType="fakeIg.ServiceRequestIntent"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="priority" elementType="fakeIg.ServiceRequestPriority"/>
+        <element name="doNotPerform" elementType="System.Boolean" target="%value.value"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="orderDetail" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="quantity" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.Ratio:FHIRHelpers.ToRatio(%value);">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="asNeeded" target="System.Boolean:%value.value;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="performerType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="performer">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="locationCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="locationReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="supportingInfo">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specimen">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="bodySite" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="patientInstruction" elementType="System.String" target="%value.value"/>
+        <element name="relevantHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="performer"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="requester"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+        <contextRelationship context="Device" relatedKeyElement="performer"/>
+        <contextRelationship context="Device" relatedKeyElement="requester"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="performer"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ServiceRequestIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ServiceRequestPriority" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="ServiceRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Signature" identifier="http://hl7.org/fhir/StructureDefinition/Signature" label="Signature" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="when" elementType="System.DateTime" target="%value.value"/>
+        <element name="who" elementType="fakeIg.Reference"/>
+        <element name="onBehalfOf" elementType="fakeIg.Reference"/>
+        <element name="targetFormat" elementType="fakeIg.MimeType"/>
+        <element name="sigFormat" elementType="fakeIg.MimeType"/>
+        <element name="data" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Quantity" namespace="fakeIg" name="SimpleQuantity" identifier="http://hl7.org/fhir/StructureDefinition/SimpleQuantity" label="SimpleQuantity" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="value" elementType="System.Decimal" target="%value.value"/>
+        <element name="unit" elementType="System.String" target="%value.value"/>
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SlicingRules" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Slot" identifier="http://hl7.org/fhir/StructureDefinition/Slot" label="Slot" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceCategory" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="serviceType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="specialty" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="appointmentType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="schedule" elementType="fakeIg.Reference"/>
+        <element name="status" elementType="fakeIg.SlotStatus"/>
+        <element name="start" elementType="System.DateTime" target="%value.value"/>
+        <element name="end" elementType="System.DateTime" target="%value.value"/>
+        <element name="overbooked" elementType="System.Boolean" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SlotStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SortDirection" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Specimen" identifier="http://hl7.org/fhir/StructureDefinition/Specimen" label="Specimen" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="accessionIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="status" elementType="fakeIg.SpecimenStatus"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subject" elementType="fakeIg.Reference"/>
+        <element name="receivedTime" elementType="System.DateTime" target="%value.value"/>
+        <element name="parent">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="request">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="collection" elementType="fakeIg.Specimen.Collection"/>
+        <element name="processing">
+            <elementTypeSpecifier elementType="fakeIg.Specimen.Processing" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="container">
+            <elementTypeSpecifier elementType="fakeIg.Specimen.Container" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="collector"/>
+        <contextRelationship context="Device" relatedKeyElement="subject"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Specimen.Collection" retrievable="false" xsi:type="ClassInfo">
+        <element name="collector" elementType="fakeIg.Reference"/>
+        <element name="collected" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="bodySite" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="fastingStatus" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Specimen.Container" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="capacity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="specimenQuantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="additive" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Specimen.Processing" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="procedure" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="additive">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="time" target="System.DateTime:%value.value;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SpecimenContainedPreference" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SpecimenDefinition" identifier="http://hl7.org/fhir/StructureDefinition/SpecimenDefinition" label="SpecimenDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="typeCollected" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="patientPreparation" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="timeAspect" elementType="System.String" target="%value.value"/>
+        <element name="collection" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="typeTested">
+            <elementTypeSpecifier elementType="fakeIg.SpecimenDefinition.TypeTested" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SpecimenDefinition.TypeTested" retrievable="false" xsi:type="ClassInfo">
+        <element name="isDerived" elementType="System.Boolean" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="preference" elementType="fakeIg.SpecimenContainedPreference"/>
+        <element name="container" elementType="fakeIg.SpecimenDefinition.TypeTested.Container"/>
+        <element name="requirement" elementType="System.String" target="%value.value"/>
+        <element name="retentionTime" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="rejectionCriterion" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="handling">
+            <elementTypeSpecifier elementType="fakeIg.SpecimenDefinition.TypeTested.Handling" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SpecimenDefinition.TypeTested.Container" retrievable="false" xsi:type="ClassInfo">
+        <element name="material" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="cap" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="capacity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="minimumVolume" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="additive">
+            <elementTypeSpecifier elementType="fakeIg.SpecimenDefinition.TypeTested.Container.Additive" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="preparation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SpecimenDefinition.TypeTested.Container.Additive" retrievable="false" xsi:type="ClassInfo">
+        <element name="additive" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SpecimenDefinition.TypeTested.Handling" retrievable="false" xsi:type="ClassInfo">
+        <element name="temperatureQualifier" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="temperatureRange">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="maxDuration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="instruction" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SpecimenStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="Status" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StrandType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="StructureDefinition" identifier="http://hl7.org/fhir/StructureDefinition/StructureDefinition" label="StructureDefinition" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="keyword" target="FHIRHelpers.ToCode(%value)">
+            <elementTypeSpecifier elementType="System.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="fhirVersion" elementType="fakeIg.FHIRVersion"/>
+        <element name="mapping">
+            <elementTypeSpecifier elementType="fakeIg.StructureDefinition.Mapping" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="kind" elementType="fakeIg.StructureDefinitionKind"/>
+        <element name="abstract" elementType="System.Boolean" target="%value.value"/>
+        <element name="context">
+            <elementTypeSpecifier elementType="fakeIg.StructureDefinition.Context" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contextInvariant" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="baseDefinition" elementType="System.String" target="%value.value"/>
+        <element name="derivation" elementType="fakeIg.TypeDerivationRule"/>
+        <element name="snapshot" elementType="fakeIg.StructureDefinition.Snapshot"/>
+        <element name="differential" elementType="fakeIg.StructureDefinition.Differential"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureDefinition.Context" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.ExtensionContextType"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureDefinition.Differential" retrievable="false" xsi:type="ClassInfo">
+        <element name="element">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureDefinition.Mapping" retrievable="false" xsi:type="ClassInfo">
+        <element name="identity" elementType="System.String" target="%value.value"/>
+        <element name="uri" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureDefinition.Snapshot" retrievable="false" xsi:type="ClassInfo">
+        <element name="element">
+            <elementTypeSpecifier elementType="fakeIg.ElementDefinition" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureDefinitionKind" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="StructureMap" identifier="http://hl7.org/fhir/StructureDefinition/StructureMap" label="StructureMap" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="structure">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Structure" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="import" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="group">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="extends" elementType="System.String" target="%value.value"/>
+        <element name="typeMode" elementType="fakeIg.StructureMapGroupTypeMode"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+        <element name="input">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Input" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="rule">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Rule" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Input" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="mode" elementType="fakeIg.StructureMapInputMode"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Rule" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Rule.Source" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Rule.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="rule">
+            <elementTypeSpecifier namespace="fakeIg" name="StructureMap.Group.Rule" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="dependent">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Rule.Dependent" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Rule.Dependent" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="variable" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Rule.Source" retrievable="false" xsi:type="ClassInfo">
+        <element name="context" elementType="System.String" target="%value.value"/>
+        <element name="min" elementType="System.Integer" target="%value.value"/>
+        <element name="max" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.String" target="%value.value"/>
+        <element name="defaultValue" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="element" elementType="System.String" target="%value.value"/>
+        <element name="listMode" elementType="fakeIg.StructureMapSourceListMode"/>
+        <element name="variable" elementType="System.String" target="%value.value"/>
+        <element name="condition" elementType="System.String" target="%value.value"/>
+        <element name="check" elementType="System.String" target="%value.value"/>
+        <element name="logMessage" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Rule.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="context" elementType="System.String" target="%value.value"/>
+        <element name="contextType" elementType="fakeIg.StructureMapContextType"/>
+        <element name="element" elementType="System.String" target="%value.value"/>
+        <element name="variable" elementType="System.String" target="%value.value"/>
+        <element name="listMode">
+            <elementTypeSpecifier elementType="fakeIg.StructureMapTargetListMode" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="listRuleId" elementType="System.String" target="%value.value"/>
+        <element name="transform" elementType="fakeIg.StructureMapTransform"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.StructureMap.Group.Rule.Target.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Group.Rule.Target.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="value" target="System.String:%value.value;System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Decimal:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="StructureMap.Structure" retrievable="false" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="mode" elementType="fakeIg.StructureMapModelMode"/>
+        <element name="alias" elementType="System.String" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapContextType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapGroupTypeMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapInputMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapModelMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapSourceListMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapTargetListMode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="StructureMapTransform" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Subscription" identifier="http://hl7.org/fhir/StructureDefinition/Subscription" label="Subscription" retrievable="true" xsi:type="ClassInfo">
+        <element name="status" elementType="fakeIg.SubscriptionStatus"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactPoint" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="end" elementType="System.DateTime" target="%value.value"/>
+        <element name="reason" elementType="System.String" target="%value.value"/>
+        <element name="criteria" elementType="System.String" target="%value.value"/>
+        <element name="error" elementType="System.String" target="%value.value"/>
+        <element name="channel" elementType="fakeIg.Subscription.Channel"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Subscription.Channel" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.SubscriptionChannelType"/>
+        <element name="endpoint" elementType="System.String" target="%value.value"/>
+        <element name="payload" elementType="fakeIg.MimeType"/>
+        <element name="header" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SubscriptionChannelType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SubscriptionStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Substance" identifier="http://hl7.org/fhir/StructureDefinition/Substance" label="Substance" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.FHIRSubstanceStatus"/>
+        <element name="category" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="instance">
+            <elementTypeSpecifier elementType="fakeIg.Substance.Instance" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="ingredient">
+            <elementTypeSpecifier elementType="fakeIg.Substance.Ingredient" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Substance.Ingredient" retrievable="false" xsi:type="ClassInfo">
+        <element name="quantity" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="substance" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Substance.Instance" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="expiry" elementType="System.DateTime" target="%value.value"/>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceAmount" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceAmount" label="SubstanceAmount" retrievable="false" xsi:type="ClassInfo">
+        <element name="amount" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="amountType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amountText" elementType="System.String" target="%value.value"/>
+        <element name="referenceRange" elementType="fakeIg.SubstanceAmount.ReferenceRange"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="SubstanceAmount.ReferenceRange" retrievable="false" xsi:type="ClassInfo">
+        <element name="lowLimit" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="highLimit" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstanceNucleicAcid" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceNucleicAcid" label="SubstanceNucleicAcid" retrievable="true" xsi:type="ClassInfo">
+        <element name="sequenceType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="numberOfSubunits" elementType="System.Integer" target="%value.value"/>
+        <element name="areaOfHybridisation" elementType="System.String" target="%value.value"/>
+        <element name="oligoNucleotideType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subunit">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceNucleicAcid.Subunit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceNucleicAcid.Subunit" retrievable="false" xsi:type="ClassInfo">
+        <element name="subunit" elementType="System.Integer" target="%value.value"/>
+        <element name="sequence" elementType="System.String" target="%value.value"/>
+        <element name="length" elementType="System.Integer" target="%value.value"/>
+        <element name="sequenceAttachment" elementType="fakeIg.Attachment"/>
+        <element name="fivePrime" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="threePrime" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="linkage">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceNucleicAcid.Subunit.Linkage" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="sugar">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceNucleicAcid.Subunit.Sugar" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceNucleicAcid.Subunit.Linkage" retrievable="false" xsi:type="ClassInfo">
+        <element name="connectivity" elementType="System.String" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="residueSite" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceNucleicAcid.Subunit.Sugar" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="residueSite" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstancePolymer" identifier="http://hl7.org/fhir/StructureDefinition/SubstancePolymer" label="SubstancePolymer" retrievable="true" xsi:type="ClassInfo">
+        <element name="class" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="geometry" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="copolymerConnectivity" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="modification" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="monomerSet">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.MonomerSet" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="repeat">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.Repeat" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.MonomerSet" retrievable="false" xsi:type="ClassInfo">
+        <element name="ratioType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="startingMaterial">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.MonomerSet.StartingMaterial" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.MonomerSet.StartingMaterial" retrievable="false" xsi:type="ClassInfo">
+        <element name="material" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="isDefining" elementType="System.Boolean" target="%value.value"/>
+        <element name="amount" elementType="fakeIg.SubstanceAmount"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.Repeat" retrievable="false" xsi:type="ClassInfo">
+        <element name="numberOfUnits" elementType="System.Integer" target="%value.value"/>
+        <element name="averageMolecularFormula" elementType="System.String" target="%value.value"/>
+        <element name="repeatUnitAmountType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="repeatUnit">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.Repeat.RepeatUnit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.Repeat.RepeatUnit" retrievable="false" xsi:type="ClassInfo">
+        <element name="orientationOfPolymerisation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="repeatUnit" elementType="System.String" target="%value.value"/>
+        <element name="amount" elementType="fakeIg.SubstanceAmount"/>
+        <element name="degreeOfPolymerisation">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.Repeat.RepeatUnit.DegreeOfPolymerisation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="structuralRepresentation">
+            <elementTypeSpecifier elementType="fakeIg.SubstancePolymer.Repeat.RepeatUnit.StructuralRepresentation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.Repeat.RepeatUnit.DegreeOfPolymerisation" retrievable="false" xsi:type="ClassInfo">
+        <element name="degree" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="fakeIg.SubstanceAmount"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstancePolymer.Repeat.RepeatUnit.StructuralRepresentation" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="representation" elementType="System.String" target="%value.value"/>
+        <element name="attachment" elementType="fakeIg.Attachment"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstanceProtein" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceProtein" label="SubstanceProtein" retrievable="true" xsi:type="ClassInfo">
+        <element name="sequenceType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="numberOfSubunits" elementType="System.Integer" target="%value.value"/>
+        <element name="disulfideLinkage" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subunit">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceProtein.Subunit" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceProtein.Subunit" retrievable="false" xsi:type="ClassInfo">
+        <element name="subunit" elementType="System.Integer" target="%value.value"/>
+        <element name="sequence" elementType="System.String" target="%value.value"/>
+        <element name="length" elementType="System.Integer" target="%value.value"/>
+        <element name="sequenceAttachment" elementType="fakeIg.Attachment"/>
+        <element name="nTerminalModificationId" elementType="fakeIg.Identifier"/>
+        <element name="nTerminalModification" elementType="System.String" target="%value.value"/>
+        <element name="cTerminalModificationId" elementType="fakeIg.Identifier"/>
+        <element name="cTerminalModification" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstanceReferenceInformation" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceReferenceInformation" label="SubstanceReferenceInformation" retrievable="true" xsi:type="ClassInfo">
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="gene">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceReferenceInformation.Gene" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="geneElement">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceReferenceInformation.GeneElement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="classification">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceReferenceInformation.Classification" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceReferenceInformation.Target" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceReferenceInformation.Classification" retrievable="false" xsi:type="ClassInfo">
+        <element name="domain" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="classification" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="subtype" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceReferenceInformation.Gene" retrievable="false" xsi:type="ClassInfo">
+        <element name="geneSequenceOrigin" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="gene" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceReferenceInformation.GeneElement" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="element" elementType="fakeIg.Identifier"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceReferenceInformation.Target" retrievable="false" xsi:type="ClassInfo">
+        <element name="target" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="interaction" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="organism" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="organismType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="amountType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstanceSourceMaterial" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSourceMaterial" label="SubstanceSourceMaterial" retrievable="true" xsi:type="ClassInfo">
+        <element name="sourceMaterialClass" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="sourceMaterialType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="sourceMaterialState" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="organismId" elementType="fakeIg.Identifier"/>
+        <element name="organismName" elementType="System.String" target="%value.value"/>
+        <element name="parentSubstanceId">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="parentSubstanceName" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="countryOfOrigin" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="geographicalLocation" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="developmentStage" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="fractionDescription">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSourceMaterial.FractionDescription" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="organism" elementType="fakeIg.SubstanceSourceMaterial.Organism"/>
+        <element name="partDescription">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSourceMaterial.PartDescription" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.FractionDescription" retrievable="false" xsi:type="ClassInfo">
+        <element name="fraction" elementType="System.String" target="%value.value"/>
+        <element name="materialType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.Organism" retrievable="false" xsi:type="ClassInfo">
+        <element name="family" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="genus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="species" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intraspecificType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intraspecificDescription" elementType="System.String" target="%value.value"/>
+        <element name="author">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSourceMaterial.Organism.Author" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="hybrid" elementType="fakeIg.SubstanceSourceMaterial.Organism.Hybrid"/>
+        <element name="organismGeneral" elementType="fakeIg.SubstanceSourceMaterial.Organism.OrganismGeneral"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.Organism.Author" retrievable="false" xsi:type="ClassInfo">
+        <element name="authorType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="authorDescription" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.Organism.Hybrid" retrievable="false" xsi:type="ClassInfo">
+        <element name="maternalOrganismId" elementType="System.String" target="%value.value"/>
+        <element name="maternalOrganismName" elementType="System.String" target="%value.value"/>
+        <element name="paternalOrganismId" elementType="System.String" target="%value.value"/>
+        <element name="paternalOrganismName" elementType="System.String" target="%value.value"/>
+        <element name="hybridType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.Organism.OrganismGeneral" retrievable="false" xsi:type="ClassInfo">
+        <element name="kingdom" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="phylum" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="class" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="order" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSourceMaterial.PartDescription" retrievable="false" xsi:type="ClassInfo">
+        <element name="part" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="partLocation" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SubstanceSpecification" identifier="http://hl7.org/fhir/StructureDefinition/SubstanceSpecification" label="SubstanceSpecification" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="domain" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="moiety">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Moiety" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Property" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="referenceInformation" elementType="fakeIg.Reference"/>
+        <element name="structure" elementType="fakeIg.SubstanceSpecification.Structure"/>
+        <element name="code">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Code" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="name">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Name" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="molecularWeight">
+            <elementTypeSpecifier namespace="fakeIg" name="SubstanceSpecification.Structure.Isotope.MolecularWeight" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="relationship">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Relationship" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="nucleicAcid" elementType="fakeIg.Reference"/>
+        <element name="polymer" elementType="fakeIg.Reference"/>
+        <element name="protein" elementType="fakeIg.Reference"/>
+        <element name="sourceMaterial" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Code" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="statusDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="comment" elementType="System.String" target="%value.value"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Moiety" retrievable="false" xsi:type="ClassInfo">
+        <element name="role" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="stereochemistry" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="opticalActivity" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="molecularFormula" elementType="System.String" target="%value.value"/>
+        <element name="amount" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Name" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="preferred" elementType="System.Boolean" target="%value.value"/>
+        <element name="language" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="domain" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="synonym">
+            <elementTypeSpecifier namespace="fakeIg" name="SubstanceSpecification.Name" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="translation">
+            <elementTypeSpecifier namespace="fakeIg" name="SubstanceSpecification.Name" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="official">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Name.Official" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Name.Official" retrievable="false" xsi:type="ClassInfo">
+        <element name="authority" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Property" retrievable="false" xsi:type="ClassInfo">
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="parameters" elementType="System.String" target="%value.value"/>
+        <element name="definingSubstance" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="amount" target="System.Quantity:FHIRHelpers.ToQuantity(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Relationship" retrievable="false" xsi:type="ClassInfo">
+        <element name="substance" target="fakeIg.Reference:null;System.Concept:FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="relationship" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="isDefining" elementType="System.Boolean" target="%value.value"/>
+        <element name="amount" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);System.String:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="amountRatioLowLimit" elementType="System.Ratio" target="FHIRHelpers.ToRatio(%value)"/>
+        <element name="amountType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Structure" retrievable="false" xsi:type="ClassInfo">
+        <element name="stereochemistry" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="opticalActivity" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="molecularFormula" elementType="System.String" target="%value.value"/>
+        <element name="molecularFormulaByMoiety" elementType="System.String" target="%value.value"/>
+        <element name="isotope">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Structure.Isotope" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="molecularWeight" elementType="fakeIg.SubstanceSpecification.Structure.Isotope.MolecularWeight"/>
+        <element name="source">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="representation">
+            <elementTypeSpecifier elementType="fakeIg.SubstanceSpecification.Structure.Representation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Structure.Isotope" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="name" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="substitution" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="halfLife" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="molecularWeight" elementType="fakeIg.SubstanceSpecification.Structure.Isotope.MolecularWeight"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Structure.Isotope.MolecularWeight" retrievable="false" xsi:type="ClassInfo">
+        <element name="method" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="amount" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SubstanceSpecification.Structure.Representation" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="representation" elementType="System.String" target="%value.value"/>
+        <element name="attachment" elementType="fakeIg.Attachment"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SupplyDelivery" identifier="http://hl7.org/fhir/StructureDefinition/SupplyDelivery" label="SupplyDelivery" retrievable="true" primaryCodePath="type" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.SupplyDeliveryStatus"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="suppliedItem" elementType="fakeIg.SupplyDelivery.SuppliedItem"/>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="supplier" elementType="fakeIg.Reference"/>
+        <element name="destination" elementType="fakeIg.Reference"/>
+        <element name="receiver">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="supplier"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="receiver"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SupplyDelivery.SuppliedItem" retrievable="false" xsi:type="ClassInfo">
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SupplyDeliveryStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="SupplyRequest" identifier="http://hl7.org/fhir/StructureDefinition/SupplyRequest" label="SupplyRequest" retrievable="true" primaryCodePath="category" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.SupplyRequestStatus"/>
+        <element name="category" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="priority" elementType="fakeIg.RequestPriority"/>
+        <element name="item" target="System.Concept:FHIRHelpers.ToConcept(%value);fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="quantity" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.SupplyRequest.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="occurrence" target="System.DateTime:%value.value;;fakeIg.Timing:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="supplier">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonCode" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="reasonReference">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="deliverFrom" elementType="fakeIg.Reference"/>
+        <element name="deliverTo" elementType="fakeIg.Reference"/>
+        <contextRelationship context="Practitioner" relatedKeyElement="requester"/>
+        <contextRelationship context="Device" relatedKeyElement="requester"/>
+        <contextRelationship context="RelatedPerson" relatedKeyElement="requester"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="SupplyRequest.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Boolean:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SupplyRequestStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="SystemRestfulInteraction" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="Task" identifier="http://hl7.org/fhir/StructureDefinition/Task" label="Task" retrievable="true" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="instantiatesCanonical" elementType="System.String" target="%value.value"/>
+        <element name="instantiatesUri" elementType="System.String" target="%value.value"/>
+        <element name="basedOn">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="groupIdentifier" elementType="fakeIg.Identifier"/>
+        <element name="partOf">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.TaskStatus"/>
+        <element name="statusReason" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="businessStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="intent" elementType="fakeIg.TaskIntent"/>
+        <element name="priority" elementType="fakeIg.TaskPriority"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="focus" elementType="fakeIg.Reference"/>
+        <element name="for" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="executionPeriod">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="authoredOn" elementType="System.DateTime" target="%value.value"/>
+        <element name="lastModified" elementType="System.DateTime" target="%value.value"/>
+        <element name="requester" elementType="fakeIg.Reference"/>
+        <element name="performerType" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="owner" elementType="fakeIg.Reference"/>
+        <element name="location" elementType="fakeIg.Reference"/>
+        <element name="reasonCode" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="reasonReference" elementType="fakeIg.Reference"/>
+        <element name="insurance">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="relevantHistory">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="restriction" elementType="fakeIg.Task.Restriction"/>
+        <element name="input">
+            <elementTypeSpecifier elementType="fakeIg.Task.Input" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="output">
+            <elementTypeSpecifier elementType="fakeIg.Task.Output" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Task.Input" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Task.Output" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.String:%value.value;System.String:%value.value;System.Date:%value.value;System.DateTime:%value.value;System.Decimal:%value.value;System.String:%value.value;System.DateTime:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.Integer:%value.value;System.String:%value.value;System.Time:%value.value;System.Integer:%value.value;System.String:%value.value;System.String:%value.value;System.String:%value.value;fakeIg.Address:null;System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.Annotation:null;fakeIg.Attachment:null;System.Concept:FHIRHelpers.ToConcept(%value);System.Code:FHIRHelpers.ToCode(%value);fakeIg.ContactPoint:null;System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);fakeIg.HumanName:null;fakeIg.Identifier:null;System.Decimal:%value.value;;System.Quantity:FHIRHelpers.ToQuantity(%value);;System.Ratio:FHIRHelpers.ToRatio(%value);fakeIg.Reference:null;fakeIg.SampledData:null;fakeIg.Signature:null;fakeIg.Timing:null;fakeIg.ContactDetail:null;fakeIg.Contributor:null;fakeIg.DataRequirement:null;fakeIg.Expression:null;fakeIg.ParameterDefinition:null;fakeIg.RelatedArtifact:null;fakeIg.TriggerDefinition:null;fakeIg.UsageContext:null;fakeIg.Dosage:null;fakeIg.Meta:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Time" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Address" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Annotation" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Attachment" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Code" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactPoint" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="HumanName" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Identifier" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="System" name="Ratio" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="SampledData" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Signature" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ContactDetail" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Contributor" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="DataRequirement" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Expression" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="ParameterDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="RelatedArtifact" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="TriggerDefinition" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="UsageContext" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Dosage" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Meta" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Task.Restriction" retrievable="false" xsi:type="ClassInfo">
+        <element name="repetitions" elementType="System.Integer" target="%value.value"/>
+        <element name="period">
+            <elementTypeSpecifier xsi:type="IntervalTypeSpecifier">
+                <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="recipient">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TaskIntent" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TaskPriority" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TaskStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="TerminologyCapabilities" identifier="http://hl7.org/fhir/StructureDefinition/TerminologyCapabilities" label="TerminologyCapabilities" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="kind" elementType="fakeIg.CapabilityStatementKind"/>
+        <element name="software" elementType="fakeIg.TerminologyCapabilities.Software"/>
+        <element name="implementation" elementType="fakeIg.TerminologyCapabilities.Implementation"/>
+        <element name="lockedDate" elementType="System.Boolean" target="%value.value"/>
+        <element name="codeSystem">
+            <elementTypeSpecifier elementType="fakeIg.TerminologyCapabilities.CodeSystem" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="expansion" elementType="fakeIg.TerminologyCapabilities.Expansion"/>
+        <element name="codeSearch" elementType="fakeIg.CodeSearchSupport"/>
+        <element name="validateCode" elementType="fakeIg.TerminologyCapabilities.ValidateCode"/>
+        <element name="translation" elementType="fakeIg.TerminologyCapabilities.Translation"/>
+        <element name="closure" elementType="fakeIg.TerminologyCapabilities.Closure"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Closure" retrievable="false" xsi:type="ClassInfo">
+        <element name="translation" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.CodeSystem" retrievable="false" xsi:type="ClassInfo">
+        <element name="uri" elementType="System.String" target="%value.value"/>
+        <element name="version">
+            <elementTypeSpecifier elementType="fakeIg.TerminologyCapabilities.CodeSystem.Version" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="subsumption" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.CodeSystem.Version" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="isDefault" elementType="System.Boolean" target="%value.value"/>
+        <element name="compositional" elementType="System.Boolean" target="%value.value"/>
+        <element name="language" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="filter">
+            <elementTypeSpecifier elementType="fakeIg.TerminologyCapabilities.CodeSystem.Version.Filter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="property" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.CodeSystem.Version.Filter" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="op" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Expansion" retrievable="false" xsi:type="ClassInfo">
+        <element name="hierarchical" elementType="System.Boolean" target="%value.value"/>
+        <element name="paging" elementType="System.Boolean" target="%value.value"/>
+        <element name="incomplete" elementType="System.Boolean" target="%value.value"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.TerminologyCapabilities.Expansion.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="textFilter" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Expansion.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="documentation" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Implementation" retrievable="false" xsi:type="ClassInfo">
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Software" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.Translation" retrievable="false" xsi:type="ClassInfo">
+        <element name="needsMap" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TerminologyCapabilities.ValidateCode" retrievable="false" xsi:type="ClassInfo">
+        <element name="translations" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="TestReport" identifier="http://hl7.org/fhir/StructureDefinition/TestReport" label="TestReport" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.TestReportStatus"/>
+        <element name="testScript" elementType="fakeIg.Reference"/>
+        <element name="result" elementType="fakeIg.TestReportResult"/>
+        <element name="score" elementType="System.Decimal" target="%value.value"/>
+        <element name="tester" elementType="System.String" target="%value.value"/>
+        <element name="issued" elementType="System.DateTime" target="%value.value"/>
+        <element name="participant">
+            <elementTypeSpecifier elementType="fakeIg.TestReport.Participant" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="setup" elementType="fakeIg.TestReport.Setup"/>
+        <element name="test">
+            <elementTypeSpecifier elementType="fakeIg.TestReport.Test" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="teardown" elementType="fakeIg.TestReport.Teardown"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Participant" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.TestReportParticipantType"/>
+        <element name="uri" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Setup" retrievable="false" xsi:type="ClassInfo">
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestReport.Setup.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Setup.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestReport.Setup.Action.Operation"/>
+        <element name="assert" elementType="fakeIg.TestReport.Setup.Action.Assert"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Setup.Action.Assert" retrievable="false" xsi:type="ClassInfo">
+        <element name="result" elementType="fakeIg.TestReportActionResult"/>
+        <element name="message" elementType="System.String" target="%value.value"/>
+        <element name="detail" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Setup.Action.Operation" retrievable="false" xsi:type="ClassInfo">
+        <element name="result" elementType="fakeIg.TestReportActionResult"/>
+        <element name="message" elementType="System.String" target="%value.value"/>
+        <element name="detail" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Teardown" retrievable="false" xsi:type="ClassInfo">
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestReport.Teardown.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Teardown.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestReport.Setup.Action.Operation"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Test" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestReport.Test.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestReport.Test.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestReport.Setup.Action.Operation"/>
+        <element name="assert" elementType="fakeIg.TestReport.Setup.Action.Assert"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TestReportActionResult" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TestReportParticipantType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TestReportResult" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TestReportStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="TestScript" identifier="http://hl7.org/fhir/StructureDefinition/TestScript" label="TestScript" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier" elementType="fakeIg.Identifier"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="origin">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Origin" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="destination">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Destination" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="metadata" elementType="fakeIg.TestScript.Metadata"/>
+        <element name="fixture">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Fixture" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="profile">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="variable">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Variable" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="setup" elementType="fakeIg.TestScript.Setup"/>
+        <element name="test">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Test" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="teardown" elementType="fakeIg.TestScript.Teardown"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Destination" retrievable="false" xsi:type="ClassInfo">
+        <element name="index" elementType="System.Integer" target="%value.value"/>
+        <element name="profile" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Fixture" retrievable="false" xsi:type="ClassInfo">
+        <element name="autocreate" elementType="System.Boolean" target="%value.value"/>
+        <element name="autodelete" elementType="System.Boolean" target="%value.value"/>
+        <element name="resource" elementType="fakeIg.Reference"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Metadata" retrievable="false" xsi:type="ClassInfo">
+        <element name="link">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Metadata.Link" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="capability">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Metadata.Capability" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Metadata.Capability" retrievable="false" xsi:type="ClassInfo">
+        <element name="required" elementType="System.Boolean" target="%value.value"/>
+        <element name="validated" elementType="System.Boolean" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="origin" target="%value.value">
+            <elementTypeSpecifier elementType="System.Integer" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="destination" elementType="System.Integer" target="%value.value"/>
+        <element name="link" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="capabilities" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Metadata.Link" retrievable="false" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Origin" retrievable="false" xsi:type="ClassInfo">
+        <element name="index" elementType="System.Integer" target="%value.value"/>
+        <element name="profile" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Setup" retrievable="false" xsi:type="ClassInfo">
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Setup.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Setup.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestScript.Setup.Action.Operation"/>
+        <element name="assert" elementType="fakeIg.TestScript.Setup.Action.Assert"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Setup.Action.Assert" retrievable="false" xsi:type="ClassInfo">
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="direction" elementType="fakeIg.AssertionDirectionType"/>
+        <element name="compareToSourceId" elementType="System.String" target="%value.value"/>
+        <element name="compareToSourceExpression" elementType="System.String" target="%value.value"/>
+        <element name="compareToSourcePath" elementType="System.String" target="%value.value"/>
+        <element name="contentType" elementType="fakeIg.MimeType"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="headerField" elementType="System.String" target="%value.value"/>
+        <element name="minimumId" elementType="System.String" target="%value.value"/>
+        <element name="navigationLinks" elementType="System.Boolean" target="%value.value"/>
+        <element name="operator" elementType="fakeIg.AssertionOperatorType"/>
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="requestMethod" elementType="fakeIg.TestScriptRequestMethodCode"/>
+        <element name="requestURL" elementType="System.String" target="%value.value"/>
+        <element name="resource" elementType="fakeIg.FHIRDefinedType"/>
+        <element name="response" elementType="fakeIg.AssertionResponseTypes"/>
+        <element name="responseCode" elementType="System.String" target="%value.value"/>
+        <element name="sourceId" elementType="System.String" target="%value.value"/>
+        <element name="validateProfileId" elementType="System.String" target="%value.value"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+        <element name="warningOnly" elementType="System.Boolean" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Setup.Action.Operation" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="resource" elementType="fakeIg.FHIRDefinedType"/>
+        <element name="label" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="accept" elementType="fakeIg.MimeType"/>
+        <element name="contentType" elementType="fakeIg.MimeType"/>
+        <element name="destination" elementType="System.Integer" target="%value.value"/>
+        <element name="encodeRequestUrl" elementType="System.Boolean" target="%value.value"/>
+        <element name="method" elementType="fakeIg.TestScriptRequestMethodCode"/>
+        <element name="origin" elementType="System.Integer" target="%value.value"/>
+        <element name="params" elementType="System.String" target="%value.value"/>
+        <element name="requestHeader">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Setup.Action.Operation.RequestHeader" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="requestId" elementType="System.String" target="%value.value"/>
+        <element name="responseId" elementType="System.String" target="%value.value"/>
+        <element name="sourceId" elementType="System.String" target="%value.value"/>
+        <element name="targetId" elementType="System.String" target="%value.value"/>
+        <element name="url" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Setup.Action.Operation.RequestHeader" retrievable="false" xsi:type="ClassInfo">
+        <element name="field" elementType="System.String" target="%value.value"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Teardown" retrievable="false" xsi:type="ClassInfo">
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Teardown.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Teardown.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestScript.Setup.Action.Operation"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Test" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="action">
+            <elementTypeSpecifier elementType="fakeIg.TestScript.Test.Action" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Test.Action" retrievable="false" xsi:type="ClassInfo">
+        <element name="operation" elementType="fakeIg.TestScript.Setup.Action.Operation"/>
+        <element name="assert" elementType="fakeIg.TestScript.Setup.Action.Assert"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="TestScript.Variable" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="defaultValue" elementType="System.String" target="%value.value"/>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="expression" elementType="System.String" target="%value.value"/>
+        <element name="headerField" elementType="System.String" target="%value.value"/>
+        <element name="hint" elementType="System.String" target="%value.value"/>
+        <element name="path" elementType="System.String" target="%value.value"/>
+        <element name="sourceId" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TestScriptRequestMethodCode" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="Timing" identifier="http://hl7.org/fhir/StructureDefinition/Timing" label="Timing" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="event" target="%value.value">
+            <elementTypeSpecifier elementType="System.DateTime" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="repeat" elementType="fakeIg.Timing.Repeat"/>
+        <element name="code" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="Timing.Repeat" retrievable="false" xsi:type="ClassInfo">
+        <element name="bounds" target="System.Quantity:FHIRHelpers.ToQuantity(%value);;">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+            </elementTypeSpecifier>
+        </element>
+        <element name="count" elementType="System.Integer" target="%value.value"/>
+        <element name="countMax" elementType="System.Integer" target="%value.value"/>
+        <element name="duration" elementType="System.Decimal" target="%value.value"/>
+        <element name="durationMax" elementType="System.Decimal" target="%value.value"/>
+        <element name="durationUnit" elementType="fakeIg.UnitsOfTime"/>
+        <element name="frequency" elementType="System.Integer" target="%value.value"/>
+        <element name="frequencyMax" elementType="System.Integer" target="%value.value"/>
+        <element name="period" elementType="System.Decimal" target="%value.value"/>
+        <element name="periodMax" elementType="System.Decimal" target="%value.value"/>
+        <element name="periodUnit" elementType="fakeIg.UnitsOfTime"/>
+        <element name="dayOfWeek">
+            <elementTypeSpecifier elementType="fakeIg.DayOfWeek" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="timeOfDay" target="%value.value">
+            <elementTypeSpecifier elementType="System.Time" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="when">
+            <elementTypeSpecifier elementType="fakeIg.EventTiming" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="offset" elementType="System.Integer" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="TriggerDefinition" identifier="http://hl7.org/fhir/StructureDefinition/TriggerDefinition" label="TriggerDefinition" retrievable="false" xsi:type="ClassInfo">
+        <element name="type" elementType="fakeIg.TriggerType"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="timing" target="fakeIg.Timing:null;fakeIg.Reference:null;System.Date:%value.value;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="fakeIg" name="Timing" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Date" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+        <element name="data">
+            <elementTypeSpecifier elementType="fakeIg.DataRequirement" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="condition" elementType="fakeIg.Expression"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TriggerType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TypeDerivationRule" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="TypeRestfulInteraction" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="UDIEntryType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="UnitsOfTime" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.Element" namespace="fakeIg" name="UsageContext" identifier="http://hl7.org/fhir/StructureDefinition/UsageContext" label="UsageContext" retrievable="false" primaryCodePath="code" xsi:type="ClassInfo">
+        <element name="code" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="value" target="System.Concept:FHIRHelpers.ToConcept(%value);System.Quantity:FHIRHelpers.ToQuantity(%value);;fakeIg.Reference:null">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                <choice xsi:type="IntervalTypeSpecifier">
+                    <pointTypeSpecifier namespace="System" name="Quantity" xsi:type="NamedTypeSpecifier"/>
+                </choice>
+                <choice namespace="fakeIg" name="Reference" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="Use" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="ValueSet" identifier="http://hl7.org/fhir/StructureDefinition/ValueSet" label="ValueSet" retrievable="true" xsi:type="ClassInfo">
+        <element name="url" elementType="System.String" target="%value.value"/>
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="title" elementType="System.String" target="%value.value"/>
+        <element name="status" elementType="fakeIg.PublicationStatus"/>
+        <element name="experimental" elementType="System.Boolean" target="%value.value"/>
+        <element name="date" elementType="System.DateTime" target="%value.value"/>
+        <element name="publisher" elementType="System.String" target="%value.value"/>
+        <element name="contact">
+            <elementTypeSpecifier elementType="fakeIg.ContactDetail" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="description" elementType="System.String" target="%value.value"/>
+        <element name="useContext">
+            <elementTypeSpecifier elementType="fakeIg.UsageContext" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="jurisdiction" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="immutable" elementType="System.Boolean" target="%value.value"/>
+        <element name="purpose" elementType="System.String" target="%value.value"/>
+        <element name="copyright" elementType="System.String" target="%value.value"/>
+        <element name="compose" elementType="fakeIg.ValueSet.Compose"/>
+        <element name="expansion" elementType="fakeIg.ValueSet.Expansion"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Compose" retrievable="false" xsi:type="ClassInfo">
+        <element name="lockedDate" elementType="System.Date" target="%value.value"/>
+        <element name="inactive" elementType="System.Boolean" target="%value.value"/>
+        <element name="include">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Compose.Include" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="exclude">
+            <elementTypeSpecifier namespace="fakeIg" name="ValueSet.Compose.Include" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Compose.Include" retrievable="false" xsi:type="ClassInfo">
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="concept">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Compose.Include.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="filter">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Compose.Include.Filter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="valueSet" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Compose.Include.Concept" retrievable="false" xsi:type="ClassInfo">
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="designation">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Compose.Include.Concept.Designation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Compose.Include.Concept.Designation" retrievable="false" xsi:type="ClassInfo">
+        <element name="language" elementType="System.String" target="%value.value"/>
+        <element name="use" elementType="System.Code" target="FHIRHelpers.ToCode(%value)"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Compose.Include.Filter" retrievable="false" xsi:type="ClassInfo">
+        <element name="property" elementType="System.String" target="%value.value"/>
+        <element name="op" elementType="fakeIg.FilterOperator"/>
+        <element name="value" elementType="System.String" target="%value.value"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Expansion" retrievable="false" xsi:type="ClassInfo">
+        <element name="identifier" elementType="System.String" target="%value.value"/>
+        <element name="timestamp" elementType="System.DateTime" target="%value.value"/>
+        <element name="total" elementType="System.Integer" target="%value.value"/>
+        <element name="offset" elementType="System.Integer" target="%value.value"/>
+        <element name="parameter">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Expansion.Parameter" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="contains">
+            <elementTypeSpecifier elementType="fakeIg.ValueSet.Expansion.Contains" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Expansion.Contains" retrievable="false" xsi:type="ClassInfo">
+        <element name="system" elementType="System.String" target="%value.value"/>
+        <element name="abstract" elementType="System.Boolean" target="%value.value"/>
+        <element name="inactive" elementType="System.Boolean" target="%value.value"/>
+        <element name="version" elementType="System.String" target="%value.value"/>
+        <element name="code" elementType="System.String" target="%value.value"/>
+        <element name="display" elementType="System.String" target="%value.value"/>
+        <element name="designation">
+            <elementTypeSpecifier namespace="fakeIg" name="ValueSet.Compose.Include.Concept.Designation" xsi:type="NamedTypeSpecifier"/>
+        </element>
+        <element name="contains">
+            <elementTypeSpecifier namespace="fakeIg" name="ValueSet.Expansion.Contains" xsi:type="NamedTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="ValueSet.Expansion.Parameter" retrievable="false" xsi:type="ClassInfo">
+        <element name="name" elementType="System.String" target="%value.value"/>
+        <element name="value" target="System.String:%value.value;System.Boolean:%value.value;System.Integer:%value.value;System.Decimal:%value.value;System.String:%value.value;System.String:%value.value;System.DateTime:%value.value">
+            <elementTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Boolean" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Integer" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="Decimal" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+                <choice namespace="System" name="DateTime" xsi:type="NamedTypeSpecifier"/>
+            </elementTypeSpecifier>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="VariableType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="VerificationResult" identifier="http://hl7.org/fhir/StructureDefinition/VerificationResult" label="VerificationResult" retrievable="true" xsi:type="ClassInfo">
+        <element name="target">
+            <elementTypeSpecifier elementType="fakeIg.Reference" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="targetLocation" target="%value.value">
+            <elementTypeSpecifier elementType="System.String" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="need" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="status" elementType="fakeIg.Status"/>
+        <element name="statusDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="validationType" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="validationProcess" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="frequency" elementType="fakeIg.Timing"/>
+        <element name="lastPerformed" elementType="System.DateTime" target="%value.value"/>
+        <element name="nextScheduled" elementType="System.Date" target="%value.value"/>
+        <element name="failureAction" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="primarySource">
+            <elementTypeSpecifier elementType="fakeIg.VerificationResult.PrimarySource" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="attestation" elementType="fakeIg.VerificationResult.Attestation"/>
+        <element name="validator">
+            <elementTypeSpecifier elementType="fakeIg.VerificationResult.Validator" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="VerificationResult.Attestation" retrievable="false" xsi:type="ClassInfo">
+        <element name="who" elementType="fakeIg.Reference"/>
+        <element name="onBehalfOf" elementType="fakeIg.Reference"/>
+        <element name="communicationMethod" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="date" elementType="System.Date" target="%value.value"/>
+        <element name="sourceIdentityCertificate" elementType="System.String" target="%value.value"/>
+        <element name="proxyIdentityCertificate" elementType="System.String" target="%value.value"/>
+        <element name="proxySignature" elementType="fakeIg.Signature"/>
+        <element name="sourceSignature" elementType="fakeIg.Signature"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="VerificationResult.PrimarySource" retrievable="false" xsi:type="ClassInfo">
+        <element name="who" elementType="fakeIg.Reference"/>
+        <element name="type" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="communicationMethod" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="validationStatus" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="validationDate" elementType="System.DateTime" target="%value.value"/>
+        <element name="canPushUpdates" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="pushTypeAvailable" target="FHIRHelpers.ToConcept(%value)">
+            <elementTypeSpecifier elementType="System.Concept" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="VerificationResult.Validator" retrievable="false" xsi:type="ClassInfo">
+        <element name="organization" elementType="fakeIg.Reference"/>
+        <element name="identityCertificate" elementType="System.String" target="%value.value"/>
+        <element name="attestationSignature" elementType="fakeIg.Signature"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="VisionBase" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="VisionEyes" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="fakeIg.DomainResource" namespace="fakeIg" name="VisionPrescription" identifier="http://hl7.org/fhir/StructureDefinition/VisionPrescription" label="VisionPrescription" retrievable="true" xsi:type="ClassInfo">
+        <element name="identifier">
+            <elementTypeSpecifier elementType="fakeIg.Identifier" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="status" elementType="fakeIg.VisionStatus"/>
+        <element name="created" elementType="System.DateTime" target="%value.value"/>
+        <element name="patient" elementType="fakeIg.Reference"/>
+        <element name="encounter" elementType="fakeIg.Reference"/>
+        <element name="dateWritten" elementType="System.DateTime" target="%value.value"/>
+        <element name="prescriber" elementType="fakeIg.Reference"/>
+        <element name="lensSpecification">
+            <elementTypeSpecifier elementType="fakeIg.VisionPrescription.LensSpecification" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <contextRelationship context="Practitioner" relatedKeyElement="prescriber"/>
+        <contextRelationship context="Encounter" relatedKeyElement="encounter"/>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="VisionPrescription.LensSpecification" retrievable="false" xsi:type="ClassInfo">
+        <element name="product" elementType="System.Concept" target="FHIRHelpers.ToConcept(%value)"/>
+        <element name="eye" elementType="fakeIg.VisionEyes"/>
+        <element name="sphere" elementType="System.Decimal" target="%value.value"/>
+        <element name="cylinder" elementType="System.Decimal" target="%value.value"/>
+        <element name="axis" elementType="System.Integer" target="%value.value"/>
+        <element name="prism">
+            <elementTypeSpecifier elementType="fakeIg.VisionPrescription.LensSpecification.Prism" xsi:type="ListTypeSpecifier"/>
+        </element>
+        <element name="add" elementType="System.Decimal" target="%value.value"/>
+        <element name="power" elementType="System.Decimal" target="%value.value"/>
+        <element name="backCurve" elementType="System.Decimal" target="%value.value"/>
+        <element name="diameter" elementType="System.Decimal" target="%value.value"/>
+        <element name="duration" elementType="System.Quantity" target="FHIRHelpers.ToQuantity(%value)"/>
+        <element name="color" elementType="System.String" target="%value.value"/>
+        <element name="brand" elementType="System.String" target="%value.value"/>
+        <element name="note">
+            <elementTypeSpecifier elementType="fakeIg.Annotation" xsi:type="ListTypeSpecifier"/>
+        </element>
+    </typeInfo>
+    <typeInfo baseType="fakeIg.BackboneElement" namespace="fakeIg" name="VisionPrescription.LensSpecification.Prism" retrievable="false" xsi:type="ClassInfo">
+        <element name="amount" elementType="System.Decimal" target="%value.value"/>
+        <element name="base" elementType="fakeIg.VisionBase"/>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="VisionStatus" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="XPathUsageType" retrievable="false" xsi:type="ClassInfo"/>
+    <typeInfo namespace="fakeIg" name="allowedUnits" identifier="http://hl7.org/fhir/StructureDefinition/elementdefinition-allowedUnits" label="allowedUnits" retrievable="false" xsi:type="ClassInfo">
+        <baseTypeSpecifier xsi:type="ChoiceTypeSpecifier">
+            <choice namespace="System" name="Concept" xsi:type="NamedTypeSpecifier"/>
+            <choice namespace="System" name="String" xsi:type="NamedTypeSpecifier"/>
+        </baseTypeSpecifier>
+    </typeInfo>
+    <typeInfo baseType="System.String" namespace="fakeIg" name="question" identifier="http://hl7.org/fhir/StructureDefinition/elementdefinition-question" label="question" retrievable="false" xsi:type="ClassInfo"/>
+    <contextInfo name="Practitioner" keyElement="id">
+        <contextType namespace="fakeIg" name="Practitioner"/>
+    </contextInfo>
+    <contextInfo name="Device" keyElement="id">
+        <contextType namespace="fakeIg" name="Device"/>
+    </contextInfo>
+    <contextInfo name="Encounter" keyElement="id">
+        <contextType namespace="fakeIg" name="Encounter"/>
+    </contextInfo>
+    <contextInfo name="RelatedPerson" keyElement="id">
+        <contextType namespace="fakeIg" name="RelatedPerson"/>
+    </contextInfo>
+    <contextInfo name="Patient" keyElement="id">
+        <contextType namespace="fakeIg" name="FakePatient"/>
+    </contextInfo>
+</modelInfo>


### PR DESCRIPTION
~I originally had code where I was passing around the model info information so it would be available in the `InJVMCqlTranslationProvider`. That started to make the code pretty clunky having to modify function calls along the way, so I instead took a page out of the cql translator's book and just register a model info provider directly from `runWithArgs`.~

Edit: Code wound up in a middle ground after a couple revisions. Not quite the same place as the starting place described above.

I added a fake IG and a test CQL written against the IG. The fake IG is base FHIR + a single `FakePatient` resource I added. `FakePatient` has one custom extension called `fakeExtension`.

The test CQL references the `FakePatient` and its custom extension. I was somewhat lazy with the test, since the main thing to verify is that the test runs without hitting an exception along the way.  I'm happy to change the test or add tests if anyone  has specific suggestions.