### PR TITLE
Adding Javadoc

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
@@ -92,7 +92,8 @@ public class CohortCLI extends BaseCLI {
 	 * @param args parameter values
 	 * @param out  location where contents that would normally go to stdout should
 	 *             be written
-	 * @throws Exception
+	 * @return CQLEngineWrapper
+	 * @throws Exception any exception
 	 */
 	public CqlEngineWrapper runWithArgs(String[] args, PrintStream out) throws Exception {
 		Arguments arguments = new Arguments();

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EvaluateMeasureResults.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EvaluateMeasureResults.java
@@ -29,9 +29,9 @@ public class EvaluateMeasureResults {
 	private List<PatientMeasureEvaluationGroup> group = new ArrayList<PatientMeasureEvaluationGroup>();
 	private List<String> evaluatedResource = new ArrayList<String>();
 
-	/**
+	/*
 	 * Tenant the measure was evaluated for
-	 **/
+	 */
 	public EvaluateMeasureResults tenant(String tenant) {
 		this.tenant = tenant;
 		return this;
@@ -47,9 +47,9 @@ public class EvaluateMeasureResults {
 		this.tenant = tenant;
 	}
 
-	/**
+	/*
 	 * Additional identifier for the MeasureReport
-	 **/
+	 */
 	public EvaluateMeasureResults identifier(String identifier) {
 		this.identifier = identifier;
 		return this;
@@ -65,9 +65,9 @@ public class EvaluateMeasureResults {
 		this.identifier = identifier;
 	}
 
-	/**
+	/*
 	 * complete | pending | error
-	 **/
+	 */
 	public EvaluateMeasureResults status(String status) {
 		this.status = status;
 		return this;
@@ -83,9 +83,9 @@ public class EvaluateMeasureResults {
 		this.status = status;
 	}
 
-	/**
+	/*
 	 * individual | subject-list | summary | data-collection
-	 **/
+	 */
 	public EvaluateMeasureResults type(String type) {
 		this.type = type;
 		return this;
@@ -101,9 +101,9 @@ public class EvaluateMeasureResults {
 		this.type = type;
 	}
 
-	/**
+	/*
 	 * What measure was calculated (measureId)
-	 **/
+	 */
 	public EvaluateMeasureResults measure(String measure) {
 		this.measure = measure;
 		return this;
@@ -119,10 +119,10 @@ public class EvaluateMeasureResults {
 		this.measure = measure;
 	}
 
-	/**
+	/*
 	 * What individual(s) the report is for (subjectId) (Patient | Practitioner |
 	 * PractitionerRole | Location | Device | RelatedPerson | Group
-	 **/
+	 */
 	public EvaluateMeasureResults subject(List<String> subject) {
 		this.subject = subject;
 		return this;
@@ -138,9 +138,9 @@ public class EvaluateMeasureResults {
 		this.subject = subject;
 	}
 
-	/**
+	/*
 	 * When the report was generated
-	 **/
+	 */
 	public EvaluateMeasureResults date(java.util.Date date) {
 		this.date = date;
 		return this;
@@ -156,9 +156,9 @@ public class EvaluateMeasureResults {
 		this.date = date;
 	}
 
-	/**
+	/*
 	 * Who is reporting the data
-	 **/
+	 */
 	public EvaluateMeasureResults reporter(String reporter) {
 		this.reporter = reporter;
 		return this;
@@ -174,8 +174,6 @@ public class EvaluateMeasureResults {
 		this.reporter = reporter;
 	}
 
-	/**
-	 **/
 	public EvaluateMeasureResults period(PatientMeasureEvaluationPeriod period) {
 		this.period = period;
 		return this;
@@ -191,9 +189,9 @@ public class EvaluateMeasureResults {
 		this.period = period;
 	}
 
-	/**
+	/*
 	 * increase | decrease
-	 **/
+	 */
 	public EvaluateMeasureResults improvementNotation(String improvementNotation) {
 		this.improvementNotation = improvementNotation;
 		return this;
@@ -209,8 +207,6 @@ public class EvaluateMeasureResults {
 		this.improvementNotation = improvementNotation;
 	}
 
-	/**
-	 **/
 	public EvaluateMeasureResults group(List<PatientMeasureEvaluationGroup> group) {
 		this.group = group;
 		return this;
@@ -226,8 +222,6 @@ public class EvaluateMeasureResults {
 		this.group = group;
 	}
 
-	/**
-	 **/
 	public EvaluateMeasureResults evaluatedResource(List<String> evaluatedResource) {
 		this.evaluatedResource = evaluatedResource;
 		return this;
@@ -293,7 +287,7 @@ public class EvaluateMeasureResults {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EvaluateMeasuresStatus.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EvaluateMeasuresStatus.java
@@ -26,9 +26,9 @@ public class EvaluateMeasuresStatus {
 	private String jobProgress = null;
 	private String jobStatus = null;
 
-	/**
+	/*
 	 * Measure evaluation job identifier
-	 **/
+	 */
 	public EvaluateMeasuresStatus jobId(String jobId) {
 		this.jobId = jobId;
 		return this;
@@ -44,9 +44,9 @@ public class EvaluateMeasuresStatus {
 		this.jobId = jobId;
 	}
 
-	/**
+	/*
 	 * The time the measure evaluation job was started
-	 **/
+	 */
 	public EvaluateMeasuresStatus jobStartTime(java.util.Date jobStartTime) {
 		this.jobStartTime = jobStartTime;
 		return this;
@@ -62,9 +62,9 @@ public class EvaluateMeasuresStatus {
 		this.jobStartTime = jobStartTime;
 	}
 
-	/**
+	/*
 	 * The time the measure evaluation job finished
-	 **/
+	 */
 	public EvaluateMeasuresStatus jobFinishTime(java.util.Date jobFinishTime) {
 		this.jobFinishTime = jobFinishTime;
 		return this;
@@ -80,9 +80,9 @@ public class EvaluateMeasuresStatus {
 		this.jobFinishTime = jobFinishTime;
 	}
 
-	/**
+	/*
 	 * Percentage of the measure evaluation job that is completed
-	 **/
+	 */
 	public EvaluateMeasuresStatus jobProgress(String jobProgress) {
 		this.jobProgress = jobProgress;
 		return this;
@@ -98,9 +98,9 @@ public class EvaluateMeasuresStatus {
 		this.jobProgress = jobProgress;
 	}
 
-	/**
+	/*
 	 * Status of the measure evaluation job (eg. running, completed, error etc.)
-	 **/
+	 */
 	public EvaluateMeasuresStatus jobStatus(String jobStatus) {
 		this.jobStatus = jobStatus;
 		return this;
@@ -151,7 +151,7 @@ public class EvaluateMeasuresStatus {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasuresEvaluation.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasuresEvaluation.java
@@ -27,9 +27,9 @@ public class MeasuresEvaluation {
 	private Integer resultsValidTil = 120;
 	private List<PatientMeasureEvaluations> measureEvaluations = new ArrayList<PatientMeasureEvaluations>();
 
-	/**
+	/*
 	 * Tenant identifier for the tenant these patients are associated with
-	 **/
+	 */
 	public MeasuresEvaluation patientsTenantId(String patientsTenantId) {
 		this.patientsTenantId = patientsTenantId;
 		return this;
@@ -45,9 +45,9 @@ public class MeasuresEvaluation {
 		this.patientsTenantId = patientsTenantId;
 	}
 
-	/**
+	/*
 	 * URL specifying the server used to store the patients
-	 **/
+	 */
 	public MeasuresEvaluation patientsServerUrl(String patientsServerUrl) {
 		this.patientsServerUrl = patientsServerUrl;
 		return this;
@@ -63,9 +63,9 @@ public class MeasuresEvaluation {
 		this.patientsServerUrl = patientsServerUrl;
 	}
 
-	/**
+	/*
 	 * A list of connection property strings to be used for the measure server
-	 **/
+	 */
 	public MeasuresEvaluation patientServerConnectionProperties(List<String> patientServerConnectionProperties) {
 		this.patientServerConnectionProperties = patientServerConnectionProperties;
 		return this;
@@ -81,9 +81,9 @@ public class MeasuresEvaluation {
 		this.patientServerConnectionProperties = patientServerConnectionProperties;
 	}
 
-	/**
+	/*
 	 * Tenant identifier for the tenant this measure is associated with
-	 **/
+	 */
 	public MeasuresEvaluation measureTenantId(String measureTenantId) {
 		this.measureTenantId = measureTenantId;
 		return this;
@@ -100,9 +100,9 @@ public class MeasuresEvaluation {
 		this.measureTenantId = measureTenantId;
 	}
 
-	/**
+	/*
 	 * URL specifying the server used to store the measure
-	 **/
+	 */
 	public MeasuresEvaluation measureServerUrl(String measureServerUrl) {
 		this.measureServerUrl = measureServerUrl;
 		return this;
@@ -119,9 +119,9 @@ public class MeasuresEvaluation {
 		this.measureServerUrl = measureServerUrl;
 	}
 
-	/**
+	/*
 	 * A list of connection property strings to be used for the measure server
-	 **/
+	 */
 	public MeasuresEvaluation measureServerConnectionProperties(List<String> measureServerConnectionProperties) {
 		this.measureServerConnectionProperties = measureServerConnectionProperties;
 		return this;
@@ -137,9 +137,9 @@ public class MeasuresEvaluation {
 		this.measureServerConnectionProperties = measureServerConnectionProperties;
 	}
 
-	/**
+	/*
 	 * Number of minutes the job results will be available after the job completes
-	 **/
+	 */
 	public MeasuresEvaluation resultsValidTil(Integer resultsValidTil) {
 		this.resultsValidTil = resultsValidTil;
 		return this;
@@ -155,8 +155,6 @@ public class MeasuresEvaluation {
 		this.resultsValidTil = resultsValidTil;
 	}
 
-	/**
-	 **/
 	public MeasuresEvaluation measureEvaluations(List<PatientMeasureEvaluations> measureEvaluations) {
 		this.measureEvaluations = measureEvaluations;
 		return this;
@@ -219,7 +217,7 @@ public class MeasuresEvaluation {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroup.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroup.java
@@ -20,9 +20,9 @@ public class PatientMeasureEvaluationGroup {
 	private PatientMeasureEvaluationQuantity measureScore = null;
 	private List<PatientMeasureEvaluationGroupStratifier> stratifier = new ArrayList<PatientMeasureEvaluationGroupStratifier>();
 
-	/**
+	/*
 	 * Meaning of the group
-	 **/
+	 */
 	public PatientMeasureEvaluationGroup code(String code) {
 		this.code = code;
 		return this;
@@ -38,8 +38,6 @@ public class PatientMeasureEvaluationGroup {
 		this.code = code;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluationGroup population(PatientMeasureEvaluationPopulation population) {
 		this.population = population;
 		return this;
@@ -55,8 +53,6 @@ public class PatientMeasureEvaluationGroup {
 		this.population = population;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluationGroup measureScore(PatientMeasureEvaluationQuantity measureScore) {
 		this.measureScore = measureScore;
 		return this;
@@ -72,8 +68,6 @@ public class PatientMeasureEvaluationGroup {
 		this.measureScore = measureScore;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluationGroup stratifier(List<PatientMeasureEvaluationGroupStratifier> stratifier) {
 		this.stratifier = stratifier;
 		return this;
@@ -122,7 +116,7 @@ public class PatientMeasureEvaluationGroup {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifier.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifier.java
@@ -18,9 +18,9 @@ public class PatientMeasureEvaluationGroupStratifier {
 	private String code = null;
 	private List<PatientMeasureEvaluationGroupStratifierStratum> stratum = new ArrayList<PatientMeasureEvaluationGroupStratifierStratum>();
 
-	/**
+	/*
 	 * What stratifier of the group
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifier code(String code) {
 		this.code = code;
 		return this;
@@ -36,8 +36,6 @@ public class PatientMeasureEvaluationGroupStratifier {
 		this.code = code;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluationGroupStratifier stratum(
 			List<PatientMeasureEvaluationGroupStratifierStratum> stratum) {
 		this.stratum = stratum;
@@ -83,7 +81,7 @@ public class PatientMeasureEvaluationGroupStratifier {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifierStratum.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifierStratum.java
@@ -20,9 +20,9 @@ public class PatientMeasureEvaluationGroupStratifierStratum {
 	private List<PatientMeasureEvaluationPopulation> population = new ArrayList<PatientMeasureEvaluationPopulation>();
 	private PatientMeasureEvaluationQuantity measureScore = null;
 
-	/**
+	/*
 	 * The stratum value, e.g. male
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifierStratum value(String value) {
 		this.value = value;
 		return this;
@@ -38,9 +38,9 @@ public class PatientMeasureEvaluationGroupStratifierStratum {
 		this.value = value;
 	}
 
-	/**
+	/*
 	 * Stratifier component values
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifierStratum component(
 			List<PatientMeasureEvaluationGroupStratifierStratumComponent> component) {
 		this.component = component;
@@ -57,9 +57,9 @@ public class PatientMeasureEvaluationGroupStratifierStratum {
 		this.component = component;
 	}
 
-	/**
+	/*
 	 * Population results in this stratum
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifierStratum population(
 			List<PatientMeasureEvaluationPopulation> population) {
 		this.population = population;
@@ -76,8 +76,6 @@ public class PatientMeasureEvaluationGroupStratifierStratum {
 		this.population = population;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluationGroupStratifierStratum measureScore(PatientMeasureEvaluationQuantity measureScore) {
 		this.measureScore = measureScore;
 		return this;
@@ -126,7 +124,7 @@ public class PatientMeasureEvaluationGroupStratifierStratum {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifierStratumComponent.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationGroupStratifierStratumComponent.java
@@ -16,9 +16,9 @@ public class PatientMeasureEvaluationGroupStratifierStratumComponent {
 	private String code = null;
 	private String value = null;
 
-	/**
+	/*
 	 * What stratifier component of the group
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifierStratumComponent code(String code) {
 		this.code = code;
 		return this;
@@ -34,9 +34,9 @@ public class PatientMeasureEvaluationGroupStratifierStratumComponent {
 		this.code = code;
 	}
 
-	/**
+	/*
 	 * The stratum component value, e.g. male
-	 **/
+	 */
 	public PatientMeasureEvaluationGroupStratifierStratumComponent value(String value) {
 		this.value = value;
 		return this;
@@ -81,7 +81,7 @@ public class PatientMeasureEvaluationGroupStratifierStratumComponent {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationPeriod.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationPeriod.java
@@ -16,9 +16,9 @@ public class PatientMeasureEvaluationPeriod {
 	private java.util.Date start = null;
 	private java.util.Date end = null;
 
-	/**
+	/*
 	 * Starting time with inclusive boundary
-	 **/
+	 */
 	public PatientMeasureEvaluationPeriod start(java.util.Date start) {
 		this.start = start;
 		return this;
@@ -34,9 +34,9 @@ public class PatientMeasureEvaluationPeriod {
 		this.start = start;
 	}
 
-	/**
+	/*
 	 * End time with inclusive boundary, if not ongoing
-	 **/
+	 */
 	public PatientMeasureEvaluationPeriod end(java.util.Date end) {
 		this.end = end;
 		return this;
@@ -81,7 +81,7 @@ public class PatientMeasureEvaluationPeriod {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationPopulation.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationPopulation.java
@@ -19,11 +19,11 @@ public class PatientMeasureEvaluationPopulation {
 	private Integer count = null;
 	private List<String> subjectResults = new ArrayList<String>();
 
-	/**
+	/*
 	 * initial-population | numerator | numerator-exclusion | denominator |
 	 * denominator-exclusion | denominator-exception | measure-population |
 	 * measure-population-exclusion | measure-observation
-	 **/
+	 */
 	public PatientMeasureEvaluationPopulation code(String code) {
 		this.code = code;
 		return this;
@@ -39,9 +39,9 @@ public class PatientMeasureEvaluationPopulation {
 		this.code = code;
 	}
 
-	/**
+	/*
 	 * Size of the population
-	 **/
+	 */
 	public PatientMeasureEvaluationPopulation count(Integer count) {
 		this.count = count;
 		return this;
@@ -57,9 +57,9 @@ public class PatientMeasureEvaluationPopulation {
 		this.count = count;
 	}
 
-	/**
+	/*
 	 * For subject-list reports, the subject id results in this population**
-	 **/
+	 */
 	public PatientMeasureEvaluationPopulation subjectResults(List<String> subjectResults) {
 		this.subjectResults = subjectResults;
 		return this;
@@ -106,7 +106,7 @@ public class PatientMeasureEvaluationPopulation {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationQuantity.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluationQuantity.java
@@ -15,9 +15,9 @@ public class PatientMeasureEvaluationQuantity {
 
 	private String fillMeIn = null;
 
-	/**
+	/*
 	 * Meaning of the group
-	 **/
+	 */
 	public PatientMeasureEvaluationQuantity fillMeIn(String fillMeIn) {
 		this.fillMeIn = fillMeIn;
 		return this;
@@ -60,7 +60,7 @@ public class PatientMeasureEvaluationQuantity {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluations.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/PatientMeasureEvaluations.java
@@ -20,10 +20,10 @@ public class PatientMeasureEvaluations {
 	private List<String> patientIds = new ArrayList<String>();
 	private List<VersionedMeasures> versionedMeasures = new ArrayList<VersionedMeasures>();
 
-	/**
+	/*
 	 * List of patient identifiers used to designate a specific patient to evaluate
 	 * one or more measures against
-	 **/
+	 */
 	public PatientMeasureEvaluations patientIds(List<String> patientIds) {
 		this.patientIds = patientIds;
 		return this;
@@ -39,8 +39,6 @@ public class PatientMeasureEvaluations {
 		this.patientIds = patientIds;
 	}
 
-	/**
-	 **/
 	public PatientMeasureEvaluations versionedMeasures(List<VersionedMeasures> versionedMeasures) {
 		this.versionedMeasures = versionedMeasures;
 		return this;
@@ -86,7 +84,7 @@ public class PatientMeasureEvaluations {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/VersionedMeasures.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/VersionedMeasures.java
@@ -23,9 +23,9 @@ public class VersionedMeasures {
 	private List<String> measureProperties = new ArrayList<String>();
 	private Boolean persistResults = false;
 
-	/**
+	/*
 	 * Measure identifier used to designate a specific measure to evaluate
-	 **/
+	 */
 	public VersionedMeasures measureId(String measureId) {
 		this.measureId = measureId;
 		return this;
@@ -42,10 +42,10 @@ public class VersionedMeasures {
 		this.measureId = measureId;
 	}
 
-	/**
+	/*
 	 * The version of the measure to evaluate. If none is provided, the latest
 	 * version of the measure is used.
-	 **/
+	 */
 	public VersionedMeasures measureVersion(String measureVersion) {
 		this.measureVersion = measureVersion;
 		return this;
@@ -61,9 +61,9 @@ public class VersionedMeasures {
 		this.measureVersion = measureVersion;
 	}
 
-	/**
+	/*
 	 * A list of parameter strings to be passed to the measure
-	 **/
+	 */
 	public VersionedMeasures measureParameters(List<String> measureParameters) {
 		this.measureParameters = measureParameters;
 		return this;
@@ -79,9 +79,9 @@ public class VersionedMeasures {
 		this.measureParameters = measureParameters;
 	}
 
-	/**
+	/*
 	 * A list of property strings to be passed to the measure
-	 **/
+	 */
 	public VersionedMeasures measureProperties(List<String> measureProperties) {
 		this.measureProperties = measureProperties;
 		return this;
@@ -97,9 +97,9 @@ public class VersionedMeasures {
 		this.measureProperties = measureProperties;
 	}
 
-	/**
+	/*
 	 * If true, results will be persisted in the datastore
-	 **/
+	 */
 	public VersionedMeasures persistResults(Boolean persistResults) {
 		this.persistResults = persistResults;
 		return this;
@@ -150,7 +150,7 @@ public class VersionedMeasures {
 		return sb.toString();
 	}
 
-	/**
+	/*
 	 * Convert the given object to string with each line indented by 4 spaces
 	 * (except the first line).
 	 */

--- a/cohort-engine/pom.xml
+++ b/cohort-engine/pom.xml
@@ -143,7 +143,18 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>			
+			</plugin>
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>org.cqframework.*, org.hl7.fhirpath.tests</excludePackageNames>
+                    <!-- There's a bug where the org.cqframework is not being excluded correctly, so this skips linting -->
+                    <additionalOptions>
+                        <additionalOption>-Xdoclint:none</additionalOption>
+                    </additionalOptions>
+                </configuration>
+            </plugin>			
 		</plugins>
 	</build>
 

--- a/cohort-engine/pom.xml
+++ b/cohort-engine/pom.xml
@@ -154,6 +154,13 @@
                         <additionalOption>-Xdoclint:none</additionalOption>
                     </additionalOptions>
                 </configuration>
+                <executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
             </plugin>			
 		</plugins>
 	</build>

--- a/cohort-engine/pom.xml
+++ b/cohort-engine/pom.xml
@@ -143,25 +143,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>org.cqframework.*, org.hl7.fhirpath.tests</excludePackageNames>
-                    <!-- There's a bug where the org.cqframework is not being excluded correctly, so this skips linting -->
-                    <additionalOptions>
-                        <additionalOption>-Xdoclint:none</additionalOption>
-                    </additionalOptions>
-                </configuration>
-                <executions>
-					<execution>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-            </plugin>			
+			</plugin>	
 		</plugins>
 	</build>
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -179,11 +179,11 @@ public class CqlEngineWrapper {
 	 *                       specified <code>expressions</code> will be executed. At
 	 *                       least one value is required.
 	 * @param callback       callback function to be evaluated once per context per
-	 *                       executed define (required).
+	 *                       executed define (required).             
 	 */
 	protected void evaluateExpressionByExpression(final String libraryName, final String libraryVersion,
 			final Map<String, Object> parameters, final Set<String> expressions, final List<String> contextIds,
-			final EvaluationResultCallback callback) throws Exception {
+			final EvaluationResultCallback callback) {
 		if (this.libraryLoader == null || this.dataServerClient == null || this.terminologyServerClient == null
 				|| this.measureServerClient == null) {
 			throw new IllegalArgumentException(
@@ -289,23 +289,22 @@ public class CqlEngineWrapper {
 	 * Helper method for turning the list of supported models into a Map of
 	 * DataProviders to be used when registering with the CQLEngine.
 	 * 
+	 * @param supportedModels List of data models that are supported (i.e. base FHIR, QICore, etc)
 	 * @param dataProvider DataProvider that will be used in support of the
 	 *                     SUPPORTED_MODELS
 	 * @return Map of model url to the <code>dataProvider</code>
 	 */
 	protected Map<String, DataProvider> mapSupportedModelsToDataProvider(List<String> supportedModels,
 			DataProvider dataProvider) {
-		Map<String, DataProvider> dataProviders = supportedModels.stream()
+		return supportedModels.stream()
 				.map(url -> new SimpleEntry<String, DataProvider>(url, dataProvider))
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-		return dataProviders;
 	}
 
 	/**
 	 * Initialize the terminology provider for the CQL Engine
 	 * 
 	 * @return terminology provider
-	 * @return
 	 */
 	protected TerminologyProvider getTerminologyProvider() {
 		return new R4FhirTerminologyProvider(this.terminologyServerClient);
@@ -331,7 +330,7 @@ public class CqlEngineWrapper {
 	 *                       executed define
 	 */
 	protected void evaluateWithEngineWrapper(String libraryName, String libraryVersion, Map<String, Object> parameters,
-			Set<String> expressions, List<String> contextIds, EvaluationResultCallback callback) throws Exception {
+			Set<String> expressions, List<String> contextIds, EvaluationResultCallback callback) {
 		if (this.libraryLoader == null || this.dataServerClient == null || this.terminologyServerClient == null
 				|| this.measureServerClient == null) {
 			throw new IllegalArgumentException(
@@ -386,10 +385,9 @@ public class CqlEngineWrapper {
 	 *                       specified <code>expressions</code> will be executed. At
 	 *                       least one value is required.
 	 * @param callback       callback function for receiving engine execution events
-	 * @throws Exception	 any error
 	 */
 	public void evaluate(String libraryName, String libraryVersion, Map<String, Object> parameters,
-			Set<String> expressions, List<String> contextIds, EvaluationResultCallback callback) throws Exception {
+			Set<String> expressions, List<String> contextIds, EvaluationResultCallback callback) {
 		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds, callback);
 	}
 
@@ -411,10 +409,9 @@ public class CqlEngineWrapper {
 	 *                       least one value is required.
 	 * @param callback       callback function to be evaluated once per context per
 	 *                       executed define
-	 * @throws Exception	 any error
 	 */
 	public void evaluate(String libraryName, String libraryVersion, Map<String, Object> parameters,
-			Set<String> expressions, List<String> contextIds, ExpressionResultCallback callback) throws Exception {
+			Set<String> expressions, List<String> contextIds, ExpressionResultCallback callback) {
 		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds,
 				new ProxyingEvaluationResultCallback(callback));
 	}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEngineWrapper.java
@@ -314,8 +314,8 @@ public class CqlEngineWrapper {
 	/**
 	 * Usage pattern that uses the CqlEngine interface to execute provided CQL. This
 	 * is the preferred usage pattern, but
-	 * {@see #evaluateExpressionByExpression(String, String, Map, Set, List,
-	 * EvaluationResultCallback)} for details on why it might not be used.
+	 * @see #evaluateExpressionByExpression(String, String, Map, Set, List,
+	 * EvaluationResultCallback) for details on why it might not be used.
 	 * 
 	 * @param libraryName    Library identifier
 	 * @param libraryVersion Library version (optional/null)

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -806,6 +806,20 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                	<failOnWarnings>true</failOnWarnings>
+                </configuration>
+                <executions>
+					<execution>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+            </plugin>
 		</plugins>
 	</build>
 

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -807,12 +807,12 @@
 				</executions>
 			</plugin>
 			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                	<failOnWarnings>true</failOnWarnings>
-                </configuration>
-                <executions>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<failOnWarnings>true</failOnWarnings>
+				</configuration>
+				<executions>
 					<execution>
 						<goals>
 							<goal>jar</goal>

--- a/fhir-client-config/src/main/java/com/ibm/cohort/fhir/client/config/FhirClientBuilderFactory.java
+++ b/fhir-client-config/src/main/java/com/ibm/cohort/fhir/client/config/FhirClientBuilderFactory.java
@@ -31,7 +31,7 @@ public abstract class FhirClientBuilderFactory {
 	 * load:
 	 * 
 	 * <ul>
-	 * <li>Use the com.ibm.cohort.FhirClientBuilderFactory</li> system property.
+	 * <li>Use the com.ibm.cohort.FhirClientBuilderFactory system property.</li> 
 	 * <li>Default FhirClientBuilderFactory instance.
 	 * </ul>
 	 * 

--- a/tests/src/main/java/com/ibm/cohort/engine/test/TestWrapper.java
+++ b/tests/src/main/java/com/ibm/cohort/engine/test/TestWrapper.java
@@ -28,8 +28,8 @@ public class TestWrapper {
 	 * @param f 'src/test/resources/cql/basic'
 	 * @param l 'Test'
 	 * @param c '1235008
-	 * @return
-	 * @throws Exception
+	 * @return Output stream
+	 * @throws Exception any exception
 	 */
     public String warm(String d, String t, String f, String l, String c) throws Exception
     {


### PR DESCRIPTION
This looks like a lot of changes, but it's just cleaning up javadoc warnings.  I added a comment to the pom that was the only significant change.

Possibly contentious: I added javadoc generation to the maven jar phase, so that people would catch this building locally (and not have to run site or javadoc commands.

Probably contentious: I made javadoc warnings fail the build.  I did this first so I could catch them and clean them up, but after thinking about it decided that it made sense to keep our javadoc as clean as possible.  If there is a preference for me to remove this, will do so.