### PR TITLE
Swagger UI fix

### DIFF
--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasureParameterInfoList.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasureParameterInfoList.java
@@ -11,7 +11,6 @@ import java.util.Objects;
 
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.cohort.annotations.Generated;
 
 import io.swagger.annotations.ApiModel;

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasureParameterInfoList.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/MeasureParameterInfoList.java
@@ -32,7 +32,6 @@ public class MeasureParameterInfoList {
 	}
 
 	@ApiModelProperty(required = true, value = "A list of parameter information objects for libraries referenced by the input measure")
-	@JsonProperty("measureParameterInfoList")
 	@NotNull
 	/**
 	 * Get the parameter info list


### PR DESCRIPTION
The JsonProperty annotation was causing the swagger ui to improperly display the name of the parameter list in the results returned from the API call.