### PR TITLE
Rename CqlEngineWrapper to CqlEvaluator

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
@@ -27,7 +27,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.Console;
 import com.beust.jcommander.internal.DefaultConsole;
 import com.ibm.cohort.cli.input.NoSplittingSplitter;
-import com.ibm.cohort.engine.CqlEngineWrapper;
+import com.ibm.cohort.engine.CqlEvaluator;
 import com.ibm.cohort.engine.DirectoryLibrarySourceProvider;
 import com.ibm.cohort.engine.EvaluationResultCallback;
 import com.ibm.cohort.engine.FhirLibraryLibrarySourceProvider;
@@ -105,13 +105,13 @@ public class CohortCLI extends BaseCLI {
 	 * @return CQLEngineWrapper
 	 * @throws IOException IOException
 	 */
-	public CqlEngineWrapper runWithArgs(String[] args, PrintStream out) throws IOException {
+	public CqlEvaluator runWithArgs(String[] args, PrintStream out) throws IOException {
 		Arguments arguments = new Arguments();
 		Console console = new DefaultConsole(out);
 		JCommander jc = JCommander.newBuilder().programName("cql-engine").console(console).addObject(arguments).build();
 		jc.parse(args);
 
-		CqlEngineWrapper wrapper = null;
+		CqlEvaluator wrapper = null;
 		
 		if (arguments.isDisplayHelp) {
 			jc.usage();
@@ -119,7 +119,7 @@ public class CohortCLI extends BaseCLI {
 			
 			FhirClientBuilderFactory factory = FhirClientBuilderFactory.newInstance();
 			
-			wrapper = new CqlEngineWrapper(factory);
+			wrapper = new CqlEvaluator(factory);
 			wrapper.setExpandValueSets( ! arguments.enableTerminologyOptimization );
 			wrapper.setSearchPageSize( arguments.searchPageSize );
 
@@ -195,7 +195,7 @@ public class CohortCLI extends BaseCLI {
 		return wrapper;
 	}
 
-	protected void configureConnections(CqlEngineWrapper wrapper, ConnectionArguments arguments) throws IOException {
+	protected void configureConnections(CqlEvaluator wrapper, ConnectionArguments arguments) throws IOException {
 		readConnectionConfiguration(arguments);
 		wrapper.setDataServerConnectionProperties(dataServerConfig);
 		wrapper.setTerminologyServerConnectionProperties(terminologyServerConfig);

--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
@@ -102,7 +102,7 @@ public class CohortCLI extends BaseCLI {
 	 * @param args parameter values
 	 * @param out  location where contents that would normally go to stdout should
 	 *             be written
-	 * @return CQLEngineWrapper
+	 * @return CQLEvaluator
 	 * @throws IOException IOException
 	 */
 	public CqlEvaluator runWithArgs(String[] args, PrintStream out) throws IOException {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
@@ -44,7 +44,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
  * engine using sensible defaults for our target execution environment and
  * providing utilities for loading library contents from various sources.
  */
-public class CqlEngineWrapper {
+public class CqlEvaluator {
 
 	protected static final List<String> SUPPORTED_MODELS = Arrays.asList("http://hl7.org/fhir",
 			"http://hl7.org/fhir/us/core", "http://hl7.org/fhir/us/qicore", CDMConstants.BASE_URL);
@@ -60,11 +60,11 @@ public class CqlEngineWrapper {
 	private Integer searchPageSize = 1000;
 	private boolean expandValueSets = true;
 
-	public CqlEngineWrapper() {
+	public CqlEvaluator() {
 		this(FhirClientBuilderFactory.newInstance());
 	}
 
-	public CqlEngineWrapper(FhirClientBuilderFactory clientBuilderFactory) {
+	public CqlEvaluator(FhirClientBuilderFactory clientBuilderFactory) {
 		this.clientBuilderFactory = clientBuilderFactory;
 	}
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/ExpressionResultCallback.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/ExpressionResultCallback.java
@@ -7,7 +7,7 @@
 package com.ibm.cohort.engine;
 
 /**
- * Callback function that will be called for each context passed to the CqlEngineWrapper.
+ * Callback function that will be called for each context passed to the CqlEvaluator.
  */
 @FunctionalInterface
 public interface ExpressionResultCallback {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
@@ -18,7 +18,7 @@ import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import com.ibm.cohort.fhir.client.config.IBMFhirServerConfig;
 
 public class BasePatientTest extends BaseFhirTest {
-	protected CqlEngineWrapper setupTestFor(Patient patient, String... resources) {
+	protected CqlEvaluator setupTestFor(Patient patient, String... resources) {
 		IBMFhirServerConfig fhirConfig = new IBMFhirServerConfig();
 		fhirConfig.setEndpoint("http://localhost:" + HTTP_PORT);
 		fhirConfig.setUser("fhiruser");
@@ -28,12 +28,12 @@ public class BasePatientTest extends BaseFhirTest {
 		return setupTestFor(patient, fhirConfig, resources);
 	}
 
-	protected CqlEngineWrapper setupTestFor(Patient patient, FhirServerConfig fhirConfig, String... resources) {
+	protected CqlEvaluator setupTestFor(Patient patient, FhirServerConfig fhirConfig, String... resources) {
 
 		mockFhirResourceRetrieval("/metadata", getCapabilityStatement());
 		mockFhirResourceRetrieval(patient);
 
-		CqlEngineWrapper wrapper = new CqlEngineWrapper();
+		CqlEvaluator wrapper = new CqlEvaluator();
 		if (resources != null) {
 			/*
 			 * Do some hacking to make the pre-existing test resources still function 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorTest.java
@@ -44,14 +44,14 @@ import com.ibm.cohort.engine.parameter.IntervalParameter;
 import com.ibm.cohort.engine.parameter.Parameter;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
-public class CqlEngineWrapperTest extends BasePatientTest {
+public class CqlEvaluatorTest extends BasePatientTest {
 
 	@Test
 	public void testPatientIsFemaleTrue() throws Exception {
 
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, null);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", /* libraryVersion= */null, /* parameters= */null,
@@ -70,7 +70,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.MALE, null);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", /* libraryVersion= */null, /* parameters= */null,
@@ -88,7 +88,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.MALE, null);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList("Female")),
@@ -110,7 +110,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = new Patient();
 		patient.setGender(Enumerations.AdministrativeGender.MALE);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "9.9.9", /* parameters= */null, new HashSet<>(Arrays.asList("Female")),
@@ -130,7 +130,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Map<String, Parameter> parameters = new HashMap<>();
 		parameters.put("MaxAge", new IntegerParameter(40));
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", parameters, new HashSet<>(Arrays.asList("Female")), Arrays.asList("123"),
@@ -150,7 +150,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Map<String, Parameter> parameters = new HashMap<>();
 		parameters.put("MaxAge", new IntegerParameter(50));
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", parameters, new HashSet<>(Arrays.asList("Female")), Arrays.asList("123"),
@@ -176,7 +176,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 
 		Map<String, Parameter> parameters = null;
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", parameters, new HashSet<>(Arrays.asList("Female")), Arrays.asList("123"),
@@ -203,7 +203,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Map<String, Parameter> parameters = new HashMap<>();
 		parameters.put("Unused", new IntegerParameter(100));
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", parameters, new HashSet<>(Arrays.asList("Female")), Arrays.asList("123"),
@@ -221,7 +221,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, null);
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluate("Test", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList("Female")),
@@ -251,7 +251,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", condition);
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,
 				"cql/condition/test-status-active.cql");
 
 		final AtomicInteger count = new AtomicInteger(0);
@@ -287,7 +287,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		mockFhirResourceRetrieval(builder, condition);
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,
 				"cql/condition/test-date-query.xml");
 		
 		Map<String,Parameter> parameters = new HashMap<>();
@@ -311,7 +311,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 	public void testNumCallsUsingEngineWrapperMethod() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluateWithEngineWrapper("Test", null, /* parameters= */null, null, Arrays.asList("123"),
@@ -328,7 +328,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 	public void testNumCallsUsingPerDefineMethod() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 
 		final AtomicInteger count = new AtomicInteger(0);
 		wrapper.evaluateExpressionByExpression("Test", null, /* parameters= */null, null, Arrays.asList("123"),
@@ -345,7 +345,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 	public void testNumCallsWithParamsUsingEngineWrapperMethod() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		Map<String, Parameter> parameters = new HashMap<>();
 		parameters.put("MaxAge", new IntegerParameter(40));
@@ -368,7 +368,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 	public void testNumCallsWithParamsUsingPerDefineMethod() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, null);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/parameters/test-with-params.xml");
 
 		Map<String, Parameter> parameters = new HashMap<>();
 		parameters.put("MaxAge", new IntegerParameter(40));
@@ -392,7 +392,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 	public void testJsonCQLWithIncludes() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1978-05-06");
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/includes/Breast-Cancer-Screening.json");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/includes/Breast-Cancer-Screening.json");
 
 		final AtomicBoolean found = new AtomicBoolean(false);
 		final AtomicInteger count = new AtomicInteger(0);
@@ -410,7 +410,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidWrapperSetup() throws Exception {
-		CqlEngineWrapper wrapper = new CqlEngineWrapper();
+		CqlEvaluator wrapper = new CqlEvaluator();
 		wrapper.evaluate("Test", null, null, null, Arrays.asList("123"), (p, e, r) -> {
 			/* do nothing */ });
 	}
@@ -420,7 +420,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = new Patient();
 		patient.setGender(Enumerations.AdministrativeGender.FEMALE);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/basic/test.xml");
 		wrapper.evaluate(null, null, null, null, null, null);
 	}
 
@@ -432,7 +432,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		FhirServerConfig fhirConfig = new FhirServerConfig();
 		fhirConfig.setEndpoint("http://its.not.me");
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
 		wrapper.evaluate("Test", /* version= */null, /* parameters= */null, /* expressions= */null,
 				Arrays.asList("123"), (p, e, r) -> {
 					fail("Execution should not reach here");
@@ -446,7 +446,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig, "cql/basic/test.xml");
 		wrapper.evaluate("NotCorrect", /* version= */null, /* parameters= */null, /* expressions= */null,
 				Arrays.asList("123"), (p, e, r) -> {
 					fail("Execution should not reach here");
@@ -460,7 +460,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		final AtomicInteger resultCount = new AtomicInteger(0);
 		// Using pre-compiled ELM that is correctly formatted for consumption. There is a test
 		// case below that does the same thing with translation.
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/uscore/test-uscore.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/uscore/test-uscore.xml");
 		wrapper.evaluate("Test", /* version= */null, /* parameters= */null, new HashSet<>(Arrays.asList("QueryByGender")),
 				Arrays.asList("123"), (p, e, r) -> {
 					assertEquals("QueryByGender", e);
@@ -477,7 +477,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1983-12-02");
 
 		final AtomicInteger resultCount = new AtomicInteger(0);
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/uscore/test-uscore.cql");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/uscore/test-uscore.cql");
 		wrapper.evaluate("Test", /* version= */null, /* parameters= */null, new HashSet<>(Arrays.asList("QueryByGender")),
 				Arrays.asList("123"), (p, e, r) -> {
 					assertEquals("QueryByGender", e);
@@ -496,7 +496,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1983-12-02");
 
 		final AtomicInteger resultCount = new AtomicInteger(0);
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/uomequivalence/TestUOMCompare-1.0.0.cql");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/uomequivalence/TestUOMCompare-1.0.0.cql");
 		wrapper.evaluate("TestUOMCompare", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList("IsEqual", "AreEquivalent", "UpConvert")),
 				Arrays.asList(patient.getId()), (p, e, r) -> {
 					if( e.equals("IsEqual") ) {
@@ -528,7 +528,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1983-12-02");
 
 		final AtomicInteger resultCount = new AtomicInteger(0);
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/valueset/Test-1.0.0.cql");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/valueset/Test-1.0.0.cql");
 		
 		Condition condition = new Condition();
 		condition.setId("Condition");
@@ -604,7 +604,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", condition);		
 		
 		final AtomicInteger resultCount = new AtomicInteger(0);
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/valueset/TestUnsupported-1.0.0.cql");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/valueset/TestUnsupported-1.0.0.cql");
 		
 		CqlException ex = assertThrows("Missing expected exception", CqlException.class, () -> {
 				wrapper.evaluate("TestUnsupported", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList(expression)),
@@ -629,7 +629,7 @@ public class CqlEngineWrapperTest extends BasePatientTest {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, "1983-12-02");
 		
 		final AtomicInteger resultCount = new AtomicInteger(0);
-		CqlEngineWrapper wrapper = setupTestFor(patient, "cql/temporal/IntervalStartsInterval-1.0.0.cql");
+		CqlEvaluator wrapper = setupTestFor(patient, "cql/temporal/IntervalStartsInterval-1.0.0.cql");
 		
 		wrapper.evaluate("IntervalStartsInterval", "1.0.0", /* parameters= */null, new HashSet<>(Arrays.asList("LHS Starts RHS")),
 				Arrays.asList(patient.getId()), (p, e, r) -> {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
@@ -48,7 +48,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_1.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_1.xml");
 
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_1, fhirConfig);
@@ -74,7 +74,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_1.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_1.xml");
 
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_1, fhirConfig);
@@ -100,7 +100,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_2.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_2.xml");
 
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_1, fhirConfig);
@@ -131,7 +131,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_2.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_2.xml");
 
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_1, fhirConfig);
@@ -156,7 +156,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_3.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_3.xml");
 
 		Bundle bundle = new Bundle();
 		Bundle.BundleEntryComponent firstEncounter = new Bundle.BundleEntryComponent();
@@ -186,7 +186,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_3.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_3.xml");
 
 		Bundle bundle = new Bundle();
 		Bundle.BundleEntryComponent firstEncounter = new Bundle.BundleEntryComponent();
@@ -216,7 +216,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_4.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_4.xml");
 
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_3, fhirConfig);
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
@@ -238,7 +238,7 @@ public class CqlTemporalTests extends BasePatientTest {
 
 		FhirServerConfig fhirConfig = getFhirServerConfig();
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_4.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_4.xml");
 
 		mockFhirResourceRetrieval("/Encounter?subject=Patient%2F123", getFhirParser(), ENCOUNTER_1, fhirConfig);
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
@@ -284,7 +284,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		bundle.addEntry(firstEncounter);
 		bundle.addEntry(secondEncounter);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_5.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_5.xml");
 
 		mockFhirResourceRetrieval("/Observation?subject=Patient%2F123", getFhirParser(), bundle, fhirConfig);
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);
@@ -328,7 +328,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		bundle.addEntry(firstEncounter);
 		bundle.addEntry(secondEncounter);
 
-		CqlEngineWrapper wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_5.xml");
+		CqlEvaluator wrapper = setupTestFor(patient, fhirConfig,"cql/temporal/test_5.xml");
 
 		mockFhirResourceRetrieval("/Observation?subject=Patient%2F123", getFhirParser(), bundle, fhirConfig);
 		mockFhirResourceRetrieval("/Condition?subject=Patient%2F123", getFhirParser(), CONDITION_IN, fhirConfig);

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,6 +1,6 @@
 # User Guide - Getting Started
 
-The [IBM Quality Measure and Cohort Engine](https://github.com/Alvearie/quality-measure-and-cohort-service/) is an open source project under the [Alvearie](https://github.com/Alvearie/) organization in Github. The Cohort Engine provides APIs for evaluating cohorts via definitions written in Clinical Quality Language (CQL). Users can execute CQL scripts directly using the CqlEngineWrapper API or indirectly through the use of FHIR measure and library resources.
+The [IBM Quality Measure and Cohort Engine](https://github.com/Alvearie/quality-measure-and-cohort-service/) is an open source project under the [Alvearie](https://github.com/Alvearie/) organization in Github. The Cohort Engine provides APIs for evaluating cohorts via definitions written in Clinical Quality Language (CQL). Users can execute CQL scripts directly using the CqlEvaluator API or indirectly through the use of FHIR measure and library resources.
 
 Builds are published in [Github packages](https://github.com/orgs/Alvearie/packages?repo_name=quality-measure-and-cohort-service) or you can pull the source code and build it yourself. If you are using the precompiled artifacts, you will most likely want to start with [cohort-cli](https://github.com/Alvearie/quality-measure-and-cohort-service/packages/506888) and choose the latest shaded jar (more on that below). If you are building yourself, use``git clone`` to pull down [the repository](https://github.com/Alvearie/quality-measure-and-cohort-service) and ``mvn install -f cohort-parent`` to build it. If you don't already have Maven installed on your workstation, [download](https://maven.apache.org/download.cgi) version 3.6.3 or newer and follow the [installation instructions](https://maven.apache.org/install.html). You should be using a Java SDK version 8.0 or higher. If you don't already have a Java SDK on your workstation, you can download one [here](https://adoptopenjdk.net/).
 
@@ -194,11 +194,11 @@ java -jar cohort-cli-*.jar -Dorg.slf4j.simpleLogger.log.org.opencds.cqf.cql.engi
 
 # Error states
 The Engine detects and throws IllegalArgumentException for the following error states:
-1) When the CqlEngineWrapper.evaluate(...) method is invoked without first configuring the library sources, data server, and terminology server settings.
-2) When the CqlEngineWrapper.evaluate(...) method is invoked without providing a library name and at least one context ID (aka patient ID).
-3) When the CqlEngineWrapper.evaluate(...) method is invoked for a CQL Library that contains parameters with no default value and no value is provided in the method's parameters map.
-4) When the CqlEngineWrapper.evaluate(...) method is invoked for a CQL Library that is not loaded
-5) When the CqlEngineWrapper.main(...) method is invoked with an invalid parameter type or interval subtype
+1) When the CqlEvaluator.evaluate(...) method is invoked without first configuring the library sources, data server, and terminology server settings.
+2) When the CqlEvaluator.evaluate(...) method is invoked without providing a library name and at least one context ID (aka patient ID).
+3) When the CqlEvaluator.evaluate(...) method is invoked for a CQL Library that contains parameters with no default value and no value is provided in the method's parameters map.
+4) When the CqlEvaluator.evaluate(...) method is invoked for a CQL Library that is not loaded
+5) When the CqlEvaluator.main(...) method is invoked with an invalid parameter type or interval subtype
 
 Connectivity issues to the FHIR server are reported through the HAPI FHIR Client library. See HAPI documentation for complete details, but an example exception would be ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException.
 

--- a/tests/src/main/java/com/ibm/cohort/engine/test/TestWrapper.java
+++ b/tests/src/main/java/com/ibm/cohort/engine/test/TestWrapper.java
@@ -11,11 +11,11 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.ibm.cohort.cli.CohortCLI;
-import com.ibm.cohort.engine.CqlEngineWrapper;
+import com.ibm.cohort.engine.CqlEvaluator;
 
 public class TestWrapper {
 	private CohortCLI cli;
-	private CqlEngineWrapper engine;
+	private CqlEvaluator engine;
 	private ByteArrayOutputStream byteStream;
 	private PrintStream ps;
 	public TestWrapper()


### PR DESCRIPTION
As discussed in the team call, renaming the public API for consistency with the MeasureEvaluator and to just be a better name.