### PR TITLE
Force line feed endings for bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 
 *.jar binary
 
-*.sh text eol=cl
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 
 *.jar binary
 
+*.sh text eol=cl


### PR DESCRIPTION
I  would need help  from folks running Windows to test this out, but this configuration might help avoid CRLF line endings that were making the docker build and run for the tests project fail.

https://docs.github.com/en/free-pro-team@latest/github/using-git/configuring-git-to-handle-line-endings

Edit: Just tested this out with Jai. Confirmed that:
* Windows was switching line endings to CRLF on the main branch.
* Windows leaves the line endings as LF with these changes.
