### PR TITLE
apply expression cache clear patch from cql-ruler

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
@@ -13,10 +13,12 @@
 
 package com.ibm.cohort.engine.cqfruler;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,7 +50,7 @@ public class MeasureEvaluation {
     private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluation.class);
 
     public static final String PATIENT = "Patient";
-    
+
     private DataProvider provider;
     private Interval measurementPeriod;
 
@@ -60,7 +62,7 @@ public class MeasureEvaluation {
     public MeasureReport evaluatePatientMeasure(Measure measure, Context context, String patientId) {
     	return evaluatePatientMeasure(measure, context, patientId, false);
     }
-    
+
     public MeasureReport evaluatePatientMeasure(Measure measure, Context context, String patientId, boolean includeEvaluatedResources) {
         logger.info("Generating individual report");
 
@@ -90,6 +92,8 @@ public class MeasureEvaluation {
 
         context.setContextValue(PATIENT, patient.getIdElement().getIdPart());
 
+        clearExpressionCache(context);
+
         ExpressionDef populationExpressionDef = context.resolveExpressionRef(pop.getCriteria().getExpression());
         Object result = populationExpressionDef.evaluate(context);
         
@@ -107,6 +111,21 @@ public class MeasureEvaluation {
 
         return (Iterable<Resource>) result;
     }
+
+	@SuppressWarnings("unchecked")
+	private void clearExpressionCache(Context context) {
+		// Hack to clear expression cache
+		// See cqf-ruler github issue #153
+		try {
+			Field privateField = context.getClass().getDeclaredField("expressions");
+			privateField.setAccessible(true);
+			LinkedHashMap expressions = (LinkedHashMap) privateField.get(context);
+			expressions.clear();
+
+		} catch (Exception e) {
+			logger.warn("Error resetting expression cache", e);
+		}
+	}
 
     private boolean evaluatePopulationCriteria(Context context, Patient patient,
             Measure.MeasureGroupPopulationComponent criteria, Map<String, Resource> population,

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
@@ -111,7 +111,7 @@ public class MeasureEvaluation {
     }
 
 	@SuppressWarnings("unchecked")
-	private void clearExpressionCache(Context context) {
+	protected void clearExpressionCache(Context context) {
 		// Hack to clear expression cache
 		// See cqf-ruler github issue #153
 		try {
@@ -125,7 +125,7 @@ public class MeasureEvaluation {
 		}
 	}
 
-    private boolean evaluatePopulationCriteria(Context context, Patient patient,
+    protected boolean evaluatePopulationCriteria(Context context, Patient patient,
             Measure.MeasureGroupPopulationComponent criteria, Map<String, Resource> population,
             Map<String, Patient> populationPatients, Measure.MeasureGroupPopulationComponent exclusionCriteria,
             Map<String, Resource> exclusionPopulation, Map<String, Patient> exclusionPatients) {
@@ -186,7 +186,7 @@ public class MeasureEvaluation {
         }
     }
 
-    private MeasureReport evaluate(Measure measure, Context context, List<Patient> patients,
+    protected MeasureReport evaluate(Measure measure, Context context, List<Patient> patients,
             MeasureReport.MeasureReportType type, boolean isSingle, boolean includeEvaluatedResources) {
         MeasureReportBuilder reportBuilder = new MeasureReportBuilder();
         reportBuilder.buildStatus("complete");
@@ -428,7 +428,7 @@ public class MeasureEvaluation {
         return report;
     }
 
-    private void populateResourceMap(Context context, MeasurePopulationType type, Map<String, Resource> resources,
+    protected void populateResourceMap(Context context, MeasurePopulationType type, Map<String, Resource> resources,
             Map<String, Set<String>> codeToResourceMap, boolean includeEvaluatedResources) {
         if (context.getEvaluatedResources().isEmpty()) {
             return;

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluation.java
@@ -92,8 +92,6 @@ public class MeasureEvaluation {
 
         context.setContextValue(PATIENT, patient.getIdElement().getIdPart());
 
-        clearExpressionCache(context);
-
         ExpressionDef populationExpressionDef = context.resolveExpressionRef(pop.getCriteria().getExpression());
         Object result = populationExpressionDef.evaluate(context);
         
@@ -302,6 +300,7 @@ public class MeasureEvaluation {
 
                     // For each patient in the initial population
                     for (Patient patient : patients) {
+                        clearExpressionCache(context);
                         // Are they in the initial population?
                         boolean inInitialPopulation = evaluatePopulationCriteria(context, patient,
                                 initialPopulationCriteria, initialPopulation, initialPopulationPatients, null, null,
@@ -362,6 +361,7 @@ public class MeasureEvaluation {
 
                     // For each patient in the patient list
                     for (Patient patient : patients) {
+                        clearExpressionCache(context);
                         evaluatePopulationCriteria(context, patient,
                                 initialPopulationCriteria, initialPopulation, initialPopulationPatients, null, null,
                                 null);

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluationTest.java
@@ -1,0 +1,49 @@
+package com.ibm.cohort.engine.cqfruler;
+
+import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportType.SUBJECTLIST;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.opencds.cqf.common.evaluation.MeasureScoring.PROPORTION;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.cqframework.cql.elm.execution.Library;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Measure;
+import org.hl7.fhir.r4.model.Patient;
+import org.junit.Test;
+import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.execution.Context;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+public class MeasureEvaluationTest {
+	@Test
+	public void testCacheCleared() {
+		DataProvider provider = mock(DataProvider.class);
+		Interval period = mock(Interval.class);
+
+		MeasureEvaluation evaluation = spy(new MeasureEvaluation(provider, period));
+		doReturn(true).when(evaluation).evaluatePopulationCriteria(any(), any(), any(), any(), any(), any(), any(), any());
+
+		List<Patient> patients = new ArrayList<>();
+		patients.add(new Patient());
+		patients.add(new Patient());
+
+		Measure measure = new Measure();
+		measure.setScoring(new CodeableConcept().addCoding(new Coding().setCode(PROPORTION.toCode())));
+		Measure.MeasureGroupComponent group = new Measure.MeasureGroupComponent();
+		measure.setGroup(Collections.singletonList(group));
+
+		Context context = new Context(new Library());
+		evaluation.evaluate(measure, context, patients, SUBJECTLIST, false, false);
+
+		verify(evaluation, times(2)).clearExpressionCache(any());
+	}
+}


### PR DESCRIPTION
ports over the changes in [DBCG/cqf-ruler#154](https://github.com/DBCG/cqf-ruler/pull/154/files#diff-2ba2e6fa2865691c2557d753dd53f08a88e3294d3cb84f70f6a5f66119efc8f3)

not exactly sure this is the best way to handle this,
but with so much code being copied over, this was the least intrusive change.

---

as Corey mentioned, the ability to use `setAccessible` won't work going into java 11,
so I also opened up a PR in https://github.com/DBCG/cql_engine/pull/494 to expose that functionality.

---

## todo
- [x] add unit test case