### PR TITLE
Wffhcohort 435 - Search parameter caching

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/MeasureCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/MeasureCLI.java
@@ -46,6 +46,7 @@ import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.measure.evidence.MeasureEvidenceOptions;
 import com.ibm.cohort.engine.measure.evidence.MeasureEvidenceOptions.DefineReturnOptions;
 import com.ibm.cohort.engine.r4.cache.CachingR4FhirModelResolver;
+import com.ibm.cohort.engine.r4.cache.CachingSearchParameterResolver;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 
@@ -179,7 +180,7 @@ public class MeasureCLI extends BaseCLI {
 
 			TerminologyProvider terminologyProvider = new R4RestFhirTerminologyProvider(terminologyServerClient);
 			try (RetrieveCacheContext retrieveCacheContext = arguments.disableRetrieveCache ? null : new DefaultRetrieveCacheContext()) {
-				Map<String, DataProvider> dataProviders = R4DataProviderFactory.createDataProviderMap(dataServerClient, terminologyProvider, retrieveCacheContext, new CachingR4FhirModelResolver(), ! arguments.enableTerminologyOptimization, arguments.searchPageSize);
+				Map<String, DataProvider> dataProviders = R4DataProviderFactory.createDataProviderMap(dataServerClient, terminologyProvider, retrieveCacheContext, new CachingR4FhirModelResolver(), new CachingSearchParameterResolver(dataServerClient.getFhirContext()), ! arguments.enableTerminologyOptimization, arguments.searchPageSize);
 
 				evaluator = new MeasureEvaluator(measureProvider, libraryProvider, terminologyProvider, dataProviders);
 

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -47,6 +47,7 @@ import com.ibm.cohort.engine.measure.ZipResourceResolutionProvider;
 import com.ibm.cohort.engine.measure.cache.DefaultRetrieveCacheContext;
 import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.r4.cache.CachingR4FhirModelResolver;
+import com.ibm.cohort.engine.r4.cache.CachingSearchParameterResolver;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
 import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
@@ -306,7 +307,7 @@ public class CohortEngineRestHandler {
 					searchPageSize = R4DataProviderFactory.DEFAULT_PAGE_SIZE;
 				}
 				
-				Map<String, DataProvider> dataProviders = R4DataProviderFactory.createDataProviderMap(dataClient, terminologyProvider, retrieveCacheContext, new CachingR4FhirModelResolver(), expandValueSets, searchPageSize);
+				Map<String, DataProvider> dataProviders = R4DataProviderFactory.createDataProviderMap(dataClient, terminologyProvider, retrieveCacheContext, new CachingR4FhirModelResolver(), new CachingSearchParameterResolver(dataClient.getFhirContext()), expandValueSets, searchPageSize);
 				
 				MeasureEvaluator evaluator = new MeasureEvaluator(provider, provider, terminologyProvider, dataProviders);
 				

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
@@ -32,6 +32,7 @@ import com.ibm.cohort.engine.cdm.CDMConstants;
 import com.ibm.cohort.engine.cqfruler.CDMContext;
 import com.ibm.cohort.engine.parameter.Parameter;
 import com.ibm.cohort.engine.r4.cache.CachingR4FhirModelResolver;
+import com.ibm.cohort.engine.r4.cache.CachingSearchParameterResolver;
 import com.ibm.cohort.engine.retrieve.R4RestFhirRetrieveProvider;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
@@ -317,7 +318,7 @@ public class CqlEvaluator {
 	 * @return Map of supported model URL to data provider
 	 */
 	protected Map<String, DataProvider> getDataProviders(TerminologyProvider terminologyProvider) {
-		SearchParameterResolver resolver = new SearchParameterResolver(this.dataServerClient.getFhirContext());
+		SearchParameterResolver resolver = new CachingSearchParameterResolver(this.dataServerClient.getFhirContext());
 		R4RestFhirRetrieveProvider retrieveProvider = new R4RestFhirRetrieveProvider(resolver, this.dataServerClient);
 		retrieveProvider.setTerminologyProvider(terminologyProvider);
 		//Ideally, we would determine this using the FHIR CapabilityStatement, but there isn't a strongly

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4DataProviderFactory.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4DataProviderFactory.java
@@ -55,7 +55,7 @@ public class R4DataProviderFactory {
 			boolean isExpandValueSets,
 			Integer pageSize
 	) {
-		return createDataProviderMap(client, terminologyProvider, retrieveCacheContext, new R4FhirModelResolver(), isExpandValueSets, pageSize);
+		return createDataProviderMap(client, terminologyProvider, retrieveCacheContext, new R4FhirModelResolver(), new SearchParameterResolver(client.getFhirContext()), isExpandValueSets, pageSize);
 	}
 	
 	public static Map<String, DataProvider> createDataProviderMap(
@@ -63,11 +63,11 @@ public class R4DataProviderFactory {
 			TerminologyProvider terminologyProvider,
 			RetrieveCacheContext retrieveCacheContext,
 			R4FhirModelResolver modelResolver,
+			SearchParameterResolver searchParameterResolver,
 			boolean isExpandValueSets,
 			Integer pageSize
 	) {
-		SearchParameterResolver resolver = new SearchParameterResolver(client.getFhirContext());
-		R4RestFhirRetrieveProvider baseRetrieveProvider = new R4RestFhirRetrieveProvider(resolver, client);
+		R4RestFhirRetrieveProvider baseRetrieveProvider = new R4RestFhirRetrieveProvider(searchParameterResolver, client);
 		baseRetrieveProvider.setExpandValueSets(isExpandValueSets);
 		baseRetrieveProvider.setSearchPageSize(pageSize);
 		baseRetrieveProvider.setTerminologyProvider(terminologyProvider);

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4MeasureEvaluatorBuilder.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4MeasureEvaluatorBuilder.java
@@ -13,10 +13,14 @@ import org.hl7.fhir.r4.model.Measure;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
 import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
+import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 
 import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 
 /**
  * A builder intended to allow for easy creation of {@link MeasureEvaluator} instances tailored for use
@@ -29,6 +33,7 @@ public class R4MeasureEvaluatorBuilder {
 	private boolean isExpandValueSets = R4DataProviderFactory.DEFAULT_IS_EXPAND_VALUE_SETS;
 	private Integer pageSize = R4DataProviderFactory.DEFAULT_PAGE_SIZE;
 	private R4FhirModelResolver modelResolver = new R4FhirModelResolver();
+	private SearchParameterResolver searchParameterResolver = new SearchParameterResolver(FhirContext.forCached(FhirVersionEnum.R4));
 
 	public R4MeasureEvaluatorBuilder withClientContext(FHIRClientContext value) {
 		this.clientContext = value;
@@ -54,6 +59,11 @@ public class R4MeasureEvaluatorBuilder {
 		this.modelResolver = modelResolver;
 		return this;
 	}
+	
+	public R4MeasureEvaluatorBuilder withSearchParameterResolver(SearchParameterResolver searchParameterResolver) {
+		this.searchParameterResolver = searchParameterResolver;
+		return this;
+	}
 
 	public MeasureEvaluator build() {
 		if (clientContext == null) {
@@ -66,6 +76,7 @@ public class R4MeasureEvaluatorBuilder {
 				terminologyProvider,
 				cacheContext,
 				modelResolver,
+				searchParameterResolver,
 				isExpandValueSets,
 				pageSize
 		);

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolver.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolver.java
@@ -1,0 +1,129 @@
+package com.ibm.cohort.engine.r4.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.cache.Cache;
+import javax.cache.Caching;
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+
+import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
+
+public class CachingSearchParameterResolver extends SearchParameterResolver {
+	
+	private FhirContext context;
+
+	private static final String CACHE_ID = "default-search-parameter-normalized-path-cache";
+
+	private static CompleteConfiguration<String, String> getDefaultConfiguration() {
+		return new MutableConfiguration<String, String>()
+				.setStoreByValue(false);
+	}
+
+	private static final Cache<String, String> CACHE = Caching.getCachingProvider().getCacheManager().createCache(CACHE_ID, getDefaultConfiguration());
+
+	public CachingSearchParameterResolver(FhirContext context) {
+		super(context);
+		this.context = context;
+	}
+
+	public RuntimeSearchParam getSearchParameterDefinition(String dataType, String path, RestSearchParameterTypeEnum paramType) {
+		if (dataType == null || path == null) {
+			return null;
+		}
+
+		// Special case for system params. They need to be resolved by name.
+		// TODO: All the others like "_language"
+		String name = null;
+		if (path.equals("id")) {
+			name = "_id";
+			path = "";
+		}
+
+		List<RuntimeSearchParam> params = this.context.getResourceDefinition(dataType).getSearchParams();
+
+		for (RuntimeSearchParam param : params) {
+			// If name matches, it's the one we want.
+			if (name != null && param.getName().equals(name))
+			{
+				return param;
+			}
+
+			// Filter out parameters that don't match our requested type.
+			if (paramType != null && !param.getParamType().equals(paramType)) {
+				continue;
+			}
+
+			// Short circuit if path is in the cache
+			String paramPath = param.getPath();
+			String normalizedPath = CACHE.get(paramPath);
+			if(normalizedPath == null) {
+				normalizedPath = normalizePath(paramPath);
+				CACHE.put(paramPath, normalizedPath);
+
+			}
+
+			if (path.equals(normalizedPath) ) {
+				return param;
+			}
+		}
+
+		return null;
+	}
+
+	protected String normalizePath(String path) {
+		// Copied code overwrites `path`. Save the initial value for caching later.
+		String pathArgument = path;
+
+		// TODO: What we really need is FhirPath parsing to just get the path
+		//MedicationAdministration.medication.as(CodeableConcept)
+		//MedicationAdministration.medication.as(Reference)
+		//(MedicationAdministration.medication as CodeableConcept)
+		//(MedicationAdministration.medication as Reference)
+
+		// Trim off outer parens
+		if (path.equals("(")) {
+			path = path.substring(1, path.length() - 1);
+		}
+
+		// Trim off DataType
+		path = path.substring(path.indexOf(".") + 1, path.length());
+
+
+		// Split into components
+		String[] pathSplit = path.split("\\.");
+		List<String> newPathParts = new ArrayList<>();
+
+		for (String p : pathSplit) {
+			// Skip the "as(X)" part.
+			if (p.startsWith("as(")) {
+				continue;
+			}
+
+			// Skip the "[x]" part.
+			if (p.startsWith("[x]")) {
+				continue;
+			}
+
+			// Filter out spaces and everything after "medication as Reference"
+			String[] ps = p.split(" ");
+			if (ps != null && ps.length > 0){
+				newPathParts.add(ps[0]);
+			}
+		}
+
+		path = String.join(".", newPathParts);
+		
+		return path;
+
+	}
+	
+	protected static void clearCache() {
+		CACHE.clear();
+	}
+}

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolver.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolver.java
@@ -32,6 +32,7 @@ public class CachingSearchParameterResolver extends SearchParameterResolver {
 		this.context = context;
 	}
 
+	@Override
 	public RuntimeSearchParam getSearchParameterDefinition(String dataType, String path, RestSearchParameterTypeEnum paramType) {
 		if (dataType == null || path == null) {
 			return null;
@@ -77,9 +78,6 @@ public class CachingSearchParameterResolver extends SearchParameterResolver {
 	}
 
 	protected String normalizePath(String path) {
-		// Copied code overwrites `path`. Save the initial value for caching later.
-		String pathArgument = path;
-
 		// TODO: What we really need is FhirPath parsing to just get the path
 		//MedicationAdministration.medication.as(CodeableConcept)
 		//MedicationAdministration.medication.as(Reference)
@@ -120,7 +118,6 @@ public class CachingSearchParameterResolver extends SearchParameterResolver {
 		path = String.join(".", newPathParts);
 		
 		return path;
-
 	}
 	
 	protected static void clearCache() {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolverTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/r4/cache/CachingSearchParameterResolverTest.java
@@ -1,0 +1,33 @@
+package com.ibm.cohort.engine.r4.cache;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.context.RuntimeSearchParam;
+import ca.uhn.fhir.rest.api.RestSearchParameterTypeEnum;
+
+public class CachingSearchParameterResolverTest {
+	@Before
+	public void clearCache() {
+		CachingSearchParameterResolver.clearCache();
+	}
+
+	@Test
+	public void testgetSearchParameterDefinition_usesCachedResponse() {
+		CachingSearchParameterResolver resolver = spy(new CachingSearchParameterResolver(FhirContext.forCached(FhirVersionEnum.R4)));
+
+		RuntimeSearchParam searchParameterDefinitionOrig = resolver.getSearchParameterDefinition("Location", "address", RestSearchParameterTypeEnum.STRING);
+		RuntimeSearchParam searchParameterDefinitionSecond = resolver.getSearchParameterDefinition("Location", "address", RestSearchParameterTypeEnum.STRING);
+
+		verify(resolver, times(1)).normalizePath("Location.address");
+		assertEquals(searchParameterDefinitionOrig, searchParameterDefinitionSecond);
+	}
+}


### PR DESCRIPTION
Work in progress for search parameter caching.

I copy pasted methods and overwrote some of them. I'd like a better way to handle the FhirContext in `CachingSearchParameterResolver`,  but didn't have any great ideas initially since the context is private in the parent class.