### PR TITLE
Allow non-semantic version strings for resources

### DIFF
--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/ResourceResolutionProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/ResourceResolutionProviderTest.java
@@ -161,6 +161,23 @@ public class ResourceResolutionProviderTest extends BaseFhirTest {
 		assertNotNull(actual);
 		assertEquals(expected, actual);
 	}
+
+	@Test
+	public void when_resolve_by_name_with_version_single_result___return_single_result() {
+
+		Measure expected = getMeasure( "MyTestMeasure", "9.5.zzzzz", "my_identifier" );
+		provider.processResource("MyTestMeasure-9.5.zzzzz.json", expected);
+
+		Measure other = getMeasure( "MyTestMeasure", "1.0.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.0.0.json", other);
+
+		other = getMeasure( "MyTestMeasure", "1.2.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.2.0.json", other);
+
+		Measure actual = provider.resolveMeasureByName("MyTestMeasure", "9.5.zzzzz");
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+	}
 	
 	protected Measure getMeasure( String name, String version, String identifier ) {
 		Measure expected = new Measure();

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/ResourceResolutionProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/ResourceResolutionProviderTest.java
@@ -131,6 +131,36 @@ public class ResourceResolutionProviderTest extends BaseFhirTest {
 				new Identifier().setSystem("my_system").setValue("my_identifier"), "10.0.0");
 		assertNull(actual);
 	}
+
+	@Test
+	public void when_resolve_by_name_with_version_none_matched___null_is_returned() {
+
+		Measure other = getMeasure( "MyTestMeasure", "1.0.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.0.0.json", other);
+
+		other = getMeasure( "MyTestMeasure", "1.2.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.2.0.json", other);
+
+		Measure actual = provider.resolveMeasureByName("Other", null);
+		assertNull(actual);
+	}
+
+	@Test
+	public void when_resolve_by_name_with_version_multiple_result___latest_semantic_version_returned() {
+
+		Measure expected = getMeasure( "MyTestMeasure", "1.2.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.2.0.json", expected);
+
+		Measure other = getMeasure( "MyTestMeasure", "1.0.0", "my_identifier" );
+		provider.processResource("MyTestMeasure-1.0.0.json", other);
+
+		other = getMeasure( "MyTestMeasure", "9.5.zzzzz", "my_identifier" );
+		provider.processResource("MyTestMeasure-9.5.zzzzz.json", other);
+
+		Measure actual = provider.resolveMeasureByName("MyTestMeasure", null);
+		assertNotNull(actual);
+		assertEquals(expected, actual);
+	}
 	
 	protected Measure getMeasure( String name, String version, String identifier ) {
 		Measure expected = new Measure();

--- a/cohort-util/src/main/java/com/ibm/cohort/version/SemanticVersion.java
+++ b/cohort-util/src/main/java/com/ibm/cohort/version/SemanticVersion.java
@@ -14,6 +14,7 @@ import com.ibm.cohort.annotations.Generated;
 
 public class SemanticVersion implements Comparable<SemanticVersion> {
 	private static final Pattern SEMANTIC_VERSION_PATTERN = Pattern.compile("^(?<major>0|[1-9]\\d*)\\.(?<minor>0|[1-9]\\d*)\\.(?<patch>0|[1-9]\\d*)");
+	private static final char SEPARATOR = '.';
 
 	public static Optional<SemanticVersion> create(String version) {
 		if (version != null) {
@@ -85,5 +86,18 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
 		} else {
 			return this.patch - o.patch;
 		}
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(this.major);
+		sb.append(SEPARATOR);
+		sb.append(this.minor);
+		sb.append(SEPARATOR);
+		sb.append(this.patch);
+
+		return sb.toString();
 	}
 }

--- a/cohort-util/src/test/java/com/ibm/cohort/version/SemanticVersionTest.java
+++ b/cohort-util/src/test/java/com/ibm/cohort/version/SemanticVersionTest.java
@@ -8,6 +8,7 @@ package com.ibm.cohort.version;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Optional;
@@ -59,5 +60,13 @@ public class SemanticVersionTest {
 		assertEquals(0, version1_9_9.compareTo(new SemanticVersion(1, 9, 9)));
 		assertEquals(0, version3_1_0.compareTo(new SemanticVersion(3, 1, 0)));
 
+	}
+
+	@Test
+	public void testToString() {
+		SemanticVersion semanticVersion = SemanticVersion.create("1.2.3").orElse(null);
+
+		assertNotNull(semanticVersion);
+		assertEquals("1.2.3", semanticVersion.toString());
 	}
 }


### PR DESCRIPTION
Change logic in ResourceResolutionProvider.java to index resources no matter the version string (previously threw an error if version was not a semantic version).

When retrieving resources and not providing a version to use during the retrieval, only consider resources with semantic versions when calculating the latest version. When a version is provided, attempt an exact match using the provided version.