### PR TITLE
Add create methods to Parameter

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/input/Parameter.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/input/Parameter.java
@@ -7,26 +7,56 @@ package com.ibm.cohort.cli.input;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ibm.cohort.annotations.Generated;
 
 public class Parameter {
-	@JsonProperty("name")
+	private static final String INTERVAL_TYPE = "interval";
+
 	private String name;
-
-	@JsonProperty("type")
 	private String type;
-
-	@JsonProperty("value")
 	private String value;
-
-	@JsonProperty("subtype")
 	private String subtype;
-
-	@JsonProperty("start")
 	private String start;
-
-	@JsonProperty("end")
 	private String end;
+	
+	/**
+	 * 
+	 * @param name Name of parameter in the CQL
+	 * @param type CQL type of the parameter
+	 * @param value CQL-formatted string value of the parameter
+	 */
+	public static Parameter create(String name, String type, String value) {
+		Parameter p = new Parameter(name, type, value, null, null, null);
+		p.validate();
+		return p;
+	}
+
+	/**
+	 * 
+	 * @param name Name of parameter in the CQL
+	 * @param subtype Type of interval for the parameter
+	 * @param start String representation of the start of the interval
+	 * @param end String representation of the end of the interval
+	 */
+	public static Parameter createInterval(String name, String subtype, String start, String end) {
+		Parameter p = new Parameter(name, INTERVAL_TYPE, null, subtype, start, end);
+		p.validate();
+		return p;
+	}
+
+	@JsonCreator
+	private Parameter(@JsonProperty("name") String name, @JsonProperty("type") String type,
+					  @JsonProperty("value") String value, @JsonProperty("subtype") String subtype,
+					  @JsonProperty("start") String start, @JsonProperty("end") String end) {
+		this.name = name;
+		this.type = type;
+		this.value = value;
+		this.subtype = subtype;
+		this.start = start;
+		this.end = end;
+	}
 
 	public String getName() {
 		return name;
@@ -66,5 +96,34 @@ public class Parameter {
 		else if (isEmpty(value)) {
 			throw new IllegalArgumentException("Invalid measure parameter file: Must provide \"value\" for each non-interval parameter.");
 		}
+	}
+
+	@Override
+	@Generated
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Parameter parameter = (Parameter) o;
+
+		if (name != null ? !name.equals(parameter.name) : parameter.name != null) return false;
+		if (type != null ? !type.equals(parameter.type) : parameter.type != null) return false;
+		if (value != null ? !value.equals(parameter.value) : parameter.value != null) return false;
+		if (subtype != null ? !subtype.equals(parameter.subtype) : parameter.subtype != null) return false;
+		if (start != null ? !start.equals(parameter.start) : parameter.start != null) return false;
+		return end != null ? end.equals(parameter.end) : parameter.end == null;
+
+	}
+
+	@Override
+	@Generated
+	public int hashCode() {
+		int result = name != null ? name.hashCode() : 0;
+		result = 31 * result + (type != null ? type.hashCode() : 0);
+		result = 31 * result + (value != null ? value.hashCode() : 0);
+		result = 31 * result + (subtype != null ? subtype.hashCode() : 0);
+		result = 31 * result + (start != null ? start.hashCode() : 0);
+		result = 31 * result + (end != null ? end.hashCode() : 0);
+		return result;
 	}
 }

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/input/ParameterTest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/input/ParameterTest.java
@@ -5,6 +5,8 @@
  */
 package com.ibm.cohort.cli.input;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -59,6 +61,22 @@ public class ParameterTest {
 		parameter.validate();
 	}
 	
+	@Test
+	public void testCreateParameter() throws Exception {
+		Parameter expected = createParameter("{\"name\":\"p1\",\"type\":\"integer\",\"value\":\"1\"}");
+		Parameter created = Parameter.create("p1", "integer", "1");
+		
+		assertEquals(expected, created);
+	}
+
+	@Test
+	public void testCreateInterval() throws Exception {
+		Parameter expected = createParameter("{\"name\":\"p1\",\"type\":\"interval\",\"start\":\"1\",\"end\":\"2\",\"subtype\":\"integer\"}");
+		Parameter created = Parameter.createInterval("p1", "integer", "1", "2");
+
+		assertEquals(expected, created);
+	}
+
 	private Parameter createParameter(String parameterString) throws JsonProcessingException {
 		ObjectMapper objectMapper = new ObjectMapper();
 		return objectMapper.readValue(parameterString, Parameter.class);


### PR DESCRIPTION
I was working on providing an example of passing  parameters to the `MeasureEvaluator` class for the IHE devs. We currently have the `ParameterHelper` class that can generate a parameter map of type `Map<String, Object>` to pass along to the engine during measure evaluation. There are two ways to  create the map:

1. https://github.com/Alvearie/quality-measure-and-cohort-service/blob/0501fa4e2adec384f9f82c1333ed6c786e39c470/cohort-cli/src/main/java/com/ibm/cohort/cli/ParameterHelper.java#L33
2. https://github.com/Alvearie/quality-measure-and-cohort-service/blob/0501fa4e2adec384f9f82c1333ed6c786e39c470/cohort-cli/src/main/java/com/ibm/cohort/cli/ParameterHelper.java#L73

Both options  are somewhat difficult to work with currently:

1. The string option uses a made up  format of `name:type:value` (where `value` can be further subdivided to `subtype,start,end` for  intervals).
2. The `Parameter` class does not have a straightforward way to currently create the POJO except  for using an `ObjectMapper`  to read a JSON string.

This PR adds some factory methods to the `Parameter` class to make them easier to create (which should make using the `ParameterHelper` class easier). If folks have different suggestions for making the `ParameterHelper`  class easier to interact with, I'd be open to those too. This was just something quick I wanted to get in front of people.