### PR TITLE
Fix extra round trip to FHIR server during Measure evaluation Library load step.

### DIFF
--- a/cohort-engine-api/.gitignore
+++ b/cohort-engine-api/.gitignore
@@ -1,0 +1,3 @@
+messages.log
+messages*.log.zip
+LogMessages.html

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProvider.java
@@ -48,7 +48,8 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 			return resolveLibraryByIdRaw(libraryId);
 		});
 		if( library != null ) {
-			cacheByNameVersion.computeIfAbsent(getCacheKey(library), k -> library);
+			cacheByUrl.computeIfAbsent(getUrlCacheKey(library), key -> library);
+			cacheByNameVersion.computeIfAbsent(getCacheKey(library), key -> library);
 		}
 		return library;
 	}
@@ -69,6 +70,10 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 		Library library = cacheByNameVersion.computeIfAbsent(cacheKey, k -> {
 			return resolveLibraryByNameRaw(libraryName, libraryVersion);
 		});
+		if( library != null ) {
+			cacheById.computeIfAbsent(library.getId(), key -> library);
+			cacheByUrl.computeIfAbsent(getUrlCacheKey(library), key -> library);
+		}
 		return library;
 	}
 	
@@ -80,10 +85,14 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 
 	@Override
 	public Library resolveLibraryByCanonicalUrl(String libraryUrl) {
-				
-		return cacheByUrl.computeIfAbsent(libraryUrl, cacheKey -> {
+		Library library = cacheByUrl.computeIfAbsent(libraryUrl, cacheKey -> {
 			return resolveLibraryByCanonicalUrlRaw(libraryUrl);
 		});
+		if( library != null ) {
+			cacheById.computeIfAbsent(library.getId(), key -> library);
+			cacheByNameVersion.computeIfAbsent(getCacheKey(library), key -> library);
+		}
+		return library;
 	}
 	
 	public Library resolveLibraryByCanonicalUrlRaw(String libraryUrl) {
@@ -104,6 +113,10 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 		cacheById.clear();
 		cacheByNameVersion.clear();
 		cacheByUrl.clear();
+	}
+	
+	protected String getUrlCacheKey(Library library) {
+		return CanonicalHelper.toCanonicalUrl(library);
 	}
 
 	protected String getCacheKey(Library library) {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProvider.java
@@ -48,8 +48,7 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 			return resolveLibraryByIdRaw(libraryId);
 		});
 		if( library != null ) {
-			cacheByUrl.computeIfAbsent(getUrlCacheKey(library), key -> library);
-			cacheByNameVersion.computeIfAbsent(getCacheKey(library), key -> library);
+			cacheByNameVersion.computeIfAbsent(getCacheKey(library), k -> library);
 		}
 		return library;
 	}
@@ -70,29 +69,21 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 		Library library = cacheByNameVersion.computeIfAbsent(cacheKey, k -> {
 			return resolveLibraryByNameRaw(libraryName, libraryVersion);
 		});
-		if( library != null ) {
-			cacheById.computeIfAbsent(library.getId(), key -> library);
-			cacheByUrl.computeIfAbsent(getUrlCacheKey(library), key -> library);
-		}
 		return library;
 	}
 	
 	public Library resolveLibraryByNameRaw(String libraryName, String libraryVersion) {
 		IQuery<IBaseBundle> query = libraryClient.search().forResource(Library.class)
-					.where(Library.NAME.matches().value(libraryName));
+					.where(Library.NAME.matchesExactly().value(libraryName));
 		return (Library) queryWithVersion( query, Library.VERSION, libraryVersion);
 	}
 
 	@Override
 	public Library resolveLibraryByCanonicalUrl(String libraryUrl) {
-		Library library = cacheByUrl.computeIfAbsent(libraryUrl, cacheKey -> {
+				
+		return cacheByUrl.computeIfAbsent(libraryUrl, cacheKey -> {
 			return resolveLibraryByCanonicalUrlRaw(libraryUrl);
 		});
-		if( library != null ) {
-			cacheById.computeIfAbsent(library.getId(), key -> library);
-			cacheByNameVersion.computeIfAbsent(getCacheKey(library), key -> library);
-		}
-		return library;
 	}
 	
 	public Library resolveLibraryByCanonicalUrlRaw(String libraryUrl) {
@@ -113,10 +104,6 @@ public class RestFhirLibraryResolutionProvider extends RestFhirResourceResolutio
 		cacheById.clear();
 		cacheByNameVersion.clear();
 		cacheByUrl.clear();
-	}
-	
-	protected String getUrlCacheKey(Library library) {
-		return CanonicalHelper.toCanonicalUrl(library);
 	}
 
 	protected String getCacheKey(Library library) {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/BaseMeasureTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/BaseMeasureTest.java
@@ -107,8 +107,8 @@ public class BaseMeasureTest extends BaseFhirTest {
 		}
 		
 		mockFhirResourceRetrieval("/Library?url=" + url, bundle );
-		mockFhirResourceRetrieval("/Library?name=" + library.getName(), bundle);
-		mockFhirResourceRetrieval("/Library?name=" + library.getName() + "&version=" + library.getVersion(), bundle);
+		mockFhirResourceRetrieval("/Library?name%3Aexact=" + library.getName(), bundle);
+		mockFhirResourceRetrieval("/Library?name%3Aexact=" + library.getName() + "&version=" + library.getVersion(), bundle);
 		return library;
 	}
 	

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -69,7 +69,8 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		verify(1, getRequestedFor(urlEqualTo("/Patient/123")));
 
 		// These ensure that the cache is working
-		verify(1, getRequestedFor(urlMatching("/Library\\?.*")));
+		verify(1, getRequestedFor(urlMatching("/Library\\?url=http.*")));
+		verify(1, getRequestedFor(urlEqualTo("/Library?name%3Aexact=" + library.getName() + "&version=1.0.0")));
 	}
 
 	@Test

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -69,8 +69,7 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		verify(1, getRequestedFor(urlEqualTo("/Patient/123")));
 
 		// These ensure that the cache is working
-		verify(1, getRequestedFor(urlMatching("/Library\\?url=http.*")));
-		verify(1, getRequestedFor(urlEqualTo("/Library?name=" + library.getName() + "&version=1.0.0")));
+		verify(1, getRequestedFor(urlMatching("/Library\\?.*")));
 	}
 
 	@Test

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
@@ -87,7 +87,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 		
 		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setVersion("1.0.0");
