### PR TITLE
Doc updates in Swagger for the evaluation API and the user guide.

### DIFF
--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -122,7 +122,7 @@ public class CohortEngineRestHandler {
 	public final static String CUSTOM_CODE_SYSTEM = "custom_code_system";
 	
 	public static final String EXAMPLE_REQUEST_DATA_JSON = "<p>A configuration file containing the information needed to process a measure evaluation request. Two possible FHIR server endoints can be configured <code>dataServerConfig</code> and <code>terminologyServerConfig</code>. Only the <code>dataServerConfig</code> is required. If <code>terminologyServerConfig</code> is not provided, the connection details are assumed to be the same as the <code>dataServerConfig</code> connection.</p>" +
-			"<p>The <code>measureContext.measureId</code> field can be a FHIR resource ID or canonical URL. Alternatively, <code>measureContext.identifier</code> and <code>measureContext.version</code> can be used to lookup the measure based on a business identifier found in the resource definition. Only one of measureId or identifier + version should be specified. Canonical URL is the recommend lookup mechanism.</p>" +
+			"<p>The <code>measureContext.measureId</code> field can be a FHIR resource ID or canonical URL. Alternatively, <code>measureContext.identifier</code> and <code>measureContext.version</code> can be used to lookup the measure based on a business identifier found in the resource definition. Only one of measureId or identifier + version should be specified. Canonical URL is the recommended lookup mechanism.</p>" +
 			"<p>The parameter types and formats are described in detail in the <a href=\"http://alvearie.io/quality-measure-and-cohort-service/#/user-guide/parameter-formats?id=parameter-formats\">user guide</a>.</p>" +
 			"<p>The <code>evidenceOptions</code> control the amount of data written the FHIR MeasureReport that is returned as a result of the evaluation. The examle demonstrates inclusion of the result of all define statements processed by the CQL Engine and no links to the resources involved in the evaluation.</p>" +
 			"<p>Example Contents: \n <pre>{\n" +
@@ -167,7 +167,6 @@ public class CohortEngineRestHandler {
 			"fhirResources/libraries/LibraryName1-LibraryVersion.json\n" + 
 			"fhirResources/libraries/LibraryName2-LibraryVersion.json\n" +
 			"etc.</pre>";
-
 	
 	public static final String EXAMPLE_DATA_SERVER_CONFIG_JSON = "A configuration file containing information needed to connect to the FHIR server. "
 			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/getting-started.md#fhir-server-configuration for more details. \n"

--- a/docs/user-guide/_sidebar.md
+++ b/docs/user-guide/_sidebar.md
@@ -2,6 +2,7 @@
 
   - [Getting Started](user-guide/getting-started.md)
   - [FHIR Server Configuration](user-guide/fhir-server-config.md)
+  - [Parameter Formats](user-guide/parameter-formats.md)
 
 - Index
 


### PR DESCRIPTION
I brought these over from my PR for WFFHCOHORT-355 since it isn't clear
that is going to make R1 and we would like to include these as part of
the release. This includes updates to the swagger for the /evaluation 
REST API and the addition of the parameter formats page to the 
sidebar in the user guide.