### PR TITLE
Wffhcohort 273 - Return MeasureReports even when not in the intitial population

### DIFF
--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
@@ -68,7 +68,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split(System.getProperty("line.separator"));
-		assertEquals( output, 2, lines.length );
+		assertEquals( output, 4, lines.length );
 	}
 
 	@Test
@@ -106,7 +106,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split(System.getProperty("line.separator"));
-		assertEquals( output, 2, lines.length );
+		assertEquals( output, 4, lines.length );
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -178,9 +178,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split(System.getProperty("line.separator"));
-		// First two patients create 7 lines of output each (1 for start of patient context, 3 per measure result).
-		// Last patient only creates 2 lines (1 for start of patient context, 1 for line divider since there is no measure report returned).
-		assertEquals( output, 16, lines.length );
+		assertEquals( output, 21, lines.length );
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -314,7 +312,7 @@ public class MeasureCLITest extends BaseMeasureTest {
 		System.out.println(output);
 		
 		String[] lines = output.split(System.getProperty("line.separator"));
-		assertEquals( output, 14, lines.length );
+		assertEquals( output, 18, lines.length );
 	}
 	
 	@Test

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/MeasureEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/MeasureEvaluator.java
@@ -75,21 +75,10 @@ public class MeasureEvaluator {
 	 */
 	public List<MeasureReport> evaluatePatientMeasures(String patientId, List<MeasureContext> measureContexts, MeasureEvidenceOptions evidenceOptions) {
 		List<MeasureReport> measureReports = new ArrayList<>();
-		MeasureReport measureReport = null;
-		boolean inInitialPopulation;
+		MeasureReport measureReport;
 		for (MeasureContext measureContext: measureContexts) {
-			inInitialPopulation = false;
 			measureReport = evaluatePatientMeasure(measureContext, patientId, evidenceOptions);
-			if (measureReport != null) {
-				for (MeasureReport.MeasureReportGroupComponent group : measureReport.getGroup()) {
-					if (CDMMeasureEvaluation.StandardReportResults.fromMeasureReportGroup(group).inInitialPopulation()) {
-						inInitialPopulation = true;
-					}
-				}
-			}
-			if (inInitialPopulation) {
-				measureReports.add(measureReport);
-			}
+			measureReports.add(measureReport);
 		}
 		return measureReports;
 	}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -207,7 +207,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 	}
 	
 	@Test
-	public void in_one_initial_population_for_two_measures___single_measure_report_returned() throws Exception {
+	public void in_one_initial_population_for_two_measures___two_measure_reports_returned() throws Exception {
 		CapabilityStatement metadata = getCapabilityStatement();
 		mockFhirResourceRetrieval("/metadata", metadata);
 
@@ -234,7 +234,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		measureContexts.add(new MeasureContext(measure1.getId(), passingParameters));
 		measureContexts.add(new MeasureContext(measure2.getId(), failingParameters));
 
-		assertEquals(1, evaluator.evaluatePatientMeasures(patient.getId(), measureContexts).size());
+		assertEquals(2, evaluator.evaluatePatientMeasures(patient.getId(), measureContexts).size());
 	}
 	
 	@Test

--- a/tests/src/main/resources/measureCLIExample-separate-measure-server.json
+++ b/tests/src/main/resources/measureCLIExample-separate-measure-server.json
@@ -5,7 +5,7 @@
             "resource": "wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0",
             "params": null,
             "targets": ["eb068c3f-3954-50c6-0c67-2b82d29865f0", "01268c61-8f89-6d50-4414-9e50d367804d", "6b6120d0-36b9-d2d5-639d-b77033cf5cee", "768202e4-b073-98e7-f3ab-2b7f467fea0b"],
-            "response": "Evaluating: eb068c3f-3954-50c6-0c67-2b82d29865f0\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 01268c61-8f89-6d50-4414-9e50d367804d\n---\nEvaluating: 6b6120d0-36b9-d2d5-639d-b77033cf5cee\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 768202e4-b073-98e7-f3ab-2b7f467fea0b\n---",
+            "response": "Evaluating: eb068c3f-3954-50c6-0c67-2b82d29865f0\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 01268c61-8f89-6d50-4414-9e50d367804d\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 0\n---\nEvaluating: 6b6120d0-36b9-d2d5-639d-b77033cf5cee\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 768202e4-b073-98e7-f3ab-2b7f467fea0b\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 0\n---",
             "measureServer": "cohort-cli/config/local-ibm-fhir.json"
         }, 
         "Over the Hill measure" : {
@@ -21,7 +21,7 @@
             "resource": null,
             "params": null,
             "targets": ["a1637d9d-8de4-b8b8-be2e-94118c7f4d71", "01268c61-8f89-6d50-4414-9e50d367804d"],
-            "response": "Evaluating: a1637d9d-8de4-b8b8-be2e-94118c7f4d71\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 01268c61-8f89-6d50-4414-9e50d367804d\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---",
+            "response": "Evaluating: a1637d9d-8de4-b8b8-be2e-94118c7f4d71\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 1\n---\nEvaluating: 01268c61-8f89-6d50-4414-9e50d367804d\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Colorectal-Cancer-Screening-Simple-1.0.0\nPopulation: initial-population = 0\n---",
             "measureServer": "cohort-cli/config/local-ibm-fhir.json"
         },
         "Over the Hill parameters test" : {
@@ -29,7 +29,7 @@
             "resource": null,
             "params": null,
             "targets": ["a1637d9d-8de4-b8b8-be2e-94118c7f4d71"],
-            "response": "Evaluating: a1637d9d-8de4-b8b8-be2e-94118c7f4d71\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---",
+            "response": "Evaluating: a1637d9d-8de4-b8b8-be2e-94118c7f4d71\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 1\n---\nResult for Measure/wh-cohort-Over-the-Hill-1.0.0\nPopulation: initial-population = 0\n---",
             "measureServer": "cohort-cli/config/local-ibm-fhir.json"
         },
         "Over the Hill parameters test - illegalArgumentException received when both -j and -r args not provided" : {
@@ -109,7 +109,7 @@
             "resource": null,
             "params": null,
             "targets": ["47c883bb-160a-7117-c5df-9344041ef048"],
-            "response": "Evaluating: 47c883bb-160a-7117-c5df-9344041ef048\nResult for Measure/identifier-test-measure-1\nPopulation: initial-population = 1\n---\nResult for Measure/identifier-test-measure-2\nPopulation: initial-population = 1\n---",
+            "response": "Evaluating: 47c883bb-160a-7117-c5df-9344041ef048\nResult for Measure/identifier-test-measure-2\nPopulation: initial-population = 0\n---\nResult for Measure/identifier-test-measure-1\nPopulation: initial-population = 1\n---\nResult for Measure/identifier-test-measure-2\nPopulation: initial-population = 0\n---\nResult for Measure/identifier-test-measure-2\nPopulation: initial-population = 1\n---",
             "measureServer": "cohort-cli/config/local-ibm-fhir.json",
             "regEx": false
         },


### PR DESCRIPTION
Make the MeasureEvaluator always return a MeasureReport even when an individual is not in the initial population. Update unit tests and Taurus tests to expect the previously filtered reports.