### PR TITLE
Wffhcohort 290 cloud readiness liveness

### DIFF
--- a/chart/cohort/templates/deployment.yaml
+++ b/chart/cohort/templates/deployment.yaml
@@ -48,6 +48,24 @@ spec:
           volumeMounts:
             - name: secret-tls
               mountPath: /secrets/tls
+      livenessProbe:
+        httpGet:
+          path: /services/cohort/api/v1/status?liveness_check=true
+          port: 9080
+        initialDelaySeconds: 30
+        periodSeconds: 10
+      startupProbe:
+        httpGet:
+          path: /services/cohort/api/v1/status?liveness_check=true
+          port: 9080
+        failureThreshold: 12
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /services/cohort/api/v1/status/health_check
+          port: 9080
+        initialDelaySeconds: 30
+        periodSeconds: 10
       nodeSelector:
         worker-type: application
 

--- a/chart/cohort/templates/deployment.yaml
+++ b/chart/cohort/templates/deployment.yaml
@@ -48,24 +48,24 @@ spec:
           volumeMounts:
             - name: secret-tls
               mountPath: /secrets/tls
-      livenessProbe:
-        httpGet:
-          path: /services/cohort/api/v1/status?liveness_check=true
-          port: 9080
-        initialDelaySeconds: 30
-        periodSeconds: 10
-      startupProbe:
-        httpGet:
-          path: /services/cohort/api/v1/status?liveness_check=true
-          port: 9080
-        failureThreshold: 12
-        periodSeconds: 10
-      readinessProbe:
-        httpGet:
-          path: /services/cohort/api/v1/status/health_check
-          port: 9080
-        initialDelaySeconds: 30
-        periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /services/cohort/api/v1/status?liveness_check=true
+            port: 9080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /services/cohort/api/v1/status?liveness_check=true
+            port: 9080
+          failureThreshold: 12
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /services/cohort/api/v1/status/health_check
+            port: 9080
+          initialDelaySeconds: 30
+          periodSeconds: 10
       nodeSelector:
         worker-type: application
 

--- a/chart/cohort/templates/deployment.yaml
+++ b/chart/cohort/templates/deployment.yaml
@@ -48,24 +48,24 @@ spec:
           volumeMounts:
             - name: secret-tls
               mountPath: /secrets/tls
-        livenessProbe:
-          httpGet:
-            path: /services/cohort/api/v1/status?liveness_check=true
-            port: 9080
-          initialDelaySeconds: 30
-          periodSeconds: 10
-        startupProbe:
-          httpGet:
-            path: /services/cohort/api/v1/status?liveness_check=true
-            port: 9080
-          failureThreshold: 12
-          periodSeconds: 10
-        readinessProbe:
-          httpGet:
-            path: /services/cohort/api/v1/status/health_check
-            port: 9080
-          initialDelaySeconds: 30
-          periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /services/cohort/api/v1/status?liveness_check=true
+              port: 9080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /services/cohort/api/v1/status?liveness_check=true
+              port: 9080
+            failureThreshold: 12
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /services/cohort/api/v1/status/health_check
+              port: 9080
+            initialDelaySeconds: 30
+            periodSeconds: 10
       nodeSelector:
         worker-type: application
 


### PR DESCRIPTION
This change implements the k8s liveness/readiness and startup probes. I picked values that seemed reasonable to me and were comparable to other implementations I check that were also running liberty servers.

From the k8s documentation:
The kubelet uses liveness probes to know when to restart a container. For example, liveness probes could catch a deadlock, where an application is running, but unable to make progress. Restarting a container in such a state can help to make the application more available despite bugs.

The kubelet uses readiness probes to know when a container is ready to start accepting traffic. A Pod is considered ready when all of its containers are ready. One use of this signal is to control which Pods are used as backends for Services. When a Pod is not ready, it is removed from Service load balancers.

The kubelet uses startup probes to know when a container application has started. If such a probe is configured, it disables liveness and readiness checks until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.