### PR TITLE
explicitly specify provider versions to avoid being broken when a newer

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -16,6 +16,14 @@ terraform {
       source  = "ibm-cloud/ibm"
       version = "~> 1.25.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.3.2"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 3.1.0"
+    }
   }
 }
 


### PR DESCRIPTION
version is published that doesn't work with the backlevel version of
terraform the toolchains are using