### PR TITLE
Update powermockito to 2.0.9

### DIFF
--- a/.github/workflows/buildJava11.yml
+++ b/.github/workflows/buildJava11.yml
@@ -1,0 +1,25 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn clean install -f cohort-parent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/cohort-engine-api-web/pom.xml
+++ b/cohort-engine-api-web/pom.xml
@@ -183,14 +183,14 @@
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito</artifactId>
-			<version>1.7.4</version>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<version>2.0.9</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
-			<version>1.7.4</version>
+			<version>2.0.9</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Updated powermockito dependency to 2.0.9. The automatic build in this repo succeeded for Java 8: https://github.com/Alvearie/quality-measure-and-cohort-service/actions/runs/408767077

I forked this repo and set up a build with Java 11 in the fork. Before the dependency update I was getting the same error Jai was hitting when building with Java 11: https://github.com/msargentibm/quality-measure-and-cohort-service/runs/1501344501?check_suite_focus=true#step:5:38631

With the dependency update, the Java 11 build succeeds: https://github.com/msargentibm/quality-measure-and-cohort-service/runs/1518725388?check_suite_focus=true