### PR TITLE
Add spark history server build and deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # unzip our binaries to. For reference:
 # https://access.redhat.com/containers/?tab=support#/registry.access.redhat.com/ubi8/ubi
 ####################
+# hadolint ignore=DL3006
 FROM registry.access.redhat.com/ubi8 AS builder
 
 WORKDIR /app
@@ -94,4 +95,5 @@ USER 1001
 # Expose the servers HTTP and HTTPS ports.  NOTE:  must match with hardcoded testcase stage scripts, Helm charts (values.yaml), server.xml
 EXPOSE 9080 9443
 
+# hadolint ignore=DL3025
 ENTRYPOINT $WLP_HOME/bin/entrypoint.sh

--- a/chart/cohort/Chart.yaml
+++ b/chart/cohort/Chart.yaml
@@ -5,6 +5,6 @@
 #
 apiVersion: v1
 appVersion: "1.0"
-description: Quality Measure and Cohort Service
+description: Quality Measure and Cohort Service with Spark
 name: cohort
 version: 1.0.2

--- a/chart/cohort/templates/_helpers.tpl
+++ b/chart/cohort/templates/_helpers.tpl
@@ -19,3 +19,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Remove image name from toolchain set value.
+*/}}
+{{- define "baseRepository" -}}
+{{- dir .Values.image.repository -}}
+{{- end -}}

--- a/chart/cohort/templates/cohort/deployment.yaml
+++ b/chart/cohort/templates/cohort/deployment.yaml
@@ -20,7 +20,7 @@ metadata:
     USER_NAME: {{ .Values.annotations.USER_NAME }}
     APPLICATION_VERSION: {{ .Values.annotations.APPLICATION_VERSION }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.cohort.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "name" . }}
@@ -36,20 +36,20 @@ spec:
       volumes:
         - name: secret-tls
           secret:
-            secretName: {{ .Values.internalTlsCertSecretName }}
+            secretName: {{ .Values.cohort.internalTlsCertSecretName }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ template "baseRepository" . }}/{{ .Values.cohort.image.name }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.cohort.image.pullPolicy }}
           env:
             - name: ENABLE_DARK_FEATURES
-              value: {{ .Values.enableDarkFeatures }}
+              value: {{ .Values.cohort.enableDarkFeatures }}
             - name: LIBERTY_INITIAL_HEAP_SIZE
-              value: {{ .Values.libertyInitialHeapSize }}
+              value: {{ .Values.cohort.libertyInitialHeapSize }}
             - name: LIBERTY_MAX_HEAP_SIZE
-              value: {{ .Values.libertyMaxHeapSize }}
+              value: {{ .Values.cohort.libertyMaxHeapSize }}
           ports:
-          {{- range .Values.service.ports }}
+          {{- range .Values.cohort.service.ports }}
           - containerPort: {{ . }}
           {{- end }}
           volumeMounts:
@@ -75,4 +75,3 @@ spec:
             periodSeconds: 10
       nodeSelector:
         worker-type: application
-

--- a/chart/cohort/templates/cohort/service.yaml
+++ b/chart/cohort/templates/cohort/service.yaml
@@ -1,3 +1,8 @@
+#
+# (C) Copyright IBM Corp. 2021, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,12 +13,11 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.cohort.service.type }}
   ports:
-    - port: {{ .Values.service.externalPort }}
-      targetPort: {{ .Values.service.externalPort }}
+    - port: {{ .Values.cohort.service.externalPort }}
+      targetPort: {{ .Values.cohort.service.externalPort }}
       protocol: TCP
-      name: {{ .Values.service.name }}
   selector:
     app: {{ template "name" . }}
     release: {{ .Release.Name }}

