### PR TITLE
Adding source jars to build

### DIFF
--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -621,7 +621,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.2.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -953,6 +953,19 @@
 					</execution>
 				</executions>
             </plugin>
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Followed this plugin's recommendation to use "jar-no-fork" as more appropriate within the build lifecycle: https://maven.apache.org/plugins/maven-source-plugin/usage.html.

There *should* be no additional work to get these into github packages on publish, but I will confirm that after merge.