### PR TITLE
Exclude dependency for appscan vulnerability

### DIFF
--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -319,6 +319,10 @@
 						<groupId>org.eclipse.jetty</groupId>
 						<artifactId>jetty-servlets</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-dbcp2</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<!-- Updating due to AppScan issue with 29.0-jre pulled in via common -->
@@ -658,11 +662,6 @@
 				<groupId>net.minidev</groupId>
 				<artifactId>json-smart</artifactId>
 				<version>1.3.2</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-dbcp2</artifactId>
-				<version>2.8.0</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Needed to exclude this dependency for an Appscan issue. Updating the version did not resolve the issue (resolution in the appscan issue was not worded clearly).