### PR TITLE
API updates for CqlEvaluator and ELM deserialization

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/TranslationCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/TranslationCLI.java
@@ -18,6 +18,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.DefaultConsole;
 import com.ibm.cohort.engine.DirectoryLibrarySourceProvider;
+import com.ibm.cohort.engine.elm.execution.OptimizedCqlLibraryReader;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
 import com.ibm.cohort.translator.provider.InJVMCqlTranslationProvider;
 
@@ -54,7 +55,7 @@ public class TranslationCLI {
 			provider.convertAndRegisterModelInfo(options.modelInfoFile);
 		}
 
-		Library library = provider.translate(new FileInputStream(new File(options.cqlPath)));
+		Library library = OptimizedCqlLibraryReader.read(provider.translate(new FileInputStream(new File(options.cqlPath))));
 
 		out.println("Translated Library: ");
 		out.println(library.toString());

--- a/cohort-engine/pom.xml
+++ b/cohort-engine/pom.xml
@@ -31,17 +31,17 @@
 			<artifactId>cohort-util</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>info.cqframework</groupId>
 			<artifactId>elm</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>info.cqframework</groupId>
 			<artifactId>cql-to-elm</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
@@ -51,27 +51,27 @@
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine.fhir</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.r4</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>org.hl7.fhir.utilities</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.opencds.cqf</groupId>
 			<artifactId>common</artifactId>
@@ -86,12 +86,12 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>javax.cache</groupId>
 			<artifactId>cache-api</artifactId>
@@ -102,37 +102,44 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>xpp3</groupId>
+			<artifactId>xpp3</artifactId>
+			<version>1.1.4c</version>
+		</dependency>
 
 		<!-- Runtime dependencies -->
-		
+
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-r4</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		
+
+
+
 		<!-- Test dependencies -->
-		
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -167,18 +174,18 @@
 			<artifactId>jcache</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>javax.validation</groupId>
 			<artifactId>validation-api</artifactId>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-validator</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>org.glassfish</groupId>
 			<artifactId>javax.el</artifactId>
@@ -218,7 +225,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>	
+			</plugin>
 		</plugins>
 	</build>
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/CqlEvaluator.java
@@ -470,15 +470,41 @@ public class CqlEvaluator {
 	 * @param contextIds     list of contexts (generally patient IDs) for which the
 	 *                       specified <code>expressions</code> will be executed. At
 	 *                       least one value is required.
-	 * @param enableLogging  The level of logging enabled, either TRACE, COVERAGE, or NA
+	 * @param logLevel       The level of logging enabled, either TRACE, COVERAGE, or NA
 	 *
 	 * @param callback       callback function for receiving engine execution events
 	 */
 	public void evaluate(String libraryName, String libraryVersion, Map<String, Parameter> parameters,
-			Set<String> expressions, List<String> contextIds, LoggingEnum enableLogging, EvaluationResultCallback callback) {
-		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds, enableLogging, callback);
+			Set<String> expressions, List<String> contextIds, LoggingEnum logLevel, EvaluationResultCallback callback) {
+		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds, logLevel, callback);
 	}
 
+	/**
+	 * Execute the given <code>libraryName</code> for each context id specified in
+	 * <code>contextIds</code> using a FHIR R4 data provider and FHIR R4 terminology
+	 * provider. Library content and FHIR server configuration data should be
+	 * configured prior to invoking this method.
+	 * 
+	 * @param libraryName    Library identifier
+	 * @param libraryVersion Library version (optional/null)
+	 * @param parameters     parameter values for required input parameters in the
+	 *                       CQL (optional/null)
+	 * @param expressions    list of defines to be executed from the specified
+	 *                       <code>libraryName</code> (optional/null). When not
+	 *                       provided, all defines in the library will be executed.
+	 * @param contextIds     list of contexts (generally patient IDs) for which the
+	 *                       specified <code>expressions</code> will be executed. At
+	 *                       least one value is required.
+	 * @param logLevel       The level of logging enabled, either TRACE, COVERAGE, or NA
+	 * @param callback       callback function to be evaluated once per context per
+	 *                       executed define
+	 */
+	public void evaluate(String libraryName, String libraryVersion, Map<String, Parameter> parameters,
+			Set<String> expressions, List<String> contextIds, LoggingEnum logLevel, ExpressionResultCallback callback) {
+		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds,
+				logLevel, new ProxyingEvaluationResultCallback(callback));
+	}
+	
 	/**
 	 * Execute the given <code>libraryName</code> for each context id specified in
 	 * <code>contextIds</code> using a FHIR R4 data provider and FHIR R4 terminology
@@ -500,7 +526,32 @@ public class CqlEvaluator {
 	 */
 	public void evaluate(String libraryName, String libraryVersion, Map<String, Parameter> parameters,
 			Set<String> expressions, List<String> contextIds, ExpressionResultCallback callback) {
-		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters, expressions, contextIds,
+		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters,
+				expressions, contextIds,
 				new ProxyingEvaluationResultCallback(callback));