--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.sparkHistoryServer.enabled -}}
+#
+# (C) Copyright IBM Corp. 2021, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "name" . }}-spark-history-deployment
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    TOOLCHAIN_ID: {{ .Values.annotations.TOOLCHAIN_ID }}
+    GIT_URL: {{ .Values.annotations.GIT_URL }}
+    GIT_BRANCH: {{ .Values.annotations.GIT_BRANCH }}
+    GIT_COMMIT: {{ .Values.annotations.GIT_COMMIT }}
+    USER_NAME: {{ .Values.annotations.USER_NAME }}
+    APPLICATION_VERSION: {{ .Values.annotations.APPLICATION_VERSION }}
+spec:
+  replicas: {{ .Values.sparkHistoryServer.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      nodeSelector:
+        worker-type: application
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ template "baseRepository" . }}/{{ .Values.sparkHistoryServer.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: SPARK_NO_DAEMONIZE
+          value: "true"
+        - name: AWS_BUCKET
+          value: {{ .Values.sparkHistoryServer.s3.bucket }}
+        - name: AWS_LOG_PATH
+          value: {{ .Values.sparkHistoryServer.s3.eventsDir }}
+        - name: AWS_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sparkHistoryServer.s3.secret.name }}
+              key: {{ .Values.sparkHistoryServer.s3.secret.accessKeyId }}
+        - name: AWS_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sparkHistoryServer.s3.secret.name }}
+              key: {{ .Values.sparkHistoryServer.s3.secret.secretKeyId }}
+        - name: AWS_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sparkHistoryServer.s3.secret.name }}
+              key: {{ .Values.sparkHistoryServer.s3.secret.endpointId }}
+        ports:
+        - name: historyport
+          containerPort: 18080
+          protocol: TCP
+        resources:
+          requests:
+              cpu: {{ .Values.sparkHistoryServer.resources.requests.cpu }}
+              memory: {{ .Values.sparkHistoryServer.resources.requests.memory }}
+          limits:
+              cpu: {{ .Values.sparkHistoryServer.resources.limits.cpu }}
+              memory: {{ .Values.sparkHistoryServer.resources.limits.memory }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: historyport
+        readinessProbe:
+          httpGet:
+            path: /
+            port: historyport
+{{- end }}

--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -24,12 +24,12 @@ spec:
   replicas: {{ .Values.sparkHistoryServer.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "name" . }}-spark-history-server
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "name" . }}-spark-history-server
         release: {{ .Release.Name }}
     spec:
       nodeSelector:

--- a/chart/cohort/templates/spark-history-server/service.yaml
+++ b/chart/cohort/templates/spark-history-server/service.yaml
@@ -9,7 +9,7 @@ kind: Service
 metadata:
   name: {{ template "name" . }}-spark-history-service
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "name" . }}-spark-history-server
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -21,6 +21,6 @@ spec:
     protocol: TCP
     name: {{ .Values.sparkHistoryServer.service.port.name }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "name" . }}-spark-history-server
     release: {{ .Release.Name }}
 {{- end }}

