### PR TITLE
Update links for the open repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This repo hosts documentation using GitHub Pages (available [here](https://pages.github.ibm.com/watson-health-cohorting/cohort-engine/#/)).
+This repo hosts documentation using GitHub Pages (available [here](https://alvearie.github.io/quality-measure-and-cohort-service/)).
 Documentation is rendered on the fly using [docsify](https://docsify.js.org/#/). Markdown files on the `master` branch in the
 `docs/` folder will be available in GitHub Pages.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
         data: ['data/vars.json']
       },
       plugins: [
-        EditOnGithubPlugin.create('https://github.ibm.com/watson-health-cohorting/cohort-engine/tree/master/docs/')
+        EditOnGithubPlugin.create('https://github.com/Alvearie/quality-measure-and-cohort-service/tree/main/docs/')
       ]
     }
   </script>


### PR DESCRIPTION
Noticed a couple places pointing at the old repo