+	}
+	
+	/**
+	 * Execute the given <code>libraryName</code> for each context id specified in
+	 * <code>contextIds</code> using a FHIR R4 data provider and FHIR R4 terminology
+	 * provider. Library content and FHIR server configuration data should be
+	 * configured prior to invoking this method.
+	 * 
+	 * @param libraryName    Library identifier
+	 * @param libraryVersion Library version (optional/null)
+	 * @param parameters     parameter values for required input parameters in the
+	 *                       CQL (optional/null)
+	 * @param expressions    list of defines to be executed from the specified
+	 *                       <code>libraryName</code> (optional/null). When not
+	 *                       provided, all defines in the library will be executed.
+	 * @param contextIds     list of contexts (generally patient IDs) for which the
+	 *                       specified <code>expressions</code> will be executed. At
+	 *                       least one value is required.
+	 * @param callback       callback function for receiving engine execution events
+	 */
+	public void evaluate(String libraryName, String libraryVersion, Map<String, Parameter> parameters,
+			Set<String> expressions, List<String> contextIds, EvaluationResultCallback callback) {
+		evaluateWithEngineWrapper(libraryName, libraryVersion, parameters,
+				expressions, contextIds, callback);
 	}
 }

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/TranslatingLibraryLoader.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/TranslatingLibraryLoader.java
@@ -17,6 +17,7 @@ import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ibm.cohort.engine.elm.execution.OptimizedCqlLibraryReader;
 import com.ibm.cohort.file.LibraryFormat;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
 
