### PR TITLE
refactor MeasureEvaluationSeed to be configurable

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/MeasureEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/MeasureEvaluator.java
@@ -14,7 +14,9 @@ import org.hl7.fhir.r4.model.MeasureReport;
 import org.opencds.cqf.common.evaluation.EvaluationProviderFactory;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
-import org.opencds.cqf.r4.evaluation.MeasureEvaluationSeed;
+
+import com.ibm.cohort.engine.measure.seed.IMeasureEvaluationSeed;
+import com.ibm.cohort.engine.measure.seed.MeasureEvaluationSeeder;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
@@ -72,14 +74,14 @@ public class MeasureEvaluator {
 		LibraryLoader libraryLoader = LibraryHelper.createLibraryLoader(libraryResolutionProvider);
 
 		EvaluationProviderFactory factory = new ProviderFactory(dataClient, terminologyClient);
-		MeasureEvaluationSeed seed = new MeasureEvaluationSeed(factory, libraryLoader, libraryResolutionProvider);
+		MeasureEvaluationSeeder seeder = new MeasureEvaluationSeeder(factory, libraryLoader, libraryResolutionProvider);
+		seeder.disableDebugLogging();
 
 		// TODO - consider talking with OSS project about making source, user, and pass
 		// a properties collection for more versatile configuration of the underlying
 		// providers. For example, we need an additional custom HTTP header for
 		// configuration of our FHIR server.
-		seed.setup(measure, periodStart, periodEnd, /* productLine= */"ProductLine", /* source= */"", /* user= */"",
-				/* pass= */"");
+		IMeasureEvaluationSeed seed = seeder.create(measure, periodStart, periodEnd, "ProductLine");
 
 		// TODO - The OSS logic takes converts the period start and end into an
 		// Interval and creates a parameter named "Measurement Period" that is populated

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/CustomMeasureEvaluationSeed.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/CustomMeasureEvaluationSeed.java
@@ -1,0 +1,41 @@
+package com.ibm.cohort.engine.measure.seed;
+
+import org.hl7.fhir.r4.model.Measure;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+public class CustomMeasureEvaluationSeed implements IMeasureEvaluationSeed {
+
+	private final Measure measure;
+	private final Context context;
+	private final Interval measurementPeriod;
+	private final DataProvider dataProvider;
+
+	public CustomMeasureEvaluationSeed(Measure measure, Context context, Interval measurementPeriod, DataProvider dataProvider) {
+		this.measure = measure;
+		this.context = context;
+		this.measurementPeriod = measurementPeriod;
+		this.dataProvider = dataProvider;
+	}
+
+	@Override
+	public Measure getMeasure() {
+		return measure;
+	}
+
+	@Override
+	public Context getContext() {
+		return context;
+	}
+
+	@Override
+	public Interval getMeasurementPeriod() {
+		return measurementPeriod;
+	}
+
+	@Override
+	public DataProvider getDataProvider() {
+		return dataProvider;
+	}
+}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/IMeasureEvaluationSeed.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/IMeasureEvaluationSeed.java
@@ -1,0 +1,16 @@
+package com.ibm.cohort.engine.measure.seed;
+
+import org.hl7.fhir.r4.model.Measure;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+public interface IMeasureEvaluationSeed {
+	Measure getMeasure();
+
+	Context getContext();
+
+	Interval getMeasurementPeriod();
+
+	DataProvider getDataProvider();
+}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeeder.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeeder.java
@@ -1,0 +1,179 @@
+package com.ibm.cohort.engine.measure.seed;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Triple;
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.Measure;
+import org.opencds.cqf.common.evaluation.EvaluationProviderFactory;
+import org.opencds.cqf.common.helpers.DateHelper;
+import org.opencds.cqf.common.helpers.UsingHelper;
+import org.opencds.cqf.common.providers.LibraryResolutionProvider;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.debug.DebugMap;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.execution.LibraryLoader;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
+import org.opencds.cqf.r4.helpers.LibraryHelper;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class MeasureEvaluationSeeder {
+
+	private final EvaluationProviderFactory providerFactory;
+	private final LibraryLoader libraryLoader;
+	private final LibraryResolutionProvider<Library> libraryResourceProvider;
+
+	private boolean disableExpressionCaching;
+	private boolean debugMode = true;
+	private String terminologyProviderSource;
+	private String terminologyProviderUser;
+	private String terminologyProviderPassword;
+
+	public MeasureEvaluationSeeder(
+			EvaluationProviderFactory providerFactory,
+			LibraryLoader libraryLoader,
+			LibraryResolutionProvider<Library> libraryResourceProvider) {
+		this.providerFactory = providerFactory;
+		this.libraryLoader = libraryLoader;
+		this.libraryResourceProvider = libraryResourceProvider;
+	}
+
+	public MeasureEvaluationSeeder disableDebugLogging() {
+		this.debugMode = false;
+
+		return this;
+	}
+
+	public MeasureEvaluationSeeder disableExpressionCaching() {
+		this.disableExpressionCaching = true;
+
+		return this;
+	}
+
+
+	public MeasureEvaluationSeeder withTerminologyProvider(String source, String user, String password) {
+		this.terminologyProviderSource = source;
+		this.terminologyProviderUser = user;
+		this.terminologyProviderPassword = password;
+
+		return this;
+	}
+
+
+	public IMeasureEvaluationSeed create(Measure measure, String periodStart, String periodEnd, String productLine) {
+		LibraryHelper.loadLibraries(measure, this.libraryLoader, this.libraryResourceProvider);
+
+		// resolve primary library
+		org.cqframework.cql.elm.execution.Library library =
+                LibraryHelper.resolvePrimaryLibrary(measure, libraryLoader, this.libraryResourceProvider);
+
+		List<Triple<String, String, String>> usingDefs = UsingHelper.getUsingUrlAndVersion(library.getUsings());
+
+		if (usingDefs.size() > 1) {
+			throw new IllegalArgumentException("Evaluation of Measure using multiple Models is not supported at this time.");
+		}
+
+
+		TerminologyProvider terminologyProvider = createTerminologyProvider(usingDefs);
+		LinkedHashMap<Triple<String, String, String>, DataProvider> dataProviders = createDataProviders(usingDefs, terminologyProvider);
+		Interval measurementPeriod = createMeasurePeriod(periodStart, periodEnd);
+		Context context = createContext(library, dataProviders, terminologyProvider, measurementPeriod, productLine);
+
+		List<Map.Entry<Triple<String, String, String>, DataProvider>> dataProviderList = new ArrayList<>(dataProviders.entrySet());
+		DataProvider lastDataProvider = dataProviderList.get(dataProviderList.size() - 1).getValue();
+
+		return new CustomMeasureEvaluationSeed(measure, context, measurementPeriod, lastDataProvider);
+	}
+
+	@VisibleForTesting
+	protected Context createContext(
+			org.cqframework.cql.elm.execution.Library library,
+			Map<Triple<String, String, String>, DataProvider> dataProviders,
+			TerminologyProvider terminologyProvider,
+			Interval measurementPeriod,
+			String productLine) {
+
+		Context context = new Context(library);
+		context.registerLibraryLoader(libraryLoader);
+
+		if (!dataProviders.isEmpty()) {
+			context.registerTerminologyProvider(terminologyProvider);
+		}
+
+		for (Map.Entry<Triple<String, String, String>, DataProvider> dataProviderEntry : dataProviders.entrySet()) {
+			Triple<String, String, String> usingDef = dataProviderEntry.getKey();
+			DataProvider dataProvider = dataProviderEntry.getValue();
+
+			context.registerDataProvider(usingDef.getRight(), dataProvider);
+		}
+
+		context.setParameter(
+		        null,
+                "Measurement Period",
+                new Interval(DateTime.fromJavaDate((Date) measurementPeriod.getStart()), true,
+                             DateTime.fromJavaDate((Date) measurementPeriod.getEnd()), true));
+
+		if (productLine != null) {
+			context.setParameter(null, "Product Line", productLine);
+		}
+
+		if (!disableExpressionCaching) {
+			context.setExpressionCaching(true);
+		}
+
+		if (debugMode) {
+			DebugMap debugMap = new DebugMap();
+			debugMap.setIsLoggingEnabled(true);
+			context.setDebugMap(debugMap);
+		}
+
+		return context;
+	}
+
+	@VisibleForTesting
+	protected Interval createMeasurePeriod(String periodStart, String periodEnd) {
+		return new Interval(DateHelper.resolveRequestDate(periodStart, true), true,
+							DateHelper.resolveRequestDate(periodEnd, false), true);
+	}
+
+
+	private LinkedHashMap<Triple<String, String, String>, DataProvider> createDataProviders(
+			Iterable<Triple<String, String, String>> usingDefs,
+			TerminologyProvider terminologyProvider) {
+		LinkedHashMap<Triple<String, String, String>, DataProvider> dataProviders = new LinkedHashMap<>();
+
+		for (Triple<String, String, String> def : usingDefs) {
+			dataProviders.put(def, this.providerFactory.createDataProvider(def.getLeft(), def.getMiddle(), terminologyProvider));
+		}
+
+		return dataProviders;
+	}
+
+	private TerminologyProvider createTerminologyProvider(List<Triple<String, String, String>> usingDefs) {
+		// If there are no Usings, there is probably not any place the Terminology
+		// actually used so I think the assumption that at least one provider exists is
+		// ok.
+		TerminologyProvider terminologyProvider = null;
+		if (!usingDefs.isEmpty()) {
+			// Creates a terminology provider based on the first using statement. This
+			// assumes the terminology
+			// server matches the FHIR version of the CQL.
+			terminologyProvider = this.providerFactory.createTerminologyProvider(
+				usingDefs.get(0).getLeft(), 
+				usingDefs.get(0).getMiddle(), 
+				terminologyProviderSource, 
+				terminologyProviderUser, 
+				terminologyProviderPassword);
+		}
+
+		return terminologyProvider;
+	}
+
+}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeederTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeederTest.java
@@ -1,0 +1,31 @@
+package com.ibm.cohort.engine.measure.seed;
+
+import java.util.HashMap;
+
+import org.cqframework.cql.elm.execution.Library;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.execution.DefaultLibraryLoader;
+
+public class MeasureEvaluationSeederTest {
+
+    @Test
+    public void createContext() {
+        MeasureEvaluationSeeder seeder = new MeasureEvaluationSeeder(null, new DefaultLibraryLoader(), null);
+
+        seeder.disableDebugLogging();
+        seeder.disableExpressionCaching();
+        seeder.withTerminologyProvider("source", "user", "password");
+
+        Context context = seeder.createContext(
+                new Library(),
+                new HashMap<>(),
+                null,
+                seeder.createMeasurePeriod("2020-01-01", "2021-01-01"),
+                "productLine");
+
+        Assert.assertFalse(context.isExpressionCachingEnabled());
+        Assert.assertNull(context.getDebugMap());
+    }
+}


### PR DESCRIPTION
resolves [WFFHCOHORT-149](https://jsw.ibm.com/browse/WFFHCOHORT-149)

`Draft PR` #5 should provide a bit more context.