### PR TITLE
Add test of the engine behavior for quantities of different UoM

### DIFF
--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
@@ -18,14 +18,14 @@ import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import com.ibm.cohort.fhir.client.config.IBMFhirServerConfig;
 
 public class BasePatientTest extends BaseFhirTest {
-	protected CqlEngineWrapper setupTestFor(Patient patient, String... elm) throws Exception {
+	protected CqlEngineWrapper setupTestFor(Patient patient, String... resources) throws Exception {
 		IBMFhirServerConfig fhirConfig = new IBMFhirServerConfig();
 		fhirConfig.setEndpoint("http://localhost:" + HTTP_PORT);
 		fhirConfig.setUser("fhiruser");
 		fhirConfig.setPassword("change-password");
 		fhirConfig.setTenantId("default");
 
-		return setupTestFor(patient, fhirConfig, elm);
+		return setupTestFor(patient, fhirConfig, resources);
 	}
 
 	protected CqlEngineWrapper setupTestFor(Patient patient, FhirServerConfig fhirConfig, String... resources)
@@ -48,7 +48,7 @@ public class BasePatientTest extends BaseFhirTest {
 					if( basename.startsWith("test") ) {
 						result = new VersionedIdentifier().withId("Test").withVersion("1.0.0");
 					} else { 
-						result = super.filenameToVersionedIdentifier( basename );
+						result = super.filenameToVersionedIdentifier( filename );
 					}
 					return result;
 				}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/DefaultFilenameToVersionedIdentifierStrategyTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/DefaultFilenameToVersionedIdentifierStrategyTest.java
@@ -42,6 +42,11 @@ public class DefaultFilenameToVersionedIdentifierStrategyTest {
 	}
 	
 	@Test
+	public void testDottedVersionValidFilenameConversion2() {
+		runTest( "TestUOMCompare-1.0.0.cql", "TestUOMCompare", "1.0.0");
+	}
+	
+	@Test
 	public void testNoExtensionWithDotsValidFilenameConversion() {
 		runTest( "Corey-Is-Here-1.0.0", "Corey-Is-Here", "1.0");
 	}

--- a/cohort-engine/src/test/resources/cql/uomequivalence/TestUOMCompare-1.0.0.cql
+++ b/cohort-engine/src/test/resources/cql/uomequivalence/TestUOMCompare-1.0.0.cql
@@ -1,0 +1,13 @@
+library "TestUOMCompare" version '1.0.0'
+
+parameter ValInGrams default 10 'g'
+parameter ValInMilligrams default 10000 'mg'
+
+define IsEqual:
+	ValInGrams = ValInMilligrams
+
+define AreEquivalent:
+	ValInGrams = convert ValInMilligrams to 'g'
+
+define UpConvert:
+	convert ValInGrams to 'kg' = convert ValInMilligrams to 'kg'


### PR DESCRIPTION
This is a follow-up to the conversation I started with our team related to units of measure and quantity comparison in the CQL engine. I added a test case to the CqlEngineWrapperTest that documents the existing behavior for direct equals comparison of two quantities with different UoMs, comparison where one quantity is converted to the known units of the other side, and a third example that is probably the best practice of converting both sides of the comparison to a specific, known unit.

There are a few minor touch points in the test framework to deal with a bug I found where filenames were not being parsed correctly to extract the library name and version. 