### PR TITLE
Update Library loading mechanism for canonical URLs

### DIFF
--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/CohortCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/CohortCLITest.java
@@ -295,8 +295,8 @@ public class CohortCLITest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
 		mockFhirResourceRetrieval(patient);
 
-		Library root = getLibrary("Breast-Cancer-Screening", "cql/includes/Breast-Cancer-Screening.cql");
-		Library helpers = getLibrary("FHIRHelpers", "cql/includes/FHIRHelpers.cql", "text/cql",
+		Library root = getLibrary("Breast-Cancer-Screening", DEFAULT_RESOURCE_VERSION, "cql/includes/Breast-Cancer-Screening.cql");
+		Library helpers = getLibrary("FHIRHelpers", "4.0.0", "cql/includes/FHIRHelpers.cql", "text/cql",
 				"cql/includes/FHIRHelpers.xml", "application/elm+json");
 
 		RelatedArtifact related = new RelatedArtifact();
@@ -319,7 +319,7 @@ public class CohortCLITest extends BasePatientTest {
 			try (PrintStream captureOut = new PrintStream(baos)) {
 				System.setOut(captureOut);
 				CohortCLI.main(new String[] { "-d", tmpFile.getAbsolutePath(), "-f", root.getId(), "-l",
-						root.getId(), "-v", "1", "-c", patient.getId(), "-s", "CQL" });
+						root.getName(), "-v", root.getVersion(), "-c", patient.getId(), "-s", "CQL" });
 			} finally {
 				System.setOut(originalOut);
 			}
