### PR TITLE
Remove forced Base64 decoding of attachment data

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/FhirLibraryLibrarySourceProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/FhirLibraryLibrarySourceProvider.java
@@ -8,7 +8,6 @@ package com.ibm.cohort.engine;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -63,8 +62,7 @@ public class FhirLibraryLibrarySourceProvider extends MultiFormatLibrarySourcePr
 					Map<LibraryFormat, InputStream> formats = sources.computeIfAbsent(id,
 							vid -> new HashMap<LibraryFormat, InputStream>());
 
-					byte[] decoded = Base64.getDecoder().decode(attachment.getData());
-					formats.put(sourceFormat, new ByteArrayInputStream(decoded));
+					formats.put(sourceFormat, new ByteArrayInputStream(attachment.getData()));
 					numLoaded++;
 				}
 			}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/LibraryFormat.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/LibraryFormat.java
@@ -17,11 +17,15 @@ import java.util.Map;
 public 	enum LibraryFormat {
 	CQL, XML;
 
+	public static final String MIME_TYPE_TEXT_CQL = "text/cql";
+	public static final String MIME_TYPE_APPLICATION_CQL = "application/cql";
+	public static final String MIME_TYPE_APPLICATION_ELM_XML = "application/elm+xml";
+	
 	private static final Map<String,LibraryFormat> MIME_TYPE_TO_FORMAT = new HashMap<>();
 	static {
-		MIME_TYPE_TO_FORMAT.put("text/cql", CQL);
-		MIME_TYPE_TO_FORMAT.put("application/cql", CQL);
-		MIME_TYPE_TO_FORMAT.put("application/elm+xml", XML);		
+		MIME_TYPE_TO_FORMAT.put(MIME_TYPE_TEXT_CQL, CQL);
+		MIME_TYPE_TO_FORMAT.put(MIME_TYPE_APPLICATION_CQL, CQL);
+		MIME_TYPE_TO_FORMAT.put(MIME_TYPE_APPLICATION_ELM_XML, XML);		
 	}
 	
 	private static final Map<String,LibraryFormat> EXTENSION_TO_FORMAT = new HashMap<>();

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
@@ -5,8 +5,6 @@
  */
 package com.ibm.cohort.engine.measure;
 
-import java.util.Base64;
-
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.common.providers.LibrarySourceProvider;
 
@@ -18,8 +16,7 @@ import com.ibm.cohort.engine.translation.InJVMCqlTranslationProvider;
 public class LibraryHelper {
 
 	/**
-	 * Create a LibraryLoader using the provided LibraryResolutionProvider, but
-	 * overriding the default behavior such that CQL text is base64 decoded.
+	 * Create a LibraryLoader using the provided LibraryResolutionProvider.
 	 * 
 	 * @param provider Library resolution provider
 	 * @return LibraryLoader that will base64 decode CQL text
@@ -27,7 +24,7 @@ public class LibraryHelper {
 	public static LibraryLoader createLibraryLoader(LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> provider) {
 		InJVMCqlTranslationProvider translator = new InJVMCqlTranslationProvider();
 		translator.addLibrarySourceProvider(new LibrarySourceProvider<org.hl7.fhir.r4.model.Library, org.hl7.fhir.r4.model.Attachment>(provider,
-				x -> x.getContent(), x -> x.getContentType(), x -> Base64.getDecoder().decode(x.getData())));
+				x -> x.getContent(), x -> x.getContentType(), x -> x.getData()));
 
 		return new LibraryLoader(provider, translator);
 	}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryLoader.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryLoader.java
@@ -8,7 +8,6 @@ package com.ibm.cohort.engine.measure;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -107,7 +106,7 @@ public class LibraryLoader implements org.opencds.cqf.cql.engine.execution.Libra
 	}
 
 	protected InputStream getAttachmentData(Attachment attachment) throws IOException {
-		return new ByteArrayInputStream(Base64.getDecoder().decode(attachment.getData()));
+		return new ByteArrayInputStream(attachment.getData());
 	}
 
 	@Override

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
@@ -23,7 +23,6 @@ import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -35,11 +34,11 @@ import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
-import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
@@ -187,7 +186,7 @@ public class BaseFhirTest {
 
 				Attachment attachment = new Attachment();
 				attachment.setContentType(contentType);
-				attachment.setData(Base64.getEncoder().encode(text.getBytes()));
+				attachment.setData(text.getBytes());
 				attachments.add(attachment);
 			}
 		}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/FhirLibraryLibrarySourceProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/FhirLibraryLibrarySourceProviderTest.java
@@ -9,7 +9,6 @@ package com.ibm.cohort.engine;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
-import java.util.Base64;
 
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.Library;
@@ -38,8 +37,8 @@ public class FhirLibraryLibrarySourceProviderTest {
 				"define DoSomething: 'hello, world'";
 		
 		Attachment attachment = new Attachment();
-		attachment.setContentType("text/cql");
-		attachment.setData( Base64.getEncoder().encode( cql.getBytes() ) );
+		attachment.setContentType(LibraryFormat.MIME_TYPE_TEXT_CQL);
+		attachment.setData( cql.getBytes() );
 		
 		Library library = new Library();
 		library.setContent(Arrays.asList(attachment));

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.opencds.cqf.common.evaluation.MeasurePopulationType;
 
+import com.ibm.cohort.engine.LibraryFormat;
+
 public class MeasureEvaluatorTest extends BaseMeasureTest {
 
 	private MeasureEvaluator evaluator;
@@ -47,7 +49,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		mockFhirResourceRetrieval(patient);
 
 		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.xml",
-				"application/elm+xml");
+				LibraryFormat.MIME_TYPE_APPLICATION_ELM_XML);
 
 		Measure measure = getCohortMeasure("CohortMeasureName", library, INITIAL_POPULATION);
 		mockFhirResourceRetrieval(measure);


### PR DESCRIPTION
Jeff noted that Library resources were being uploaded with CQL/ELM content being Base64-encoded twice. This PR updates the evaluation code to remove all the places where were forcing Base64 decoding. Kwas updated the test resources in a separate changeset. 