### PR TITLE
fix typo

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -28,7 +28,7 @@ If you are building an image that will use port forwarding to access the FHIR se
 using the `taurus-bridge-portForwarding.dockerfile` dockerfile:
 
 ```bash
-docker build -t taurus-javabridge-portForwarding -f {Your path to}/quality-measure-and-cohort-service/tests/docker/taurus-bridge-portForwarding.dockerfile .
+docker build -t taurus-javabridge-portforwarding -f {Your path to}/quality-measure-and-cohort-service/tests/docker/taurus-bridge-portForwarding.dockerfile .
 ```
 
 After building the docker image, you can run tests with:

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,7 +37,7 @@ After building the docker image, you can run tests with:
 docker run -it --rm --env-file {Your path to}/quality-measure-and-cohort-service/tests/docker/Env.txt -v {Your path to}/quality-measure-and-cohort-service:/bzt-configs -v {Your path to}/quality-measure-and-cohort-service/tests/results:/tmp/artifacts {docker-image-name} ./tests/scenarios/{test-scenarios}
 ```
 
-Where {docker-image-name} is `taurus-javabridge` or `taurus-javabridge-portForwarding` in the examples above and {test-scenarios} is a yaml file
+Where {docker-image-name} is `taurus-javabridge` or `taurus-javabridge-portforwarding` in the examples above and {test-scenarios} is a yaml file
 containing the tests to run.
 
 ### Environemnt file for docker runs


### PR DESCRIPTION
```bash
invalid argument "taurus-javabridge-portForwarding" for "-t, --tag" flag: 
invalid reference format: repository name must be lowercase
See 'docker build --help'.
```