### PR TITLE
return FHIR exception details in endpoint requests

### DIFF
--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +87,7 @@ public class CohortServiceExceptionMapper implements ExceptionMapper<Throwable>{
 			else if (ex instanceof BaseServerResponseException) {
 				serviceErrorCode = Status.INTERNAL_SERVER_ERROR.getStatusCode();
 				serviceErrorListCode = serviceErrorCode;
-				description = ((BaseServerResponseException) ex).getResponseBody();
+				description = StringEscapeUtils.escapeJson(((BaseServerResponseException) ex).getResponseBody());
 			}
 			//catch everything else and return a 500
 			else {

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
@@ -23,6 +23,7 @@ import com.ibm.watson.service.base.model.ServiceError;
 
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 
 @Provider
 public class CohortServiceExceptionMapper implements ExceptionMapper<Throwable>{
@@ -80,6 +81,12 @@ public class CohortServiceExceptionMapper implements ExceptionMapper<Throwable>{
 			else if (ex instanceof IllegalArgumentException){
 				serviceErrorCode = Status.BAD_REQUEST.getStatusCode();
 				serviceErrorListCode = serviceErrorCode;
+			}
+			// FHIR Exception
+			else if (ex instanceof BaseServerResponseException) {
+				serviceErrorCode = Status.INTERNAL_SERVER_ERROR.getStatusCode();
+				serviceErrorListCode = serviceErrorCode;
+				description = ((BaseServerResponseException) ex).getResponseBody();
 			}
 			//catch everything else and return a 500
 			else {


### PR DESCRIPTION
when an `FHIR`-side error occurs

`BaseServerResponseException::getResponseBody` contains more details regarding why the error occurred.

_per discussion in [#cohorting-backend](https://ibm-watsonhealth.slack.com/archives/C01922MH1EY/p1615907830006800)_