### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @Alvearie/cohort-ibm
+*   @deekim @jillrdoty @csandersdev @jaigoradia @rickjstevens @shelleyMurphy @msargentibm @dkwasny-ibm @tabishop @ToddHicks


### PR DESCRIPTION
per our standup discussion

---

not sure I understand the default ordering in [Alvearie/cohort-ibm](https://github.com/orgs/Alvearie/teams/cohort-ibm/members), but I went with that.