### PR TITLE
Add unit test for "interval starts interval"

### DIFF
--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEngineWrapperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEngineWrapperTest.java
@@ -615,4 +615,28 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 			});
 		assertTrue( "Unexpected exception message: " + ex.getMessage(), ex.getMessage().contains("version and code system bindings are not supported at this time") );
 	}
+	
+	@Test
+	/**
+	 * This test exists to validate the the engine correctly evaluates CQL
+	 * that includes an "interval starts interval" expression. This was 
+	 * called out because the CQL Author's Guide documentation mentioned
+	 * "interval begins interval" as a supported feature and "begins"
+	 * isn't the correct operator name. 
+	 *  
+	 * @throws Exception on any error.
+	 */
+	public void testIntervalStartsInterval() throws Exception {
+		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1983-12-02");
+		
+		final AtomicInteger resultCount = new AtomicInteger(0);
+		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/temporal/IntervalStartsInterval-1.0.0.cql", "cql/temporal/FHIRHelpers.cql");
+		
+		wrapper.evaluate("IntervalStartsInterval", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList("LHS Starts RHS")),
+				Arrays.asList(patient.getId()), (p, e, r) -> {
+					assertEquals(Boolean.TRUE, r);
+					resultCount.incrementAndGet();
+				});
+		assertEquals(1, resultCount.get());
+	}
 }

--- a/cohort-engine/src/test/resources/cql/temporal/IntervalStartsInterval-1.0.0.cql
+++ b/cohort-engine/src/test/resources/cql/temporal/IntervalStartsInterval-1.0.0.cql
@@ -1,0 +1,11 @@
+ library "IntervalStartsInterval" version '1.0.0'
+ 
+ define LHS:
+ 	Interval[@2020-07-04T12:00:00.000-05:00, @2021-07-04T12:00:00.000-05:00]
+ 
+ 
+ define RHS:
+ 	Interval[@2020-07-04T12:00:00.000-05:00, @2022-07-04T12:00:00.000-05:00]
+ 
+ define "LHS Starts RHS":
+ 	LHS starts RHS


### PR DESCRIPTION
It was noted that the CQL Author's Guide lists "interval begins
interval" as a valid operator, but it wasn't functioning in the engine.
After investigation, it was determined to be a documentation problem.
The correct operation is "interval starts interval". This unit test
validates that operator exists and is functional.