### PR TITLE
Wffhcohort 344 open source base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@
 # base as builder until this is ready. For reference:
 # https://github.com/ibmruntimes/ci.docker/tree/master/ibmjava/8/sdk/ubi-min
 ####################
-FROM us.icr.io/cdt-common-rns/base-images/ubi8:latest AS builder
+#FROM us.icr.io/cdt-common-rns/base-images/ubi8:latest AS builder
+FROM registry.access.redhat.com/ubi8 AS builder
 
 WORKDIR /app
 ENV COHORT_DIST_SOLUTION=/app/cohortSolutionDistribution \
@@ -30,7 +31,8 @@ RUN mkdir -p $COHORT_DIST_SOLUTION && \
 # Liberty document reference : https://hub.docker.com/_/websphere-liberty/
 ####################
 #TODO periodically update to the latest base image
-FROM us.icr.io/cdt-common-rns/base-images/ubi8-liberty:20210308.1322
+#FROM us.icr.io/cdt-common-rns/base-images/ubi8-liberty:20210308.1322
+FROM registry.hub.docker.com/ibmcom/websphere-liberty:21.0.0.3-full-java8-openj9-ubi
 
 # Labels - certain labels are required if you want to have
 #          a Red Hat certified image (this is not a full set per se)
@@ -47,7 +49,7 @@ ENV WLP_HOME=/opt/ibm/wlp \
     SERVER_NAME=cohortServer \
     ALVEARIE_HOME=/opt/alvearie \
     COHORT_DIST_SOLUTION=/app/cohortSolutionDistribution \
-    JAVA_HOME=/opt/ibm/java
+    JAVA_HOME=/opt/java/openjdk
 ENV COHORT_ENGINE_HOME=$ALVEARIE_HOME/cohortEngine
 
 # create server instance
@@ -57,11 +59,10 @@ RUN $WLP_HOME/bin/server create $SERVER_NAME && \
 
 USER root
 # Update image to pick up latest security updates
-# Make dir for test resources
 # Update symlnk used by Liberty to new server.  Need root.
-RUN microdnf update -y && rm -rf /var/cache/yum && \
-    microdnf install -y --nodocs vim openssl && \
-    microdnf clean all && \
+RUN dnf update -y && rm -rf /var/cache/yum && \
+    dnf install -y --nodocs vim openssl && \
+    dnf clean all && \
     ln -sfn $WLP_HOME/usr/servers/$SERVER_NAME /config
 
 #Copy in war files, config files, etc. to final image
@@ -78,9 +79,9 @@ ENV PATH="$JAVA_HOME/jre/bin:${PATH}"
 COPY --from=builder $COHORT_DIST_SOLUTION/solution/bin/*.sh $WLP_HOME/bin/
 
 # Grant write access to apps folder and startup script
-RUN chown -R --from=root whuser $WLP_HOME && \
+RUN chown -R --from=root 1001 $WLP_HOME && \
     chmod -R u+rwx $WLP_HOME && \
-    chown -R --from=root whuser $COHORT_ENGINE_HOME && \
+    chown -R --from=root 1001 $COHORT_ENGINE_HOME && \
     chmod -R u+rwx $COHORT_ENGINE_HOME
 
 # install any missing features required by server config
@@ -90,7 +91,7 @@ RUN $WLP_HOME/bin/installUtility install --acceptLicense $SERVER_NAME
 #RUN ["/bin/bash", "-c", "ls -al $WLP_HOME/usr/servers/$SERVER_NAME/" ]
 #RUN ["/bin/bash", "-c", "ls -al $WLP_HOME/usr/servers/$SERVER_NAME/*" ]
 
-USER whuser
+USER 1001
 
 # Expose the servers HTTP and HTTPS ports.  NOTE:  must match with hardcoded testcase stage scripts, Helm charts (values.yaml), server.xml
 EXPOSE 9080 9443

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ####################
-# First stage:  IBM Java SDK UBI
-# IBM Java SDK UBI is not available on public docker yet. Use regular
-# base as builder until this is ready. For reference:
-# https://github.com/ibmruntimes/ci.docker/tree/master/ibmjava/8/sdk/ubi-min
+# First stage:  Red Hat UBI8
+# Use this image as a builder image for someplace to
+# unzip our binaries to. For reference:
+# https://access.redhat.com/containers/?tab=support#/registry.access.redhat.com/ubi8/ubi
 ####################
-#FROM us.icr.io/cdt-common-rns/base-images/ubi8:latest AS builder
 FROM registry.access.redhat.com/ubi8 AS builder
 
 WORKDIR /app
@@ -28,10 +27,9 @@ RUN mkdir -p $COHORT_DIST_SOLUTION && \
 
 ####################
 # Multi-stage build. New build stage that uses the Liberty UBI as the base image.
-# Liberty document reference : https://hub.docker.com/_/websphere-liberty/
+# Liberty document reference : https://registry.hub.docker.com/r/ibmcom/websphere-liberty
 ####################
 #TODO periodically update to the latest base image
-#FROM us.icr.io/cdt-common-rns/base-images/ubi8-liberty:20210308.1322
 FROM registry.hub.docker.com/ibmcom/websphere-liberty:21.0.0.3-full-java8-openj9-ubi
 
 # Labels - certain labels are required if you want to have


### PR DESCRIPTION
Changed to use openly available base images that have been approved by security after review with our security focal. Also updated our liberty version to 21.0.0.3 since it was the latest available.