### PR TITLE
Filtering fix

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -394,15 +394,34 @@ public class SparkCqlEvaluator implements Serializable {
             jobSpecification.set(requests);
         }
 
-        List<CqlEvaluationRequest> filteredRequests = requests.getEvaluations().stream()
-                .filter(r -> r.getContextKey().equals(contextName)).collect(Collectors.toList());
+        return evaluate(rowsByContext, contextName, evaluator, requests, perContextAccum);
+    }
+
+    /**
+     * Evaluate the input CQL for a single context + data pair.
+     *
+     * @param contextName     Name of the context used to select measure evaluations.
+     *                        
+     * @param requests        CqlEvaluationRequests containing lists of libraries,
+     *                        expressions, and parameters to evaluate
+     * @return Filtered list of CqlEvaluationResult. 
+     */
+    protected List<CqlEvaluationRequest> filterRequests(CqlEvaluationRequests requests, String contextName) {
+        List<CqlEvaluationRequest> requestsForContext = new ArrayList<>();
+        
+        List<CqlEvaluationRequest> evaluations = requests.getEvaluations();
+        if (evaluations != null) {
+            requestsForContext = requests.getEvaluations().stream()
+                    .filter(r -> r.getContextKey().equals(contextName)).collect(Collectors.toList());
+        }
 
         if (libraries != null && libraries.size() > 0) {
-            filteredRequests = filteredRequests.stream()
+            requestsForContext = requestsForContext.stream()
                     .filter(r -> libraries.keySet().contains(r.getDescriptor().getLibraryId()))
                     .collect(Collectors.toList());
         }
-        return evaluate(rowsByContext, evaluator, requests, perContextAccum);
+        
+        return requestsForContext;
     }
 
     /**
@@ -410,6 +429,7 @@ public class SparkCqlEvaluator implements Serializable {
      * 
      * @param rowsByContext   In-memory data for all datatypes related to a single
      *                        context
+     * @param contextName     Name of the context used to select measure evaluations.
      * @param evaluator       configured CQLEvaluator (data provider, term provider,
      *                        library provider all previously setup)
      * @param requests        CqlEvaluationRequests containing lists of libraries,
@@ -422,11 +442,13 @@ public class SparkCqlEvaluator implements Serializable {
      *         between libraries (e.g. LibraryName.ExpressionName).
      */
     protected Tuple2<Object, Map<String, Object>> evaluate(Tuple2<Object, List<Row>> rowsByContext,
-            CqlEvaluator evaluator, CqlEvaluationRequests requests, LongAccumulator perContextAccum) {
+            String contextName, CqlEvaluator evaluator, CqlEvaluationRequests requests, LongAccumulator perContextAccum) {
         perContextAccum.add(1);
         
+        List<CqlEvaluationRequest> requestsForContext = filterRequests(requests, contextName);
+        
         Map<String, Object> expressionResults = new HashMap<>();
-        for (CqlEvaluationRequest request : requests.getEvaluations()) {
+        for (CqlEvaluationRequest request : requestsForContext) {
             if (expressions != null && expressions.size() > 0) {
                 request.setExpressions(expressions);
             }

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
@@ -3,6 +3,9 @@ package com.ibm.cohort.cql.evaluation;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 
 public class CqlEvaluationRequest {
@@ -42,4 +45,32 @@ public class CqlEvaluationRequest {
     public void setContextValue(String contextValue) {
         this.contextValue = contextValue;
     }
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (o == null || getClass() != o.getClass()) return false;
+
+		CqlEvaluationRequest that = (CqlEvaluationRequest) o;
+
+		return new EqualsBuilder()
+				.append(descriptor, that.descriptor)
+				.append(expressions, that.expressions)
+				.append(parameters, that.parameters)
+				.append(contextKey, that.contextKey)
+				.append(contextValue, that.contextValue)
+				.isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(17, 37)
+				.append(descriptor)
+				.append(expressions)
+				.append(parameters)
+				.append(contextKey)
+				.append(contextValue)
+				.toHashCode();
+	}
 }

--- a/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/model/CodeKey.java
+++ b/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/model/CodeKey.java
@@ -26,7 +26,8 @@ public class CodeKey extends Code {
 
     @Override
     public boolean equals(Object o2) {
-        return super.equal(o2);
+        Boolean codeEquals = super.equal(o2);
+        return codeEquals != null && codeEquals;
     }
 
     @Override

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/model/CodeKeyTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/model/CodeKeyTest.java
@@ -7,6 +7,7 @@
 package com.ibm.cohort.datarow.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -67,5 +68,16 @@ public class CodeKeyTest {
         CodeKey right = new CodeKey(data);
 
         assertEquals(left, right);
+    }
+
+    @Test
+    public void testCodeKeysNotEqualMissingSystem() {
+        Code data = new Code().withCode("123").withSystem("http://snomed.info/sct").withDisplay("display")
+                .withVersion("20200809");
+        CodeKey codeKeyWithSystem = new CodeKey(data);
+        
+        CodeKey codeKeyWithoutSystem = new CodeKey(data.withSystem(null));
+
+        assertNotEquals(codeKeyWithSystem, codeKeyWithoutSystem);
     }
 }


### PR DESCRIPTION
Filtering logic was happening, but the resulting object wasn't being passed through to the final  evaluate. I moved the logic to the final evaluate statement.

I'm not a huge fan of the extra method I added, but it made it easy to write tests quickly.

There was also a NullPointerException for the CodeKey class if System was null and equals was called. I added a test and a code fix.