@@ -396,8 +396,8 @@ public class CohortCLITest extends BasePatientTest {
 		patient.addExtension(new Extension("http://fakeIg.com/fake-extension", new StringType("fakeValue")));
 		mockFhirResourceRetrieval(patient);
 
-		Library root = getLibrary("test", "cql/ig-test/test.cql");
-		Library helpers = getLibrary("FHIRHelpers", "cql/includes/FHIRHelpers.cql", "text/cql",
+		Library root = getLibrary("test", DEFAULT_RESOURCE_VERSION, "cql/ig-test/test.cql");
+		Library helpers = getLibrary("FHIRHelpers", "4.0.0", "cql/includes/FHIRHelpers.cql", "text/cql",
 									 "cql/includes/FHIRHelpers.xml", "application/elm+json");
 
 		RelatedArtifact related = new RelatedArtifact();
@@ -420,7 +420,7 @@ public class CohortCLITest extends BasePatientTest {
 			try (PrintStream captureOut = new PrintStream(baos)) {
 				System.setOut(captureOut);
 				CohortCLI.main(new String[] { "-d", tmpFile.getAbsolutePath(), "-f", root.getId(), "-l",
-						root.getId(), "-v", "1.0.0", "-c", patient.getId(), "-s", "CQL", "-i", "src/test/resources/modelinfo/ig-with-target-modelinfo-0.0.1.xml" });
+						root.getName(), "-v", root.getVersion(), "-c", patient.getId(), "-s", "CQL", "-i", "src/test/resources/modelinfo/ig-with-target-modelinfo-0.0.1.xml" });
 			} finally {
 				System.setOut(originalOut);
 			}

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
@@ -39,7 +39,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1592-14-03");
 		mockFhirResourceRetrieval(patient);
 		
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 		
 		Measure measure = getCohortMeasure("Test", library, "Female");
 		mockFhirResourceRetrieval(measure);
@@ -78,7 +78,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1592-14-03");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 
 		Measure measure = getCohortMeasure("Test", library, "Female");
 		mockFhirResourceRetrieval(measure);
@@ -145,7 +145,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		Patient patient3 = getPatient("888", AdministrativeGender.FEMALE, "1592-14-05");
 		mockFhirResourceRetrieval(patient3);
 
-		Library library1 = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library1 = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 
 		Measure measure = getCohortMeasure("Test", library1, "Male");
 		mockFhirResourceRetrieval(measure);
@@ -218,7 +218,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		
 		mockFhirResourceRetrieval(patient);
 		
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 		
 		expressionsByPopulationType.clear();
 		expressionsByPopulationType.put(MeasurePopulationType.INITIALPOPULATION, "Male");
@@ -271,7 +271,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		Patient patient2 = mockPatientRetrieval("456", AdministrativeGender.MALE, 45);
 		Patient patient3 = mockPatientRetrieval("789", AdministrativeGender.FEMALE, 45);
 		
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 		
 		expressionsByPopulationType.clear();
 		expressionsByPopulationType.put(MeasurePopulationType.INITIALPOPULATION, "Male");
@@ -323,7 +323,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		
 		Patient patient1 = mockPatientRetrieval("123", AdministrativeGender.MALE, 30);
 		
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 		
 		expressionsByPopulationType.clear();
 		expressionsByPopulationType.put(MeasurePopulationType.INITIALPOPULATION, "Male");
@@ -374,7 +374,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1592-14-03");
 		mockFhirResourceRetrieval(patient);
 		
-		Library library = mockLibraryRetrieval("Test", "cql/basic/test.cql");
+		Library library = mockLibraryRetrieval("Test", DEFAULT_RESOURCE_VERSION, "cql/basic/test.cql");
 		
 		Measure measure = getCohortMeasure("Test", library, "Male");
 		mockFhirResourceRetrieval(measure);

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.cqframework.cql.elm.execution.VersionedIdentifier;
-import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Measure;
@@ -196,7 +195,7 @@ public class LibraryHelper {
         if (!library.hasType()) {
             // If no type is specified, assume it is a logic library based on whether there is a CQL content element.
             if (library.hasContent()) {
-                for (Attachment a : library.getContent()) {
+                for (org.hl7.fhir.r4.model.Attachment a : library.getContent()) {
                     if (a.hasContentType() && (a.getContentType().equals("text/cql")
                             || a.getContentType().equals("application/elm+xml")
                             || a.getContentType().equals("application/elm+json"))) {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryHelper.java
@@ -5,27 +5,171 @@
  */
 package com.ibm.cohort.engine.measure;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.cqframework.cql.elm.execution.VersionedIdentifier;
+import org.hl7.fhir.r4.model.CanonicalType;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.common.providers.LibrarySourceProvider;
 
 import com.ibm.cohort.engine.translation.InJVMCqlTranslationProvider;
 
 /**
- * Helper functions for working with FHIR Libraries
+ * Helper functions for working with FHIR Library resources
  */
 public class LibraryHelper {
 
 	/**
 	 * Create a LibraryLoader using the provided LibraryResolutionProvider.
 	 * 
-	 * @param provider Library resolution provider
+	 * @param provider Resource provider that handles loading the FHIR library
+	 *                 resource that contains the CQL/ELM content.
 	 * @return LibraryLoader that will base64 decode CQL text
 	 */
 	public static LibraryLoader createLibraryLoader(LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> provider) {
 		InJVMCqlTranslationProvider translator = new InJVMCqlTranslationProvider();
-		translator.addLibrarySourceProvider(new LibrarySourceProvider<org.hl7.fhir.r4.model.Library, org.hl7.fhir.r4.model.Attachment>(provider,
-				x -> x.getContent(), x -> x.getContentType(), x -> x.getData()));
+		translator.addLibrarySourceProvider(
+				new LibrarySourceProvider<org.hl7.fhir.r4.model.Library, org.hl7.fhir.r4.model.Attachment>(provider,
+						x -> x.getContent(), x -> x.getContentType(), x -> x.getData()));
 
 		return new LibraryLoader(provider, translator);
+	}
+
+	/**
+	 * Load all of the libraries reference by a Measure resource and the Library
+	 * resources is directly references. This will recurse through all of the
+	 * library dependencies.
+	 * 
+	 * @param measure                 FHIR Measure resource
+	 * @param libraryLoader           LibraryLoader library loading mechanism for
+	 *                                handling CQL/ELM source to in memory library
+	 *                                loading
+	 * @param libraryResourceProvider Resource provider that handles loading the
+	 *                                FHIR library resource that contains the
+	 *                                CQL/ELM content
+	 * @return List of executable logic libraries
+	 */
+	public static List<org.cqframework.cql.elm.execution.Library> loadLibraries(Measure measure,
+			org.opencds.cqf.cql.engine.execution.LibraryLoader libraryLoader,
+			LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> libraryResourceProvider) {
+
+		List<org.cqframework.cql.elm.execution.Library> libraries = new ArrayList<>();
+
+		// TODO: The cqfmeasure IG says there should only be one library here. Should we
+		// enforce that?
+		// http://hl7.org/fhir/us/cqfmeasures/StructureDefinition-measure-cqfm.html
+		for (CanonicalType ref : measure.getLibrary()) {
+			org.hl7.fhir.r4.model.Library library = resolveLibrary(ref.getValue(), libraryLoader,
+					libraryResourceProvider);
+			if (library != null) {
+				libraries.addAll(loadLibraries(library, libraryLoader, libraryResourceProvider));
+			}
+		}
+
+		return libraries;
+	}
+	
+	/**
+	 * Load the provided Library and all of its dependencies using a recursive tree
+	 * walk of related artifacts.
+	 * 
+	 * @param library                 FHIR Library resource
+	 * @param libraryLoader           LibraryLoader library loading mechanism for
+	 *                                handling CQL/ELM source to in memory library
+	 *                                loading
+	 * @param libraryResourceProvider Resource provider that handles loading the
+	 *                                FHIR library resource that contains the
+	 *                                CQL/ELM content
+	 * @return List of executable logic libraries
+	 */
+	public static List<org.cqframework.cql.elm.execution.Library> loadLibraries(org.hl7.fhir.r4.model.Library library,
+			org.opencds.cqf.cql.engine.execution.LibraryLoader libraryLoader,
+			LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> libraryResourceProvider) {
+		Set<String> ids = new HashSet<>();
+		return loadLibraries( library, libraryLoader, libraryResourceProvider, ids );
+	}
+
+	/**
+	 * Load the provided Library and all of its dependencies using a recursive tree
+	 * walk of related artifacts.
+	 * 
+	 * @param library                 FHIR Library resource
+	 * @param libraryLoader           LibraryLoader library loading mechanism for
+	 *                                handling CQL/ELM source to in memory library
+	 *                                loading
+	 * @param libraryResourceProvider Resource provider that handles loading the
+	 *                                FHIR library resource that contains the
+	 *                                CQL/ELM content
+	 * @param loadedIds               Set of library IDs that have already been loaded by the tree walk. This is used for cycle detection.
+	 * @return List of executable logic libraries
+	 */
+	protected static List<org.cqframework.cql.elm.execution.Library> loadLibraries(org.hl7.fhir.r4.model.Library library,
+			org.opencds.cqf.cql.engine.execution.LibraryLoader libraryLoader,
+			LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> libraryResourceProvider, Set<String> loadedIds) {
+
+		List<org.cqframework.cql.elm.execution.Library> libraries = new ArrayList<>();
+		
+		if( ! loadedIds.contains(library.getId()) ) {
+
+			loadedIds.add( library.getId() );
+			
+			VersionedIdentifier libraryIdentifier = new VersionedIdentifier().withId(library.getName())
+					.withVersion(library.getVersion());
+			org.cqframework.cql.elm.execution.Library executable = libraryLoader.load(libraryIdentifier);
+			libraries.add(executable);
+	
+			for (RelatedArtifact related : library.getRelatedArtifact()) {
+				if (related.hasType() && related.getType().equals(RelatedArtifact.RelatedArtifactType.DEPENDSON)
+						&& related.hasResource()) {
+					org.hl7.fhir.r4.model.Library child = resolveLibrary(related.getResource(), libraryLoader,
+							libraryResourceProvider);
+					if (child != null) {
+						libraries.addAll(loadLibraries(child, libraryLoader, libraryResourceProvider, loadedIds));
+					}
+				}
+			}
+		}
+
+		return libraries;
+	}
+
+	/**
+	 * Resolve a FHIR Library resource based on the string reference provided.
+	 * 
+	 * @param resource                String reference to a FHIR Library resource
+	 * @param libraryLoader           LibraryLoader library loading mechanism for
+	 *                                handling CQL/ELM source to in memory library
+	 *                                loading
+	 * @param libraryResourceProvider Resource provider that handles loading the
+	 *                                FHIR library resource that contains the
+	 *                                CQL/ELM content
+	 * @return Loaded FHIR Library resource or null if the String does not contain
+	 *         an understood reference
+	 */
+	public static org.hl7.fhir.r4.model.Library resolveLibrary(String resource,
+			org.opencds.cqf.cql.engine.execution.LibraryLoader libraryLoader,
+			LibraryResolutionProvider<org.hl7.fhir.r4.model.Library> libraryResourceProvider) {
+
+		org.hl7.fhir.r4.model.Library library = null;
+
+		// Raw references to Library/libraryId or libraryId
+		if (resource.startsWith("Library/") || !resource.contains("/")) {
+			library = libraryResourceProvider.resolveLibraryById(resource.replace("Library/", ""));
+		}
+		// Full url (e.g. http://hl7.org/fhir/us/Library/FHIRHelpers)
+		else if (resource.contains(("/Library/"))) {
+			library = libraryResourceProvider.resolveLibraryByCanonicalUrl(resource);
+		}
+
+		// TODO: The cqf-ruler code checks at this point whether or not the library
+		// looks ok by checking for 1) the type field set to "logic-library" or 2) no
+		// type, but a valid CQL/ELM attachment. Is that necessary?
+
+		return library;
 	}
 }

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
@@ -27,28 +27,24 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.hl7.elm.r1.VersionedIdentifier;
 import org.hl7.fhir.r4.model.Attachment;
 import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.hl7.fhir.r4.model.Enumerations;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.MetadataResource;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Resource;
 import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.ibm.cohort.engine.translation.CqlTranslationProvider;
-import com.ibm.cohort.engine.translation.InJVMCqlTranslationProvider;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
-import com.ibm.cohort.fhir.client.config.IBMFhirServerConfig;
+import com.ibm.cohort.fhir.client.config.FhirServerConfig.LogInfo;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
@@ -56,6 +52,7 @@ import ca.uhn.fhir.parser.IParser;
 public class BaseFhirTest {
 
 	static int HTTP_PORT = 0;
+	static String IBM_PREFIX = "http://ibm.com/fhir/measure";
 
 	@BeforeClass
 	public static void setUpBeforeClass() {
@@ -125,6 +122,7 @@ public class BaseFhirTest {
 	protected FhirServerConfig getFhirServerConfig() {
 		FhirServerConfig fhirConfig = new FhirServerConfig();
 		fhirConfig.setEndpoint("http://localhost:" + HTTP_PORT);
+		fhirConfig.setLogInfo(Arrays.asList(LogInfo.REQUEST_SUMMARY));
 		return fhirConfig;
 	}
 
@@ -166,7 +164,7 @@ public class BaseFhirTest {
 		return patient;
 	}	
 
-	protected Library getLibrary(String id, String... attachmentData) throws Exception {
+	protected Library getLibrary(String name, String version, String... attachmentData) throws Exception {
 		if (attachmentData == null || attachmentData.length == 0
 				|| (attachmentData.length > 2) && ((attachmentData.length % 2) != 0)) {
 			fail("Invalid attachment data. Data must consist of one or more pairs of resource path and content-type strings");
@@ -192,11 +190,12 @@ public class BaseFhirTest {
 				attachments.add(attachment);
 			}
 		}
-
+		
 		Library library = new Library();
-		library.setId(id);
-		library.setName(id);
-		// library.setVersion("1.0.0");
+		library.setId("library-" + name + "-" + version);
+		library.setName(name);
+		library.setUrl(IBM_PREFIX + "/Library/" + name);
+		library.setVersion(version);
 		library.setContent(attachments);
 
 		return library;
@@ -206,8 +205,13 @@ public class BaseFhirTest {
 		return new Reference(resource.getIdElement().getResourceType() + "/" + resource.getId());
 	}
 
-	public CanonicalType asCanonical(Resource resource) {
-		return new CanonicalType(resource.getClass().getSimpleName() + "/" + resource.getId());
+	public CanonicalType asCanonical(MetadataResource resource) {
+		//return new CanonicalType(resource.getClass().getSimpleName() + "/" + resource.getId());
+		String canonical = "http://ibm.com/fhir/measure/" + resource.getClass().getSimpleName() + "/" + resource.getName();
+		if( resource.getVersion() != null ) {
+			canonical = canonical + "|" + resource.getVersion();
+		}
+		return new CanonicalType(canonical);
 	}
 
 	protected CapabilityStatement getCapabilityStatement() {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BaseFhirTest.java
@@ -51,6 +51,8 @@ import ca.uhn.fhir.parser.IParser;
 
 public class BaseFhirTest {
 
+	public static String DEFAULT_RESOURCE_VERSION = "1.0.0";
+	
 	static int HTTP_PORT = 0;
 	static String IBM_PREFIX = "http://ibm.com/fhir/measure";
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/LibraryHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/LibraryHelperTest.java
@@ -1,0 +1,52 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.engine;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.hl7.fhir.r4.model.Library;
+import org.hl7.fhir.r4.model.RelatedArtifact;
+import org.junit.Test;
+import org.opencds.cqf.common.providers.LibraryResolutionProvider;
+import org.opencds.cqf.cql.engine.execution.LibraryLoader;
+
+import com.ibm.cohort.engine.measure.LibraryHelper;
+
+
+public class LibraryHelperTest {
+	@Test
+	public void graph_with_cycles___no_infinite_loop() {
+		
+		@SuppressWarnings("unchecked")
+		LibraryResolutionProvider<Library> llp = mock(LibraryResolutionProvider.class);
+		LibraryLoader ll = mock(LibraryLoader.class);
+		
+		Library parent = new Library();
+		parent.setId("Parent");
+		
+		Library child = new Library();
+		child.setId("Child");
+		
+		parent.addRelatedArtifact(asRelation(child));
+		child.addRelatedArtifact(asRelation(parent));
+		
+		when(llp.resolveLibraryById("Parent")).thenReturn(parent);
+		when(llp.resolveLibraryById("Child")).thenReturn(child);
+		when(ll.load(any())).thenReturn( new org.cqframework.cql.elm.execution.Library() );
+		
+		List<org.cqframework.cql.elm.execution.Library> loaded = LibraryHelper.loadLibraries(parent, ll, llp);
+		assertEquals( 2, loaded.size() );
+	}
+
+	protected RelatedArtifact asRelation(Library library) {
+		return new RelatedArtifact().setType( RelatedArtifact.RelatedArtifactType.DEPENDSON ).setResource("Library/" + library.getId());
+	}
+}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/LibraryHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/LibraryHelperTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
+import org.hl7.fhir.r4.model.Attachment;
+import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.junit.Test;
@@ -29,10 +31,10 @@ public class LibraryHelperTest {
 		LibraryResolutionProvider<Library> llp = mock(LibraryResolutionProvider.class);
 		LibraryLoader ll = mock(LibraryLoader.class);
 		
-		Library parent = new Library();
+		Library parent = setLogicLibrary( new Library() );
 		parent.setId("Parent");
 		
-		Library child = new Library();
+		Library child = setLogicLibrary( new Library() );
 		child.setId("Child");
 		
 		parent.addRelatedArtifact(asRelation(child));
@@ -45,8 +47,35 @@ public class LibraryHelperTest {
 		List<org.cqframework.cql.elm.execution.Library> loaded = LibraryHelper.loadLibraries(parent, ll, llp);
 		assertEquals( 2, loaded.size() );
 	}
+	
+	@Test
+	public void library_with_correct_type_set___returns_true() { 
+		Library lib = setLogicLibrary(new Library());
+		
+		assertEquals( true, LibraryHelper.isLogicLibrary(lib) );
+	}
+	
+	@Test
+	public void library_with_no_type_but_cql_attachment___returns_true() { 
+		Library lib = new Library();
+		lib.getContent().add(new Attachment().setContentType("text/cql"));
+		
+		assertEquals( true, LibraryHelper.isLogicLibrary(lib) );
+	}
+	
+	@Test
+	public void library_with_no_valid_data___returns_false() { 
+		Library lib = new Library();
+		
+		assertEquals( false, LibraryHelper.isLogicLibrary(lib) );
+	}
 
 	protected RelatedArtifact asRelation(Library library) {
 		return new RelatedArtifact().setType( RelatedArtifact.RelatedArtifactType.DEPENDSON ).setResource("Library/" + library.getId());
+	}
+	
+	protected Library setLogicLibrary(Library library) {
+		library.getType().addCoding( new Coding().setSystem(LibraryHelper.CODE_SYSTEM_LIBRARY_TYPE).setCode(LibraryHelper.CODE_LOGIC_LIBRARY) );
+		return library;
 	}
 }

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/BaseMeasureTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/BaseMeasureTest.java
@@ -8,6 +8,8 @@ package com.ibm.cohort.engine.measure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -93,11 +95,18 @@ public class BaseMeasureTest extends BaseFhirTest {
 		return careGapPopulations;
 	}
 
-	protected Library mockLibraryRetrieval(String libraryName, String... cqlResource) throws Exception {
-		Library library = getLibrary(libraryName, cqlResource);
+	protected Library mockLibraryRetrieval(String libraryName, String libraryVersion, String... cqlResource) throws Exception {
+		Library library = getLibrary(libraryName, libraryVersion, cqlResource);
 		mockFhirResourceRetrieval(library);
 
 		Bundle bundle = getBundle(library);
+		
+		String url = URLEncoder.encode( library.getUrl(), StandardCharsets.UTF_8.toString() );
+		if( library.getVersion() != null ) {
+			url += "&version=" + library.getVersion();
+		}
+		
+		mockFhirResourceRetrieval("/Library?url=" + url, bundle );
 		mockFhirResourceRetrieval("/Library?name=" + library.getName() + "&_sort=-date", bundle);
 		mockFhirResourceRetrieval("/Library?name=" + library.getName() + "&version=1.0.0&_sort=-date", bundle);
 		return library;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -7,6 +7,7 @@ package com.ibm.cohort.engine.measure;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -15,16 +16,19 @@ import static org.junit.Assert.fail;
 
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hl7.fhir.r4.model.CanonicalType;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.r4.model.Library;
 import org.hl7.fhir.r4.model.Measure;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.RelatedArtifact;
 import org.junit.Before;
 import org.junit.Test;
 import org.opencds.cqf.common.evaluation.MeasurePopulationType;
@@ -33,6 +37,8 @@ import com.ibm.cohort.engine.LibraryFormat;
 
 public class MeasureEvaluatorTest extends BaseMeasureTest {
 
+	public static final String DEFAULT_VERSION = "1.0.0";
+	
 	private MeasureEvaluator evaluator;
 	
 	@Before
@@ -49,7 +55,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.xml",
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.xml",
 				LibraryFormat.MIME_TYPE_APPLICATION_ELM_XML);
 
 		Measure measure = getCohortMeasure("CohortMeasureName", library, INITIAL_POPULATION);
@@ -62,7 +68,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		verify(1, getRequestedFor(urlEqualTo("/Patient/123")));
 
 		// These ensure that the cache is working
-		verify(1, getRequestedFor(urlEqualTo("/Library/TestDummyPopulations")));
+		verify(1, getRequestedFor(urlMatching("/Library\\?url=http.*")));
 		verify(1, getRequestedFor(urlEqualTo("/Library?name=" + library.getName() + "&version=1.0.0&_sort=-date")));
 	}
 
@@ -74,7 +80,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.cql",
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.cql",
 				"text/cql", "cql/fhir-measure/test-dummy-populations.xml", "application/elm+xml");
 
 		Measure measure = getCohortMeasure("CohortMeasureName", library, INITIAL_POPULATION);
@@ -93,7 +99,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.cql");
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.cql");
 
 		expressionsByPopulationType.clear();
 		expressionsByPopulationType.put(MeasurePopulationType.INITIALPOPULATION, INITIAL_POPULATION);
@@ -207,7 +213,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.cql");
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.cql");
 
 		Measure measure1 = getCareGapMeasure("ProportionMeasureName1", library, expressionsByPopulationType, "CareGap1",
 											"CareGap2");
@@ -221,13 +227,75 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		passingParameters.put("InInitialPopulation", Boolean.TRUE);
 
 		Map<String, Object> failingParameters = new HashMap<>();
-		passingParameters.put("InInitialPopulation", Boolean.FALSE);
+		failingParameters.put("InInitialPopulation", Boolean.FALSE);
 
 		List<MeasureContext> measureContexts = new ArrayList<>();
 		measureContexts.add(new MeasureContext(measure1.getId(), passingParameters));
 		measureContexts.add(new MeasureContext(measure2.getId(), failingParameters));
 
 		assertEquals(1, evaluator.evaluatePatientMeasures(patient.getId(), measureContexts).size());
+	}
+	
+	@Test
+	public void multilevel_library_dependencies___successfully_loaded_and_evaluated() throws Exception {
+		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
+
+		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
+		mockFhirResourceRetrieval(patient);
+
+		Library nestedHelperLibrary = mockLibraryRetrieval("NestedChild", DEFAULT_VERSION, "cql/fhir-measure-nested-libraries/test-nested-child.cql");
+		
+		Library helperLibrary = mockLibraryRetrieval("Child", DEFAULT_VERSION, "cql/fhir-measure-nested-libraries/test-child.cql");
+		helperLibrary.addRelatedArtifact( asRelation(nestedHelperLibrary) );
+		
+		Library library = mockLibraryRetrieval("Parent", DEFAULT_VERSION, "cql/fhir-measure-nested-libraries/test-parent.cql");
+		library.addRelatedArtifact( asRelation(helperLibrary) );
+		
+		Measure measure = getCareGapMeasure("NestedLibraryMeasure", library, expressionsByPopulationType, "CareGap1",
+											"CareGap2");
+		mockFhirResourceRetrieval(measure);
+
+		Map<String, Object> passingParameters = new HashMap<>();
+		passingParameters.put("InInitialPopulation", Boolean.TRUE);
+
+		List<MeasureContext> measureContexts = new ArrayList<>();
+		measureContexts.add(new MeasureContext(measure.getId(), passingParameters));
+
+		List<MeasureReport> reports = evaluator.evaluatePatientMeasures(patient.getId(), measureContexts);
+		assertEquals(1, reports.size());
+		
+		MeasureReport report = reports.get(0);
+		verifyStandardPopulationCounts(report);
+	}
+	
+	@Test
+	public void id_based_library_link___successfully_loaded_and_evaluated() throws Exception {
+		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
+
+		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
+		mockFhirResourceRetrieval(patient);
+		
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.cql");
+		
+		Measure measure = getCareGapMeasure("IDBasedLibraryMeasure", library, expressionsByPopulationType, "CareGap1",
+											"CareGap2");
+		
+		measure.setLibrary( Arrays.asList( new CanonicalType( "Library/" + library.getId()) ) );
+		mockFhirResourceRetrieval(measure);
+
+		Map<String, Object> passingParameters = new HashMap<>();
+		passingParameters.put("InInitialPopulation", Boolean.TRUE);
+
+		List<MeasureContext> measureContexts = new ArrayList<>();
+		measureContexts.add(new MeasureContext(measure.getId(), passingParameters));
+
+		List<MeasureReport> reports = evaluator.evaluatePatientMeasures(patient.getId(), measureContexts);
+		assertEquals(1, reports.size());
+		
+		MeasureReport report = reports.get(0);
+		verifyStandardPopulationCounts(report);
+		
+		verify(1, getRequestedFor(urlEqualTo("/Library/" + library.getId())));
 	}
 
 	private void runCareGapTest(Map<String, Object> parameters, Map<String, Integer> careGapExpectations)
@@ -238,7 +306,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
 		mockFhirResourceRetrieval(patient);
 
-		Library library = mockLibraryRetrieval("TestDummyPopulations", "cql/fhir-measure/test-dummy-populations.cql");
+		Library library = mockLibraryRetrieval("TestDummyPopulations", DEFAULT_VERSION, "cql/fhir-measure/test-dummy-populations.cql");
 
 		Measure measure = getCareGapMeasure("ProportionMeasureName", library, expressionsByPopulationType, "CareGap1",
 				"CareGap2");
@@ -246,6 +314,11 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 
 		MeasureReport report = evaluator.evaluatePatientMeasure(measure.getId(), patient.getId(), parameters);
 		assertNotNull(report);
+		assertPopulationExpectations(measure, report, careGapExpectations);
+	}
+
+	protected void assertPopulationExpectations(Measure measure, MeasureReport report,
+			Map<String, Integer> expectations) {
 		assertEquals(measure.getGroupFirstRep().getPopulation().size(),
 				report.getGroupFirstRep().getPopulation().size());
 		List<MeasureReport.MeasureReportGroupPopulationComponent> careGapPopulations = verifyStandardPopulationCounts(
@@ -258,7 +331,11 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 			assertEquals(CDMMeasureEvaluation.CARE_GAP, pop.getCode().getCodingFirstRep().getCode());
 			assertTrue(pop.getId().startsWith("CareGap")); // this is part of the test fixture and may not match
 															// production behavior
-			assertEquals(pop.getId(), careGapExpectations.get(pop.getId()).intValue(), pop.getCount());
+			assertEquals(pop.getId(), expectations.get(pop.getId()).intValue(), pop.getCount());
 		}
+	}
+	
+	protected RelatedArtifact asRelation(Library library) {
+		return new RelatedArtifact().setType(RelatedArtifact.RelatedArtifactType.DEPENDSON).setResource( library.getUrl() + "|" + library.getVersion() );
 	}
 }

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureHelperTest.java
@@ -27,6 +27,8 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 public class MeasureHelperTest extends BaseMeasureTest {
 	
+	private static final String DEFAULT_VERSION = "1.0.0";
+	
 	private MeasureResolutionProvider<Measure> provider;
 
 	@Before
@@ -41,7 +43,7 @@ public class MeasureHelperTest extends BaseMeasureTest {
 	
 	@Test
 	public void testResolveByID() throws Exception {
-		Measure measure = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
+		Measure measure = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
 		mockFhirResourceRetrieval(measure);
 		
 		Measure actual = MeasureHelper.loadMeasure(measure.getId(), provider);
@@ -50,7 +52,7 @@ public class MeasureHelperTest extends BaseMeasureTest {
 	
 	@Test
 	public void testResolveByCanonicalUrl() throws Exception {
-		Measure measure = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
+		Measure measure = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
 		measure.setUrl("http://fhir.ibm.com/fhir-server/api/v4/Measure/Test-1.0.0");
 		
 		MappingBuilder builder = get(urlMatching("/Measure\\?url=.*"));
@@ -65,7 +67,7 @@ public class MeasureHelperTest extends BaseMeasureTest {
 		String identifierSystem = "system1";
 		String identifierValue = "val1";
 
-		Measure measure = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
+		Measure measure = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
 
 		Identifier identifier = new IdentifierBuilder()
 				.buildValue(identifierValue)
@@ -88,9 +90,9 @@ public class MeasureHelperTest extends BaseMeasureTest {
 		String identifierSystem = "system1";
 		String identifierValue = "val1";
 
-		Measure measure1 = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
-		Measure measure2 = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
-		Measure measure3 = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
+		Measure measure1 = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
+		Measure measure2 = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
+		Measure measure3 = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
 
 		measure1.setVersion("1.0.0");
 		measure2.setVersion("2.0.0");
@@ -118,7 +120,7 @@ public class MeasureHelperTest extends BaseMeasureTest {
 		String identifierValue = "val1";
 		String measureVersion = "4.5.6";
 
-		Measure measure = getCohortMeasure("Test", getLibrary("123", "cql/basic/test.xml"), "Female");
+		Measure measure = getCohortMeasure("Test", getLibrary("123", DEFAULT_VERSION, "cql/basic/test.xml"), "Female");
 
 		Identifier identifier = new IdentifierBuilder()
 				.buildValue(identifierValue)

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
@@ -32,6 +32,7 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 
 	private static final String TEST_URL = "http://somewhere.com/cds/Test|1.0.0";
+	private static final String DEFAULT_VERSION = "1.0.0";
 	private RestFhirLibraryResolutionProvider provider;
 
 	@Before
@@ -46,7 +47,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	public void resolveLibraryById___returns_library_when_found() throws Exception {
 		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
 		
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		mockFhirResourceRetrieval( library );
 		
 		Library actual = provider.resolveLibraryById(library.getId());
@@ -70,7 +71,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	public void resolveLibraryById_twice___returns_cached_data() throws Exception {
 		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
 		
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		mockFhirResourceRetrieval( library );
 		
 		Library actual = provider.resolveLibraryById(library.getId());
@@ -86,7 +87,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	public void resolveLibraryByName___returns_library_when_found() throws Exception {
 		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
 		
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setVersion("1.0.0");
 		MappingBuilder mapping = get(urlMatching("/Library\\?name=[^&]+&version=.+"));
 		mockFhirResourceRetrieval( mapping, makeBundle(library) );
@@ -111,7 +112,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	public void resolveLibraryByName_twice___returns_cached_data() throws Exception {
 		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
 		
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setVersion("1.0.0");
 		MappingBuilder mapping = get(urlMatching("/Library\\?name=[^&]+&version=.+"));
 		mockFhirResourceRetrieval( mapping, makeBundle(library) );
@@ -127,7 +128,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 
 	@Test
 	public void resolveLibraryByCanonicalUrl___returns_library_when_found() throws Exception {
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setUrl(TEST_URL);
 
 		Library actual = runTest(TEST_URL, makeBundle( library ));
@@ -137,7 +138,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	
 	@Test
 	public void resolveLibraryByCanonicalUrl_twice___returns_cached_data() throws Exception {
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setUrl(TEST_URL);
 
 		Library actual = runTest(TEST_URL, makeBundle( library ));
@@ -155,10 +156,10 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void resolveLibraryByCanonicalUrl___exception_when_multiple_library_found() throws Exception {
-		Library library1 = getLibrary("Test", "cql/basic/test.cql");
+		Library library1 = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library1.setUrl(TEST_URL);
 
-		Library library2 = getLibrary("Test", "cql/basic/test.cql");
+		Library library2 = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library2.setUrl(TEST_URL);
 
 		Library actual = runTest(TEST_URL, makeBundle(library1, library2));
@@ -167,7 +168,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 	
 	@Test(expected = UnsupportedOperationException.class)
 	public void update___exception_throw() throws Exception {
-		Library library = getLibrary("Test", "cql/basic/test.cql");
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		provider.update(library);
 	}
 

--- a/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-child.cql
+++ b/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-child.cql
@@ -1,0 +1,40 @@
+library "Child" version '1.0.0'
+using "FHIR" version '4.0.0'
+
+include "NestedChild" version '1.0.0'
+
+parameter MeasurementPeriod Interval<DateTime>
+parameter InInitialPopulation Boolean default true
+parameter InDenominator Boolean default true
+parameter InDenominatorException Boolean default false
+parameter InDenominatorExclusion Boolean default false
+parameter InNumerator Boolean default false
+parameter InNumeratorExclusion Boolean default false
+parameter InCareGap1 Boolean default false
+parameter InCareGap2 Boolean default true
+
+context Patient
+
+define "Initial Population":
+	"InInitialPopulation"
+	
+define "Denominator":
+	"InDenominator"
+	
+define "Numerator":
+	NestedChild."InNumerator"
+	
+define "Numerator Exclusion":
+	"InNumeratorExclusion"
+	
+define "Denominator Exception":
+	"InDenominatorException"
+	
+define "Denominator Exclusion":
+	"InDenominatorExclusion"
+	
+define "CareGap1":
+	"InCareGap1"
+	
+define "CareGap2":
+	"InCareGap2"

--- a/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-nested-child.cql
+++ b/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-nested-child.cql
@@ -1,0 +1,38 @@
+library "NestedChild" version '1.0.0'
+using "FHIR" version '4.0.0'
+
+parameter MeasurementPeriod Interval<DateTime>
+parameter InInitialPopulation Boolean default true
+parameter InDenominator Boolean default true
+parameter InDenominatorException Boolean default false
+parameter InDenominatorExclusion Boolean default false
+parameter InNumerator Boolean default false
+parameter InNumeratorExclusion Boolean default false
+parameter InCareGap1 Boolean default false
+parameter InCareGap2 Boolean default true
+
+context Patient
+
+define "Initial Population":
+	"InInitialPopulation"
+	
+define "Denominator":
+	"InDenominator"
+	
+define "Numerator":
+	"InNumerator"
+	
+define "Numerator Exclusion":
+	"InNumeratorExclusion"
+	
+define "Denominator Exception":
+	"InDenominatorException"
+	
+define "Denominator Exclusion":
+	"InDenominatorExclusion"
+	
+define "CareGap1":
+	"InCareGap1"
+	
+define "CareGap2":
+	"InCareGap2"

--- a/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-parent.cql
+++ b/cohort-engine/src/test/resources/cql/fhir-measure-nested-libraries/test-parent.cql
@@ -1,0 +1,40 @@
+library "Parent" version '1.0.0'
+using "FHIR" version '4.0.0'
+
+include "Child" version '1.0.0'
+
+parameter MeasurementPeriod Interval<DateTime>
+parameter InInitialPopulation Boolean default true
+parameter InDenominator Boolean default true
+parameter InDenominatorException Boolean default false
+parameter InDenominatorExclusion Boolean default false
+parameter InNumerator Boolean default false
+parameter InNumeratorExclusion Boolean default false
+parameter InCareGap1 Boolean default false
+parameter InCareGap2 Boolean default true
+
+context Patient
+
+define "Initial Population":
+	"InInitialPopulation"
+	
+define "Denominator":
+	"InDenominator"
+	
+define "Numerator":
+	Child."InNumerator"
+	
+define "Numerator Exclusion":
+	"InNumeratorExclusion"
+	
+define "Denominator Exception":
+	"InDenominatorException"
+	
+define "Denominator Exclusion":
+	"InDenominatorExclusion"
+	
+define "CareGap1":
+	"InCareGap1"
+	
+define "CareGap2":
+	"InCareGap2"


### PR DESCRIPTION
The Library loading mechanism provided through the cqf-ruler requires that Measure.library references use ID-based retrieval vs. understanding canonical URLs appropriately for Library.url based retrieval. This PR updates the library loading mechanism with support for canonical URL resolution in addition to the resource ID based retreival. Additionally, the default mechanism would load a Measure and its direct Library dependencies, but would not traverse transitive dependencies. This PR adds a recursive tree-walk for library loading and includes cycle detection to prevent infinite loops during library loading.