@@ -82,7 +83,7 @@ public class TranslatingLibraryLoader implements LibraryLoader {
 					String is = provider.getLibrarySource(translatorVersionedId, LibraryFormat.CQL);
 					if (is != null) {
 						logger.debug("Translating \"{}\" version '{}'", translatorVersionedId.getId(), translatorVersionedId.getVersion());
-						library = translator.translate(is);
+						library = OptimizedCqlLibraryReader.read( translator.translate(is) );
 						assert library.getIdentifier().getId() != null;
 					} else {
 						throw new IllegalArgumentException(String.format("No library source found for \"%s\" version '%s'",

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/OptimizedCqlLibraryReader.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/OptimizedCqlLibraryReader.java
@@ -5,7 +5,7 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
 import java.io.StringReader;
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/OptimizedObjectFactory.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/OptimizedObjectFactory.java
@@ -5,7 +5,7 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlElementDecl;

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/ShortAndEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/ShortAndEvaluator.java
@@ -5,13 +5,13 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.Or;
-import org.opencds.cqf.cql.engine.elm.execution.OrEvaluator;
+import org.cqframework.cql.elm.execution.And;
+import org.opencds.cqf.cql.engine.elm.execution.AndEvaluator;
 import org.opencds.cqf.cql.engine.execution.Context;
 
-public class ShortOrEvaluator extends Or {
+public class ShortAndEvaluator extends And {
 
     @Override
     protected Object internalEvaluate(Context context) {
@@ -19,19 +19,19 @@ public class ShortOrEvaluator extends Or {
 
         Boolean right;
         if (left == null) {
-	        // Evaluate to be consistent with base logic
+            // Evaluate to be consistent with base logic
             right = getValue(1, context);
         }
         else if (left) {
-            // Default to false because left is already true
+            right = getValue(1, context);
+        }
+        else {
+            // Default to false because left is already false
             // thus we don't care about the result of right.
             right = Boolean.FALSE;
         }
-        else {
-            right = getValue(1, context);
-        }
 
-        return OrEvaluator.or(left, right);
+        return AndEvaluator.and(left, right);
     }
 
     protected Boolean getValue(int idx, Context context) {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/ShortOrEvaluator.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/elm/execution/ShortOrEvaluator.java
@@ -5,13 +5,13 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
-import org.cqframework.cql.elm.execution.And;
-import org.opencds.cqf.cql.engine.elm.execution.AndEvaluator;
+import org.cqframework.cql.elm.execution.Or;
+import org.opencds.cqf.cql.engine.elm.execution.OrEvaluator;
 import org.opencds.cqf.cql.engine.execution.Context;
 
-public class ShortAndEvaluator extends And {
+public class ShortOrEvaluator extends Or {
 
     @Override
     protected Object internalEvaluate(Context context) {
@@ -19,19 +19,19 @@ public class ShortAndEvaluator extends And {
 
         Boolean right;
         if (left == null) {
-            // Evaluate to be consistent with base logic
+	        // Evaluate to be consistent with base logic
             right = getValue(1, context);
         }
         else if (left) {
-            right = getValue(1, context);
-        }
-        else {
-            // Default to false because left is already false
+            // Default to false because left is already true
             // thus we don't care about the result of right.
             right = Boolean.FALSE;
         }
+        else {
+            right = getValue(1, context);
+        }
 
-        return AndEvaluator.and(left, right);
+        return OrEvaluator.or(left, right);
     }
 
     protected Boolean getValue(int idx, Context context) {

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryLoader.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/LibraryLoader.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.r4.model.Attachment;
 import org.opencds.cqf.common.providers.LibraryResolutionProvider;
 import org.opencds.cqf.cql.engine.execution.CqlLibraryReader;
 
+import com.ibm.cohort.engine.elm.execution.OptimizedCqlLibraryReader;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
 
 
@@ -92,7 +93,7 @@ public class LibraryLoader implements org.opencds.cqf.cql.engine.execution.Libra
 								libraryIdentifier.getId(), libraryIdentifier.getVersion()));
 			} else {
 				try {
-					elmLibrary = translationProvider.translate(getAttachmentData(attachment));
+					elmLibrary = OptimizedCqlLibraryReader.read(translationProvider.translate(getAttachmentData(attachment)));
 				} catch (Exception ex) {
 					throw new IllegalArgumentException(
 							String.format("Library %s-%s cql attachment failed to deserialize",

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/DirectoryLibrarySourceProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/DirectoryLibrarySourceProviderTest.java
@@ -15,6 +15,7 @@ import org.cqframework.cql.elm.execution.Library;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.junit.Test;
 
+import com.ibm.cohort.engine.elm.execution.OptimizedCqlLibraryReader;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
 import com.ibm.cohort.translator.provider.InJVMCqlTranslationProvider;
 
@@ -27,7 +28,7 @@ public class DirectoryLibrarySourceProviderTest {
 			assertNotNull( is );
 			
 			CqlTranslationProvider tx = new InJVMCqlTranslationProvider();
-			Library library = tx.translate( is );
+			Library library = OptimizedCqlLibraryReader.read( tx.translate( is ) );
 			assertEquals( "Test", library.getIdentifier().getId() );
 		}
 	}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/ZipStreamLibrarySourceProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/ZipStreamLibrarySourceProviderTest.java
@@ -17,6 +17,7 @@ import org.cqframework.cql.elm.execution.Library;
 import org.hl7.elm.r1.VersionedIdentifier;
 import org.junit.Test;
 
+import com.ibm.cohort.engine.elm.execution.OptimizedCqlLibraryReader;
 import com.ibm.cohort.translator.provider.CqlTranslationProvider;
 import com.ibm.cohort.translator.provider.InJVMCqlTranslationProvider;
 
@@ -31,7 +32,7 @@ public class ZipStreamLibrarySourceProviderTest {
 				assertNotNull( is );
 
 				CqlTranslationProvider tx = new InJVMCqlTranslationProvider();
-				Library library = tx.translate( is );
+				Library library = OptimizedCqlLibraryReader.read( tx.translate( is ) );
 				assertEquals( "BreastCancerScreening", library.getIdentifier().getId() );
 			}
 		}
@@ -46,7 +47,7 @@ public class ZipStreamLibrarySourceProviderTest {
 				assertNotNull( is );
 				
 				CqlTranslationProvider tx = new InJVMCqlTranslationProvider();
-				Library library = tx.translate( is );
+				Library library = OptimizedCqlLibraryReader.read( tx.translate( is ) );
 				assertEquals( "COL_InitialPop", library.getIdentifier().getId() );
 			}
 		}

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/OptimizedCqlLibraryReaderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/OptimizedCqlLibraryReaderTest.java
@@ -5,7 +5,7 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/OptimizedObjectFactoryTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/OptimizedObjectFactoryTest.java
@@ -5,7 +5,7 @@
  *  * SPDX-License-Identifier: Apache-2.0
  *
  */
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/ShortCircuitEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/elm/execution/ShortCircuitEvaluatorTest.java
@@ -6,12 +6,12 @@
  *
  */
 
-package com.ibm.cohort.translator.optimization;
+package com.ibm.cohort.engine.elm.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -33,7 +33,8 @@ public class ShortCircuitEvaluatorTest {
 	@Before
 	public void setUp() throws Exception {
 		InJVMCqlTranslationProvider provider = new InJVMCqlTranslationProvider();
-		library = provider.translate(this.getClass().getClassLoader().getResourceAsStream("cql/override/short-circuit-and-or.cql"));
+		String elm = provider.translate(this.getClass().getClassLoader().getResourceAsStream("cql/override/short-circuit-and-or.cql"));
+		library = OptimizedCqlLibraryReader.read(elm);
 	}
 
 	@Test

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -665,6 +665,11 @@
 				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-jaxb-annotations</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
 				<version>3.2.2</version>
@@ -1134,10 +1139,10 @@
 					</execution>
 					
 					<execution>
-            			<goals>
-            				<goal>analyze-only</goal>
-            			</goals>
-            			<configuration>
+						<goals>
+							<goal>analyze-only</goal>
+						</goals>
+						<configuration>
 							<failOnWarning>true</failOnWarning>
 							<ignoredUsedUndeclaredDependencies>
 								<!-- Excluding this because the JAXB classes are provided by the JRE as of Java 8, but there are potentially other classes in jakarta that we don't want to wholesale exclude -->
@@ -1156,7 +1161,7 @@
 								<ignoredUnusedDeclaredDependency>com.github.tomakehurst:wiremock-jre8</ignoredUnusedDeclaredDependency>
 							</ignoredUnusedDeclaredDependencies>
 						</configuration>
-            		</execution>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -1199,8 +1204,8 @@
 						</goals>
 					</execution>
 				</executions>
-            </plugin>
-            <plugin>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>

--- a/cohort-translation/pom.xml
+++ b/cohort-translation/pom.xml
@@ -30,12 +30,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>info.cqframework</groupId>
-			<artifactId>elm</artifactId>
+			<artifactId>cql-to-elm</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>info.cqframework</groupId>
-			<artifactId>cql-to-elm</artifactId>
+			<artifactId>elm</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.cohort</groupId>
@@ -74,12 +73,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xpp3</groupId>
-			<artifactId>xpp3</artifactId>
-			<version>1.1.4c</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
 			<version>1.3</version>
@@ -91,14 +84,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
+			<groupId>org.eclipse.persistence</groupId>
+			<artifactId>org.eclipse.persistence.moxy</artifactId>
+			<version>2.7.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -128,7 +116,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>	
+			</plugin>
 		</plugins>
 	</build>
 

--- a/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/BaseCqlTranslationProvider.java
+++ b/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/BaseCqlTranslationProvider.java
@@ -16,7 +16,6 @@ import com.ibm.cohort.file.LibraryFormat;
 
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
 import org.cqframework.cql.cql2elm.CqlTranslatorOptions;
-import org.cqframework.cql.elm.execution.Library;
 
 /**
  * Common functionality for use when implementing CQL translator
@@ -34,21 +33,21 @@ public abstract class BaseCqlTranslationProvider implements CqlTranslationProvid
 	}
 
 	@Override
-	public Library translate(InputStream cql) throws Exception {
+	public String translate(InputStream cql) throws Exception {
 		return translate( cql, getDefaultOptions() );
 	}
 
 	@Override
-	public Library translate(InputStream cql, List<Options> options) throws Exception {
+	public String translate(InputStream cql, List<Options> options) throws Exception {
 		return translate(cql, options, DEFAULT_TARGET_FORMAT);
 	}
 
 	@Override
-	public Library translate(String cql) throws Exception {
+	public String translate(String cql) throws Exception {
 		return translate( cql, getDefaultOptions() );
 	}
 
-	public Library translate(String cql, List<Options> options) throws Exception {
+	public String translate(String cql, List<Options> options) throws Exception {
 		return translate(cql, options, DEFAULT_TARGET_FORMAT);
 	}
 }

--- a/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/CqlTranslationProvider.java
+++ b/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/CqlTranslationProvider.java
@@ -12,7 +12,6 @@ import java.io.Reader;
 import java.util.List;
 
 import org.cqframework.cql.cql2elm.CqlTranslator.Options;
-import org.cqframework.cql.elm.execution.Library;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
 
 import com.ibm.cohort.file.LibraryFormat;
@@ -24,15 +23,15 @@ import com.ibm.cohort.file.LibraryFormat;
  * JAR or calling out to the CqlTranslationService microservice.
  */
 public interface CqlTranslationProvider {
-	Library translate(InputStream cql) throws Exception;
+	String translate(InputStream cql) throws Exception;
 
-	Library translate(String cql) throws Exception;
+	String translate(String cql) throws Exception;
 
-	Library translate(InputStream cql, List<Options> options) throws Exception;
+	String translate(InputStream cql, List<Options> options) throws Exception;
 
-	Library translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
+	String translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
 
-	Library translate(String cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
+	String translate(String cql, List<Options> options, LibraryFormat targetFormat) throws Exception;
 
 	void registerModelInfo(ModelInfo modelInfo);
 	

--- a/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/InJVMCqlTranslationProvider.java
+++ b/cohort-translation/src/main/java/com/ibm/cohort/translator/provider/InJVMCqlTranslationProvider.java
@@ -25,7 +25,6 @@ import org.cqframework.cql.cql2elm.LibrarySourceProvider;
 import org.cqframework.cql.cql2elm.ModelInfoLoader;
 import org.cqframework.cql.cql2elm.ModelInfoProvider;
 import org.cqframework.cql.cql2elm.ModelManager;
-import org.cqframework.cql.elm.execution.Library;
 import org.cqframework.cql.elm.tracking.TrackBack;
 import org.fhir.ucum.UcumService;
 import org.hl7.elm_modelinfo.r1.ModelInfo;
@@ -33,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.ibm.cohort.file.LibraryFormat;
-import com.ibm.cohort.translator.optimization.OptimizedCqlLibraryReader;
 
 /**
  * Uses the CqlTranslator inprocess to convert CQL to ELM. 
@@ -62,8 +60,8 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 	}
 
 	@Override
-	public Library translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception {
-		Library result;
+	public String translate(InputStream cql, List<Options> options, LibraryFormat targetFormat) throws Exception {
+		String result;
 
 		UcumService ucumService = null;
 		LibraryBuilder.SignatureLevel signatureLevel = LibraryBuilder.SignatureLevel.None;
@@ -93,7 +91,7 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 
 		switch (targetFormat) {
 		case XML:
-			result = OptimizedCqlLibraryReader.read(translator.toXml());
+			result = translator.toXml();
 			break;
 // This is only a theoretical nice-to-have and fails deserialization, so disabling support for now.
 //		case JSON:
@@ -108,7 +106,7 @@ public class InJVMCqlTranslationProvider extends BaseCqlTranslationProvider {
 	}
 
 	@Override
-	public Library translate(String cql, List<Options> options, LibraryFormat targetFormat) throws Exception {
+	public String translate(String cql, List<Options> options, LibraryFormat targetFormat) throws Exception {
 		return translate(new ByteArrayInputStream(cql.getBytes()), options, targetFormat);
 	}
 

--- a/cohort-translation/src/main/resources/com/ibm/cohort/translator/optimization/jaxb.properties
+++ b/cohort-translation/src/main/resources/com/ibm/cohort/translator/optimization/jaxb.properties
@@ -1,9 +1,0 @@
-#
-# /*
-#  * (C) Copyright IBM Corp. 2021
-#  *
-#  * SPDX-License-Identifier: Apache-2.0
-#  */
-#
-
-javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/cohort-translation/src/test/resources/cql/basic/test.xml
+++ b/cohort-translation/src/test/resources/cql/basic/test.xml
@@ -1,52 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <library xmlns="urn:hl7-org:elm:r1" xmlns:t="urn:hl7-org:elm-types:r1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fhir="http://hl7.org/fhir" xmlns:qdm43="urn:healthit-gov:qdm:v4_3" xmlns:qdm53="urn:healthit-gov:qdm:v5_3" xmlns:a="urn:hl7-org:cql-annotations:r1">
-   <annotation translatorOptions="" xsi:type="a:CqlToElmInfo"/>
+   <annotation translatorOptions="EnableAnnotations,EnableLocators,DisableListDemotion,DisableListPromotion" xsi:type="a:CqlToElmInfo"/>
    <identifier id="Test" version="1.0.0"/>
    <schemaIdentifier id="urn:hl7-org:elm" version="r1"/>
    <usings>
       <def localIdentifier="System" uri="urn:hl7-org:elm-types:r1"/>
-      <def localIdentifier="FHIR" uri="http://hl7.org/fhir" version="4.0.0"/>
+      <def localId="1" locator="2:1-2:28" localIdentifier="FHIR" uri="http://hl7.org/fhir" version="4.0.0">
+         <annotation xsi:type="a:Annotation">
+            <a:s r="1">
+               <a:s>using &quot;FHIR&quot; version '4.0.0'</a:s>
+            </a:s>
+         </annotation>
+      </def>
    </usings>
    <contexts>
-      <def name="Patient"/>
+      <def locator="3:1-3:15" name="Patient"/>
    </contexts>
    <statements>
-      <def name="Patient" context="Patient">
+      <def locator="3:1-3:15" name="Patient" context="Patient">
          <expression xsi:type="SingletonFrom">
-            <operand dataType="fhir:Patient" xsi:type="Retrieve"/>
+            <operand locator="3:1-3:15" dataType="fhir:Patient" xsi:type="Retrieve"/>
          </expression>
       </def>
-      <def name="Female" context="Patient" accessLevel="Public">
-         <expression xsi:type="Equal">
-            <operand path="value" xsi:type="Property">
-               <source path="gender" xsi:type="Property">
-                  <source name="Patient" xsi:type="ExpressionRef"/>
+      <def localId="7" locator="4:1-5:32" name="Female" context="Patient" accessLevel="Public">
+         <annotation xsi:type="a:Annotation">
+            <a:s r="7">
+               <a:s>define &quot;Female&quot;:&#xd;
+	</a:s>
+               <a:s r="6">
+                  <a:s r="4">
+                     <a:s r="3">
+                        <a:s r="2">
+                           <a:s>Patient</a:s>
+                        </a:s>
+                        <a:s>.</a:s>
+                        <a:s r="3">
+                           <a:s>gender</a:s>
+                        </a:s>
+                     </a:s>
+                     <a:s>.</a:s>
+                     <a:s r="4">
+                        <a:s>value</a:s>
+                     </a:s>
+                  </a:s>
+                  <a:s> = </a:s>
+                  <a:s r="5">
+                     <a:s>'female'</a:s>
+                  </a:s>
+               </a:s>
+            </a:s>
+         </annotation>
+         <expression localId="6" locator="5:2-5:32" xsi:type="Equal">
+            <operand localId="4" locator="5:2-5:21" path="value" xsi:type="Property">
+               <source localId="3" locator="5:2-5:15" path="gender" xsi:type="Property">
+                  <source localId="2" locator="5:2-5:8" name="Patient" xsi:type="ExpressionRef"/>
                </source>
             </operand>
-            <operand valueType="t:String" value="female" xsi:type="Literal"/>
+            <operand localId="5" locator="5:25-5:32" valueType="t:String" value="female" xsi:type="Literal"/>
          </expression>
       </def>
-      <def name="Male" context="Patient" accessLevel="Public">
-         <expression xsi:type="Equal">
-            <operand path="value" xsi:type="Property">
-               <source path="gender" xsi:type="Property">
-                  <source name="Patient" xsi:type="ExpressionRef"/>
+      <def localId="13" locator="6:1-7:30" name="Male" context="Patient" accessLevel="Public">
+         <annotation xsi:type="a:Annotation">
+            <a:s r="13">
+               <a:s>define &quot;Male&quot;:&#xd;
+	</a:s>
+               <a:s r="12">
+                  <a:s r="10">
+                     <a:s r="9">
+                        <a:s r="8">
+                           <a:s>Patient</a:s>
+                        </a:s>
+                        <a:s>.</a:s>
+                        <a:s r="9">
+                           <a:s>gender</a:s>
+                        </a:s>
+                     </a:s>
+                     <a:s>.</a:s>
+                     <a:s r="10">
+                        <a:s>value</a:s>
+                     </a:s>
+                  </a:s>
+                  <a:s> = </a:s>
+                  <a:s r="11">
+                     <a:s>'male'</a:s>
+                  </a:s>
+               </a:s>
+            </a:s>
+         </annotation>
+         <expression localId="12" locator="7:2-7:30" xsi:type="Equal">
+            <operand localId="10" locator="7:2-7:21" path="value" xsi:type="Property">
+               <source localId="9" locator="7:2-7:15" path="gender" xsi:type="Property">
+                  <source localId="8" locator="7:2-7:8" name="Patient" xsi:type="ExpressionRef"/>
                </source>
             </operand>
-            <operand valueType="t:String" value="male" xsi:type="Literal"/>
+            <operand localId="11" locator="7:25-7:30" valueType="t:String" value="male" xsi:type="Literal"/>
          </expression>
       </def>
-      <def name="Over the hill" context="Patient" accessLevel="Public">
-         <expression xsi:type="GreaterOrEqual">
-            <operand precision="Year" xsi:type="CalculateAge">
+      <def localId="17" locator="8:1-9:19" name="Over the hill" context="Patient" accessLevel="Public">
+         <annotation xsi:type="a:Annotation">
+            <a:s r="17">
+               <a:s>define &quot;Over the hill&quot;:&#xd;
+	</a:s>
+               <a:s r="16">
+                  <a:s r="14">
+                     <a:s>AgeInYears()</a:s>
+                  </a:s>
+                  <a:s r="15"> >= 40</a:s>
+               </a:s>
+            </a:s>
+         </annotation>
+         <expression localId="16" locator="9:2-9:19" xsi:type="GreaterOrEqual">
+            <operand localId="14" locator="9:2-9:13" precision="Year" xsi:type="CalculateAge">
                <operand path="birthDate.value" xsi:type="Property">
                   <source name="Patient" xsi:type="ExpressionRef"/>
                </operand>
             </operand>
-            <operand valueType="t:Integer" value="40" xsi:type="Literal"/>
+            <operand localId="15" locator="9:18-9:19" valueType="t:Integer" value="40" xsi:type="Literal"/>
          </expression>
       </def>
    </statements>
 </library>
-
-


### PR DESCRIPTION
While working with the health patterns team, I found that the
CqlEvaluator interface was inconsistent with regard to the APIs exposed
for CqlEvaluationResult and CqlExpressionResult callbacks. I added a few
signatures so that we have consistency.

While I was working, I noticed that the split of the
CqlTranslationProvider into its own project moved some code into the
translator project that did not technically belong to the translator.
The translator produces ELM in an execution agnostic ELM format, the CQL
Engine consumes that ELM and maps it into an execution typesystem. The
custom object factory code is only needed on the execution side and not
the translation side. I moved the OptimizedCqlLibraryReader and its
related classes back into the cohort-engine project where they started.
This means that the translation component no longer has the ability to
render the ELM XML in the execution typesystem. I had to change the
CqlTranslationProvider interface to produce strings instead of inflated
Library objects to make this work. There aren't any preexisting
consumers consuming translation directly, so this should be fine. There
is probably more room for improvement here (perhaps the optimized
Library reader code could be its own module), but it is better now than
it was when forcing the translator dependency on the runtime just to
deserialize the ELM.