### PR TITLE
Update spark-history-server to use latest spark-cos-secret contents

### DIFF
--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -43,6 +43,8 @@ spec:
         env:
         - name: SPARK_NO_DAEMONIZE
           value: "true"
+        - name: AWS_ENDPOINT
+          value: {{ .Values.sparkHistoryServer.s3.endpointId }}
         - name: AWS_BUCKET
           value: {{ .Values.sparkHistoryServer.s3.bucket }}
         - name: AWS_LOG_PATH
@@ -57,11 +59,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.sparkHistoryServer.s3.secret.name }}
               key: {{ .Values.sparkHistoryServer.s3.secret.secretKeyId }}
-        - name: AWS_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.sparkHistoryServer.s3.secret.name }}
-              key: {{ .Values.sparkHistoryServer.s3.secret.endpointId }}
         ports:
         - name: historyport
           containerPort: 18080

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -80,8 +80,8 @@ sparkHistoryServer:
   s3:
     secret:
       name: spark-cos-secret
-      accessKeyId: AWS_ACCESS_KEY
-      secretKeyId: AWS_SECRET_KEY
-      endpointId: AWS_ENDPOINT
+      accessKeyId: access-key
+      secretKeyId: secret-key
+    endpointId: "https://s3.us.cloud-object-storage.appdomain.cloud"
     bucket: cohort-spark-history
     eventsDir: "/"


### PR DESCRIPTION
I updated the Spark History Server deployment to use values from the newly formatted `spark-cos-secret` that is based on the IBM S3 FS plugin. We don't have endpoint ID as part of that secret, so it needed to come from somewhere else. I set a default value of the US geography endpoint with the assumption that the CD deployment pipeline will override to set whatever is truly used in the deployment environment. As part of that, I updated the overrides files in the cohorting-config repo. This was tested in cicdtest and works. 