-		MappingBuilder mapping = get(urlMatching("/Library\\?name=[^&]+&version=.+"));
+		MappingBuilder mapping = get(urlMatching("/Library\\?name%3Aexact=[^&]+&version=.+"));
 		mockFhirResourceRetrieval( mapping, makeBundle(library) );
 		
 		Library actual = provider.resolveLibraryByName(library.getId(), library.getVersion());
@@ -112,7 +112,7 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 		
 		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
 		library.setVersion("1.0.0");
-		MappingBuilder mapping = get(urlMatching("/Library\\?name=[^&]+&version=.+"));
+		MappingBuilder mapping = get(urlMatching("/Library\\?name%3Aexact=[^&]+&version=.+"));
 		mockFhirResourceRetrieval( mapping, makeBundle(library) );
 		
 		Library actual = provider.resolveLibraryByName(library.getId(), library.getVersion());
@@ -145,19 +145,6 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 		
 		provider.resolveLibraryByCanonicalUrl(TEST_URL);
 		verify(1, getRequestedFor(urlMatching("/Library\\?url=.*")));
-	}
-	
-	@Test
-	public void resolveLibraryByCanonicalUrlThenNameVersion___returns_cached_data() throws Exception {
-		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
-		library.setUrl(TEST_URL);
-
-		Library actual = runTest(TEST_URL, makeBundle( library ));
-		assertNotNull(actual);
-		assertEquals(library.getUrl(), actual.getUrl());
-		
-		provider.resolveLibraryByName(library.getName(), library.getVersion());
-		verify(1, getRequestedFor(urlMatching("/Library\\?.*")));
 	}
 
 	@Test

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolutionProviderTest.java
@@ -146,6 +146,19 @@ public class RestFhirLibraryResolutionProviderTest extends BaseFhirTest {
 		provider.resolveLibraryByCanonicalUrl(TEST_URL);
 		verify(1, getRequestedFor(urlMatching("/Library\\?url=.*")));
 	}
+	
+	@Test
+	public void resolveLibraryByCanonicalUrlThenNameVersion___returns_cached_data() throws Exception {
+		Library library = getLibrary("Test", DEFAULT_VERSION, "cql/basic/test.cql");
+		library.setUrl(TEST_URL);
+
+		Library actual = runTest(TEST_URL, makeBundle( library ));
+		assertNotNull(actual);
+		assertEquals(library.getUrl(), actual.getUrl());
+		
+		provider.resolveLibraryByName(library.getName(), library.getVersion());
+		verify(1, getRequestedFor(urlMatching("/Library\\?.*")));
+	}
 
 	@Test
 	public void resolveLibraryByCanonicalUrl__null_when_library_not_found() throws Exception {


### PR DESCRIPTION
Kwas noticed that after my recent PR to address measure resource resolution tasks we were getting an extra round trip to the FHIR server for each Library associated with a measure. This patch updates the caching implementation to avoid the extra hit. I also added a .gitignore file to cohort-engine-api to avoid some extraneous build artifacts from showing up as changes. See the individual commit messages for complete details.