### PR TITLE
WFFHCOHORT-413: Check for CQL Translation Exceptions

### DIFF
--- a/cohort-cli/src/test/resources/cql/result-types/test_result_types.cql
+++ b/cohort-cli/src/test/resources/cql/result-types/test_result_types.cql
@@ -1,6 +1,8 @@
 library "test_result_types" version '1.0.0'
 using "FHIR" version '4.0.0'
 
+include FHIRHelpers version '4.0.0'
+
 valueset "SomeCodes" : 'http://some.io/condition'
 
 context Patient

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/translation/InJVMCqlTranslationProvider.java
@@ -86,6 +86,11 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 			throw new Exception("CQL translation contained errors: " + translator.getErrors().stream().map(Throwable::toString).collect(Collectors.joining("\n")));
 		}
 
+		LOG.debug("Translated CQL contains {} exceptions", translator.getExceptions().size());
+		if (!translator.getExceptions().isEmpty()) {
+			throw new Exception("CQL translation contained exceptions: " + translator.getExceptions().stream().map(Throwable::toString).collect(Collectors.joining("\n")));
+		}
+
 		switch (targetFormat) {
 		case XML:
 			result = CqlLibraryReader.read(new StringReader(translator.toXml()));

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
@@ -128,8 +128,8 @@ public abstract class CqlTranslatorProviderTest {
 		catch (Exception e) {
 			failed = true;
 			Assert.assertTrue(
-					"Unexpected exception message",
-					e.getMessage().startsWith("CQL translation contained errors")
+					"Unexpected exception message: " + e.getMessage(),
+					e.getMessage().startsWith("CQL translation contained errors:")
 			);
 		}
 		if (!failed) {
@@ -147,8 +147,8 @@ public abstract class CqlTranslatorProviderTest {
 		catch (Exception e) {
 			failed = true;
 			Assert.assertTrue(
-					"Unexpected exception message",
-					e.getMessage().startsWith("CQL translation contained exceptions")
+					"Unexpected exception message: " + e.getMessage(),
+					e.getMessage().startsWith("CQL translation contained exceptions:")
 			);
 		}
 		if (!failed) {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
@@ -136,6 +136,25 @@ public abstract class CqlTranslatorProviderTest {
 			Assert.fail("Did not fail translation");
 		}
 	}
+
+	@Test
+	public void exceptionCausedByNotIncludingFHIRHelpers() {
+		boolean failed = false;
+		Path cqlFile = Paths.get("src/test/resources/cql/failure/exception.cql");
+		try (InputStream is = Files.newInputStream(cqlFile)) {
+			getTranslator().translate(is);
+		}
+		catch (Exception e) {
+			failed = true;
+			Assert.assertTrue(
+					"Unexpected exception message",
+					e.getMessage().startsWith("CQL translation contained exceptions")
+			);
+		}
+		if (!failed) {
+			Assert.fail("Did not fail translation");
+		}
+	}
 	
 	private Library getById(List<Library> libraries, String libraryName) {
 		Library library = null;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/translation/CqlTranslatorProviderTest.java
@@ -9,9 +9,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +28,7 @@ import org.cqframework.cql.cql2elm.CqlTranslator.Options;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
 import org.cqframework.cql.elm.execution.Library;
 import org.hl7.cql_annotations.r1.CqlToElmInfo;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.cohort.engine.LibraryUtils;
@@ -113,6 +116,25 @@ public abstract class CqlTranslatorProviderTest {
 		assertTrue( o instanceof CqlToElmInfo );
 		CqlToElmInfo info = (CqlToElmInfo) o;
 		assertEquals("EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion", info.getTranslatorOptions());
+	}
+
+	@Test
+	public void errorCausedByInvalidContent() {
+		boolean failed = false;
+		String content = "junk";
+		try (InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
+			getTranslator().translate(is);
+		}
+		catch (Exception e) {
+			failed = true;
+			Assert.assertTrue(
+					"Unexpected exception message",
+					e.getMessage().startsWith("CQL translation contained errors")
+			);
+		}
+		if (!failed) {
+			Assert.fail("Did not fail translation");
+		}
 	}
 	
 	private Library getById(List<Library> libraries, String libraryName) {

--- a/cohort-engine/src/test/resources/cql/failure/exception.cql
+++ b/cohort-engine/src/test/resources/cql/failure/exception.cql
@@ -1,0 +1,11 @@
+library "exception" version '1.0.0'
+using "FHIR" version '4.0.0'
+
+// Intentionally omitting FHIRHelpers to force an exception
+//include FHIRHelpers version '4.0.0'
+
+valueset "vs" : 'http://some.io/condition'
+
+context Patient
+define "cohort":
+	["Condition":"vs"]


### PR DESCRIPTION
Pretty simple change.  Added an "error" and "exception" test case.
The only "exception only" test case I have run into is not including `FHIRHelpers` when it's needed.
This change actually revealed that one of our test measures did not include `FHIRHelpers` when it should have.