### PR TITLE
Lock in hapi dependencies to 5.2.0

### DIFF
--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -148,6 +148,11 @@
 				<version>5.2.0</version>
 			</dependency>
 			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>hapi-fhir-converter</artifactId>
+				<version>5.2.0</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.14</version>

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -140,27 +140,27 @@
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-client</artifactId>
-				<version>5.2.0</version>
+				<version>${hapi.fhir.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-base</artifactId>
-				<version>5.2.0</version>
+				<version>${hapi.fhir.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-converter</artifactId>
-				<version>5.2.0</version>
+				<version>${hapi.fhir.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>org.hl7.fhir.convertors</artifactId>
-				<version>5.2.0</version>
+				<version>${hapi.fhir.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>org.hl7.fhir.validation</artifactId>
-				<version>5.2.0</version>
+				<version>${hapi.fhir.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>
@@ -1010,4 +1010,3 @@
 	</profiles>
 
 </project>
-

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -158,6 +158,11 @@
 				<version>5.2.0</version>
 			</dependency>
 			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>org.hl7.fhir.validation</artifactId>
+				<version>5.2.0</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.14</version>

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -64,6 +64,7 @@
 
 		<whBldVer>${project.version}</whBldVer>
 		<watson.buildtools.version>1.27</watson.buildtools.version>
+		<hapi.fhir.version>5.2.0</hapi.fhir.version>
 
 		<srcjavaDir>src/main/java</srcjavaDir>
 		<srcjavaTestDir>src/test/java</srcjavaTestDir>

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -140,12 +140,12 @@
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-client</artifactId>
-				<version>5.0.2</version>
+				<version>5.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>ca.uhn.hapi.fhir</groupId>
 				<artifactId>hapi-fhir-base</artifactId>
-				<version>5.0.2</version>
+				<version>5.2.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-codec</groupId>

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -153,6 +153,11 @@
 				<version>5.2.0</version>
 			</dependency>
 			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>org.hl7.fhir.convertors</artifactId>
+				<version>5.2.0</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.14</version>

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -138,6 +138,16 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>hapi-fhir-client</artifactId>
+				<version>5.0.2</version>
+			</dependency>
+			<dependency>
+				<groupId>ca.uhn.hapi.fhir</groupId>
+				<artifactId>hapi-fhir-base</artifactId>
+				<version>5.0.2</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.14</version>


### PR DESCRIPTION
Took the cautious route. Added in dependencies until everything with a hapi- prefix in the dependency tree was on version 5.2.0.