--- a/chart/cohort/templates/spark-history-server/service.yaml
+++ b/chart/cohort/templates/spark-history-server/service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.sparkHistoryServer.enabled -}}
+#
+# (C) Copyright IBM Corp. 2021, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "name" . }}-spark-history-service
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.sparkHistoryServer.service.type }}
+  ports:
+  - port: {{ .Values.sparkHistoryServer.service.port.number }}
+    targetPort: historyport
+    protocol: TCP
+    name: {{ .Values.sparkHistoryServer.service.port.name }}
+  selector:
+    app: {{ template "name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -5,10 +5,9 @@
 #
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-# Should have at least 3 replicas so that they can be spread to different
-# zones and so that during upgrades, k8s can ensure at least 1 replica is running
-# while the others are being upgraded
-replicaCount: 3
+
+# common  #
+# ------- #
 annotations:
   TOOLCHAIN_ID: null
   GIT_URL: null
@@ -25,24 +24,64 @@ image:
   #didn't hardcode it in deployment.yaml, because it caused an error/warning in the toolchain insights console
   pullsecret: ibmcloud-toolchain-common-services-registry
   pullPolicy: IfNotPresent
-  imageName: cohort-app
 
-service:
-  type: ClusterIP
-  externalPort: 9443
-  ports:
-    - 9080
-    - 9443
+# cohort service  #
+# --------------- #
+cohort:
+  # Should have at least 3 replicas so that they can be spread to different
+  # zones and so that during upgrades, k8s can ensure at least 1 replica is running
+  # while the others are being upgraded
+  replicaCount: 3
+  image:
+    name: cohorting-app
 
-#overriden in config repo
-internalTlsCertSecretName: cohort-services-cohort-cohort-tls
+  service:
+    type: ClusterIP
+    externalPort: 9443
+    ports:
+      - 9080
+      - 9443
 
-# enableDarkFeatures is used to enable or disable REST endpoints depending on the env. we are deploying to
-# there are some REST endpoints we only want enabled in a development environment. The value ends up
-# in the jvm.options file the liberty server. Set to "all" "none" (no quotes) 
-# or the specific feature value you want to enable
-#overriden in config repo
-enableDarkFeatures: none
+  #overriden in config repo
+  internalTlsCertSecretName: cohort-services-cohort-cohort-tls
 
-libertyInitialHeapSize: 1G
-libertyMaxHeapSize: 2G
+  # enableDarkFeatures is used to enable or disable REST endpoints depending on the env. we are deploying to
+  # there are some REST endpoints we only want enabled in a development environment. The value ends up
+  # in the jvm.options file the liberty server. Set to "all" "none" (no quotes) 
+  # or the specific feature value you want to enable
+  enableDarkFeatures: none
+  
+  libertyInitialHeapSize: 1G
+  libertyMaxHeapSize: 2G
+
+# spark history server  #
+# --------------------- #
+sparkHistoryServer:
+  enabled: true
+  replicaCount: 1
+  
+  image:
+    name: spark-history-server
+  
+  service:
+    type: ClusterIP
+    port:
+      number: 18080
+      name: http-historyport
+  
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+  
+  s3:
+    secret:
+      name: spark-cos-secret
+      accessKeyId: AWS_ACCESS_KEY
+      secretKeyId: AWS_SECRET_KEY
+      endpointId: AWS_ENDPOINT
+    bucket: cohort-spark-history
+    eventsDir: "/"

--- a/docker/spark-history-server/Dockerfile
+++ b/docker/spark-history-server/Dockerfile
@@ -1,0 +1,96 @@
+#
+# (C) Copyright IBM Corp. 2021, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# The official ubi8 image from redhat's registry is one of the few accepted base images for Alvearie
+ARG BASE_IMAGE=registry.access.redhat.com/ubi8
+ARG BASE_IMAGE_VERSION=8.4-206.1626828523
+
+ARG SPARK_VERSION=spark-3.1.2
+ARG SPARK_DIST=bin-hadoop3.2
+ARG SPARK_UID=185
+ARG SPARK_WORK_DIR=/spark-work-dir
+ARG SPARK_HOME=/opt/spark
+
+
+#################
+# spark-builder #
+#################
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} AS spark-builder
+
+ARG SPARK_HOME
+ARG SPARK_VERSION
+ARG SPARK_DIST
+
+# Download and extract Spark
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl "https://archive.apache.org/dist/spark/${SPARK_VERSION}/${SPARK_VERSION}-${SPARK_DIST}.tgz" | tar -xz
+# Move the extracted spark dist to SPARK_HOME
+RUN mv "${SPARK_VERSION}-${SPARK_DIST}" "${SPARK_HOME}"
+# Move entrypoint.sh to SPARK_HOME
+RUN mv "${SPARK_HOME}/kubernetes/dockerfiles/spark/entrypoint.sh" "${SPARK_HOME}"
+# Move decom.sh to SPARK_HOME
+RUN mv "${SPARK_HOME}/kubernetes/dockerfiles/spark/decom.sh" "${SPARK_HOME}"
+# Remove the `tini` use from entrypoint.sh.  Tini is unavailable on Red Hat.
+RUN sed -i 's_/usr/bin/tini -s --__g' "${SPARK_HOME}/entrypoint.sh"
+
+
+##############
+# spark-base #
+##############
+FROM ${BASE_IMAGE}:${BASE_IMAGE_VERSION} as spark-base
+
+ARG SPARK_WORK_DIR
+ENV SPARK_WORK_DIR=${SPARK_WORK_DIR}
+ARG SPARK_UID
+ARG SPARK_HOME
+ENV SPARK_HOME=${SPARK_HOME}
+
+# Become root for the Spark installation process
+USER root
+# Perform a full update of all packages to minimize vulnerabilities
+RUN dnf update -y &&\
+    # Install Java 11
+    dnf install -y java-11-openjdk &&\
+    # Clean dnf
+    dnf clean all
+
+# Copy spark code from builder stage and chown to root
+COPY --from=spark-builder --chown=root ${SPARK_HOME} ${SPARK_HOME}
+
+# Add the spark user, create SPARK_WORK_DIR, and set it as the user's home directory
+RUN useradd -l -u "${SPARK_UID}" -d "${SPARK_WORK_DIR}" spark
+
+# Configure the runtime for downstream images
+WORKDIR ${SPARK_WORK_DIR}
+USER spark
+ENTRYPOINT [ "/opt/spark/entrypoint.sh" ]
+
+#################
+# spark-history #
+#################
+FROM spark-base as spark-history
+
+# Become the root user
+USER root
+
+# Add the hadoop-aws jar and its aws dependency jar.
+# hadoop-aws:3.2.0 was chosen as it lines up with the spark version in our base image.
+# aws-java-sdk-bundle:1.11.375 was chosen as it's the primary dependency of hadoop-aws:3.2.0.
+ADD https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.375/aws-java-sdk-bundle-1.11.375.jar $SPARK_HOME/jars
+# Ensure all Spark jars are readable by all users
+RUN chmod +r "$SPARK_HOME"/jars/* &&\
+    # Ensure all Spark jars are owned by root
+    chown root:root "$SPARK_HOME"/jars/*
+
+# Replace the existing entrypoint script with the history server one
+COPY --chown=root:root entrypoint.sh $SPARK_HOME
+# Make the entrypoint script executable by all users
+RUN chmod +x "$SPARK_HOME/entrypoint.sh"
+
+# Change back to the spark user
+USER spark
+

--- a/docker/spark-history-server/entrypoint.sh
+++ b/docker/spark-history-server/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# (C) Copyright IBM Corp. 2021, 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
+    -Dspark.history.fs.logDirectory=s3a://$AWS_BUCKET$AWS_LOG_PATH \
+    -Dspark.hadoop.fs.s3a.endpoint=$AWS_ENDPOINT \
+    -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY \
+    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY";
+
+/opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer;

--- a/pipeline.config
+++ b/pipeline.config
@@ -25,6 +25,7 @@ CI:
   # added to allow mixed case branch names (toolchains fail on mixed case branch names without this set,
   # could remove when we switch to using main branch
   RELEASE_NAME_NO_GIT_BRANCH: "true"
+  USEHADOLINT: "true"
 CIVALIDATE:
   BUILD_FILE: "cohort-parent/pom.xml"
   BUILD_OPTIONS: "package -s /workspace/.toolchain.maven.settings.xml"


### PR DESCRIPTION
There are a couple of toolchain-specific reasons things are set up this way that my notes on [Confluence](https://confluence.wh-sdlc.watson-health.ibm.com/pages/viewpage.action?pageId=69960134) cover in a bit more detail.
Still, these changes get us the base things we want for now (with the possibility of splitting/moving the components to different repositories in the future).

## Overview of Changes
* _Add_ `Dockerfile` for spark history server based on [base spark image setup](https://confluence.wh-sdlc.watson-health.ibm.com/pages/viewpage.action?spaceKey=COH&title=Spark+Base+Dockerfile). 
* _Add_ spark history server deployment, with an overridable feature flag (`sparkHistoryServer.enabled`).
* _Update_ toolchain to use  `hadolint` for parsing `Dockerfile`s: allows for inline comments within commands.

## Related PR
* [watson-health-cohorting/wh-cohorting-config#1](https://github.ibm.com/watson-health-cohorting/wh-cohorting-config/pull/1)

## References
* [WFFHCOHORT-489](https://jira.wh-sdlc.watson-health.ibm.com/browse/WFFHCOHORT-489)
* [Test CD Run](https://cloud.ibm.com/devops/pipelines/tekton/2a73d620-78a5-4f25-9ef4-988d77272815/runs/fddcf24f-f16f-4f1c-a064-c7be67453cd3/cd/git-sync?env_id=ibm:yp:us-east)