### PR TITLE
Added shaded jar to dockerfile

### DIFF
--- a/cohort-engine-distribution/pom.xml
+++ b/cohort-engine-distribution/pom.xml
@@ -115,6 +115,13 @@
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
+		<!-- Added so we can copy the shaded (aka uber) jar into the distribution zip -->
+		<dependency>
+			<groupId>com.ibm.cohort</groupId>
+			<artifactId>cohort-cli</artifactId>
+			<version>${project.version}</version>
+			<classifier>shaded</classifier>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant-junit</artifactId>

--- a/cohort-engine-distribution/src/main/assembly/distribution.xml
+++ b/cohort-engine-distribution/src/main/assembly/distribution.xml
@@ -22,24 +22,14 @@
 			<outputFileNameMapping>cohort-engine.war</outputFileNameMapping>
 			<outputDirectory>webapps</outputDirectory>
 		</dependencySet>
-		<!-- Uncomment to include cohort engine jar in the distribution .tar -->
-		<!-- We could also include artifacts from the cli projects as well -->
-		<!-- dependencySet>
-			<includes>
-				<include>com.ibm.cohort:cohort-engine:jar</include>
-			</includes>
-			<outputFileNameMapping>cohort-engine.jar</outputFileNameMapping>
-			<outputDirectory>jars</outputDirectory>
-		</dependencySet>
+		<!-- Add the shaded/uber jar to the distribution zip -->
 		<dependencySet>
 			<includes>
-				<include>*:jar</include>
-				<include>*:jar:classes</include>
+				<include>com.ibm.cohort:cohort-cli:jar</include>
 			</includes>
-			<outputDirectory>lib</outputDirectory>
-			<useProjectArtifact>false</useProjectArtifact>
-			<useTransitiveFiltering>true</useTransitiveFiltering>
-		</dependencySet> -->
+			<outputFileNameMapping>cohort-cli-shaded.jar</outputFileNameMapping>
+			<outputDirectory>jars</outputDirectory>
+		</dependencySet>
 	</dependencySets>
 	<fileSets>
 		<fileSet>


### PR DESCRIPTION
Small change to add the shaded cli engine jar to our dockerfile so that the test test can execute tests against it during the toolchain. I added the jar to our distribution tar.gz that gets created by the maven build, and then added it to the dockerfile