### PR TITLE
Add full parameter support to the CqlEvaluator

### DIFF
--- a/cohort-evaluator-spark/pom.xml
+++ b/cohort-evaluator-spark/pom.xml
@@ -44,6 +44,23 @@
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+		</dependency>
+
+		<!-- This needs to be before Spark because spark pulls in JSP 2.1 and JSP 
+			2.1 has an embedded version of the javax.el API -->
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.spark;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+
+/**
+ * Command-line arguments for the SparkCqlEvaluator program.
+ */
+public class SparkCqlEvaluatorArgs implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Parameter(names = { "-h", "--help" }, description = "Print help text", help = true)
+    public boolean help;
+
+    @Parameter(names = { "-d",
+            "--context-definitions" }, description = "Filesystem path to the context-definitions file.", required = false)
+    public String contextDefinitionPath;
+
+    @Parameter(names = { "--input-format" }, description = "Spark SQL format identifier for input files. If not provided, the value of spark.sql.datasources.default is used.", required = false)
+    public String inputFormat;
+    
+    @DynamicParameter(names = { "-i",
+            "--input-path" }, description = "Key-value pair of resource=URI controlling where Spark should read resources referenced in the context definitions file will be read from. Specify multiple files by providing a separate option for each input.", required = true)
+    public Map<String, String> inputPaths = new HashMap<>();
+
+    @Parameter(names = { "--output-format" }, description = "Spark SQL format identifier for output files. If not provided, the value of spark.sql.datasources.default is used.", required = false)
+    public String outputFormat;
+    
+    @DynamicParameter(names = { "-o",
+            "--output-path" }, description = "Key-value pair of context=URI controlling where Spark should write the results of CQL evaluation requests. Specify multiple files by providing a separate option for each output.", required = true)
+    public Map<String, String> outputPaths = new HashMap<>();
+
+    @Parameter(names = { "-j", "--jobs" }, description = "Filesystem path to the CQL job file", required = true)
+    public String jobSpecPath;
+
+    @Parameter(names = { "-m",
+            "--model-info" }, description = "Filesystem path(s) to custom model-info files that may be required for CQL translation.", required = true)
+    public List<String> modelInfoPaths = new ArrayList<>();
+
+    @Parameter(names = { "-c",
+            "--cql-path" }, description = "Filesystem path to the location containing the CQL libraries referenced in the jobs file.", required = true)
+    public String cqlPath;
+
+    @Parameter(names = { "-a",
+            "--aggregation" }, description = "One or more context names, as defined in the context-definitions file, that should be run in this evaluation. Defaults to all evaluations.", required = false)
+    public List<String> aggregations = new ArrayList<>();
+
+    @DynamicParameter(names = { "-l",
+            "--library" }, description = "One or more library=version key-value pair(s), as defined in the jobs file, that describe the libraries that should be run in this evaluation. Defaults to all libraries. Specify multiple libraries by providing a separate option for each library.", required = false)
+    public Map<String, String> libraries = new HashMap<>();
+
+    @Parameter(names = { "-e",
+            "--expression" }, description = "One or more expression names, as defined in the context-definitions file, that should be run in this evaluation. Defaults to all expressions.", required = false)
+    public Set<String> expressions = new HashSet<>();
+
+    @Parameter(names = { "-n",
+            "--output-partitions" }, description = "Number of partitions to use when storing data", required = false)
+    public Integer outputPartitions = null;
+
+    @Parameter(names = { "--debug" }, description = "Enables CQL debug logging")
+    public boolean debug = false;
+}

--- a/cohort-evaluator-spark/src/test/resources/alltypes/cql-jobs.json
+++ b/cohort-evaluator-spark/src/test/resources/alltypes/cql-jobs.json
@@ -32,7 +32,7 @@
 			"version": "1.0.0"
 		},
 		"expressions": ["cohort"],
-		"contextKey": "Patient",
+		"contextKey": "C",
 		"contextValue": "NA"
 	},
 	{
@@ -41,7 +41,7 @@
 			"version": "1.0.0"
 		},
 		"expressions": ["cohort"],
-		"contextKey": "Patient",
+		"contextKey": "D",
 		"contextValue": "NA"
 	}]
 }

--- a/cohort-evaluator-spark/src/test/resources/invalid/cql-jobs-invalid-global.json
+++ b/cohort-evaluator-spark/src/test/resources/invalid/cql-jobs-invalid-global.json
@@ -1,0 +1,9 @@
+{
+	"globalParameters": {
+		"ParamWithMissingProperties": {
+			"type": "interval"
+		}
+	},
+	"evaluations": [
+	]
+}

--- a/cohort-evaluator-spark/src/test/resources/simple-job/cql-jobs.json
+++ b/cohort-evaluator-spark/src/test/resources/simple-job/cql-jobs.json
@@ -1,13 +1,13 @@
 {
 	"globalParameters": {
-		"measurementPeriod": {
-			"__type": "Interval",
-			"begin": {
-				"__type": "Date",
+		"Measurement Period": {
+			"type": "interval",
+			"start": {
+				"type": "date",
 				"value": "2020-01-01"
 			},
 			"end": {
-				"__type": "Date",
+				"type": "date",
 				"value": "2021-01-01"
 			}
 		}
@@ -23,7 +23,7 @@
 			],
 			"parameters": {
 				"MinimumAge": {
-					"__type": "Integer",
+					"type": "integer",
 					"value": 17
 				}
 			},

--- a/cohort-evaluator/pom.xml
+++ b/cohort-evaluator/pom.xml
@@ -66,7 +66,39 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
-
+		
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-annotations</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>javax.validation</groupId>
+			<artifactId>validation-api</artifactId>
+		</dependency>
+	
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlContextFactory.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlContextFactory.java
@@ -25,6 +25,7 @@ import org.opencds.cqf.cql.engine.execution.Context;
 import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 
 import com.ibm.cohort.cql.data.CqlDataProvider;
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryDeserializationException;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
@@ -44,11 +45,11 @@ public class CqlContextFactory {
         final public CqlTerminologyProvider terminologyProvider;
         final public CqlLibraryDescriptor topLevelLibrary;
         final public ZonedDateTime evaluationDateTime;
-        final public Map<String,Object> parameters;
+        final public Map<String,Parameter> parameters;
 
         public ContextCacheKey(CqlLibraryProvider libraryProvider, CqlLibraryDescriptor topLevelLibrary,
                 CqlTerminologyProvider terminologyProvider,ZonedDateTime evaluationDateTime,
-                Map<String, Object> parameters ) {
+                Map<String, Parameter> parameters ) {
             this.libraryProvider = libraryProvider;
             this.topLevelLibrary = topLevelLibrary;
             this.terminologyProvider = terminologyProvider;
@@ -122,7 +123,7 @@ public class CqlContextFactory {
      */
     public Context createContext(CqlLibraryProvider libraryProvider, CqlLibraryDescriptor topLevelLibrary,
             CqlTerminologyProvider terminologyProvider, CqlDataProvider dataProvider, ZonedDateTime evaluationDateTime,
-            Pair<String, String> contextData, Map<String, Object> parameters, CqlDebug debug)
+            Pair<String, String> contextData, Map<String, Parameter> parameters, CqlDebug debug)
             throws CqlLibraryDeserializationException {
         
         ContextCacheKey key = new ContextCacheKey( libraryProvider, topLevelLibrary, terminologyProvider, evaluationDateTime, parameters );
@@ -183,15 +184,17 @@ public class CqlContextFactory {
         if( contextKey.parameters != null ) {
             Library library = cqlContext.getCurrentLibrary();
             
-            for( Map.Entry<String,Object> entry : contextKey.parameters.entrySet() ) {
-                cqlContext.setParameter(library.getLocalId(), entry.getKey(), entry.getValue());
+            for( Map.Entry<String,Parameter> entry : contextKey.parameters.entrySet() ) {
+                Object cqlValue = entry.getValue().toCqlType();
+                cqlContext.setParameter(library.getLocalId(), entry.getKey(), cqlValue);
             }
             
             if (library.getIncludes() != null && library.getIncludes().getDef() != null) {
                 for (IncludeDef def : library.getIncludes().getDef()) {
                     String name = def.getLocalIdentifier();
-                    for (Map.Entry<String, Object> parameterValue : contextKey.parameters.entrySet()) {
-                        cqlContext.setParameter(name, parameterValue.getKey(), parameterValue.getValue());
+                    for (Map.Entry<String, Parameter> parameterValue : contextKey.parameters.entrySet()) {
+                        Object cqlValue = parameterValue.getValue().toCqlType();
+                        cqlContext.setParameter(name, parameterValue.getKey(), cqlValue);
                     }
                 }
             }

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
@@ -1,19 +1,41 @@
 package com.ibm.cohort.cql.evaluation;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import javax.validation.Valid;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 
 public class CqlEvaluationRequest {
     private CqlLibraryDescriptor descriptor;
 	private Set<String> expressions;
-	private Map<String,Object> parameters;
+	@Valid
+	private Map<String,Parameter> parameters;
 	private String contextKey;
 	private String contextValue;
+	
+	public CqlEvaluationRequest() {
+	    super();
+	}
+	
+	public CqlEvaluationRequest(CqlEvaluationRequest other) {
+	    this.setDescriptor(other.getDescriptor());
+	    this.setContextKey(other.getContextKey());
+	    this.setContextValue(other.getContextValue());
+	    if( other.getExpressions() != null ) {
+	        this.setExpressions(new HashSet<>(other.getExpressions()));    
+	    }
+	    if( other.getParameters() != null ) {
+	        this.setParameters(new HashMap<>(other.getParameters()));
+	    }
+	}
 	
     public CqlLibraryDescriptor getDescriptor() {
         return descriptor;
@@ -27,10 +49,10 @@ public class CqlEvaluationRequest {
 	public void setExpressions(Set<String> expressions) {
 		this.expressions = expressions;
 	}
-	public Map<String, Object> getParameters() {
+	public Map<String, Parameter> getParameters() {
 		return parameters;
 	}
-	public void setParameters(Map<String, Object> parameters) {
+	public void setParameters(Map<String, Parameter> parameters) {
 		this.parameters = parameters;
 	}
     public String getContextKey() {

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequests.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequests.java
@@ -3,13 +3,25 @@ package com.ibm.cohort.cql.evaluation;
 import java.util.List;
 import java.util.Map;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
+
 public class CqlEvaluationRequests {
-    private Map<String,Object> globalParameters;
+    @Valid
+    private Map<String,Parameter> globalParameters;
+    
+    @NotNull
+    @Size( min = 1 )
+    @Valid
     private List<CqlEvaluationRequest> evaluations;
-    public Map<String, Object> getGlobalParameters() {
+    
+    public Map<String, Parameter> getGlobalParameters() {
         return globalParameters;
     }
-    public void setGlobalParameters(Map<String, Object> globalParameters) {
+    public void setGlobalParameters(Map<String, Parameter> globalParameters) {
         this.globalParameters = globalParameters;
     }
     public List<CqlEvaluationRequest> getEvaluations() {

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/BooleanParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/BooleanParameter.java
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.constraints.NotNull;
+
+public class BooleanParameter extends Parameter {
+	
+	@NotNull
+	private Boolean value;
+	
+	public BooleanParameter() {
+		setType(ParameterType.BOOLEAN);
+	}
+	public BooleanParameter(boolean value) {
+		this();
+		setValue(value);
+	}
+	
+	public boolean getValue() {
+		return value;
+	}
+	public void setValue(boolean value) {
+		this.value = value;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return value;
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/CodeParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/CodeParameter.java
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.constraints.NotNull;
+
+import org.opencds.cqf.cql.engine.runtime.Code;
+
+public class CodeParameter extends Parameter {
+	private String system;
+	@NotNull
+	private String value;
+	private String display;
+	private String version;
+	
+	public CodeParameter() {
+		setType(ParameterType.CODE);
+	}
+	
+	public CodeParameter(String system, String value, String display, String version) {
+		this();
+		setSystem(system);
+		setValue(value);
+		setDisplay(display);
+		setVersion(version);
+	}
+	
+	public String getSystem() {
+		return system;
+	}
+	public CodeParameter setSystem(String system) {
+		this.system = system;
+		return this;
+	}
+	public String getValue() {
+		return value;
+	}
+	public CodeParameter setValue(String value) {
+		this.value = value;
+		return this;
+	}
+
+	public String getDisplay() {
+		return display;
+	}
+
+	public CodeParameter setDisplay(String display) {
+		this.display = display;
+		return this;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public CodeParameter setVersion(String version) {
+		this.version = version;
+		return this;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		Code code = new Code();
+		code.setSystem(system);
+		code.setCode(this.value);
+		code.setDisplay(this.display);
+		code.setVersion(version);
+		
+		return code;
+	}
+	
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/ConceptParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/ConceptParameter.java
@@ -1,0 +1,76 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.opencds.cqf.cql.engine.runtime.Code;
+import org.opencds.cqf.cql.engine.runtime.Concept;
+
+
+public class ConceptParameter extends Parameter {
+	
+	private String display;
+	
+	@NotNull
+	@Size(min=1)
+	@Valid
+	private List<CodeParameter> codes;
+	
+	public ConceptParameter() {
+		setType(ParameterType.CONCEPT);
+	}
+	
+	public ConceptParameter(String display, CodeParameter ...codes) {
+		this();
+		setDisplay(display);
+		if( codes != null ) {
+			setCodes( Arrays.asList(codes) );
+		}
+	}
+	
+	public ConceptParameter(String display, List<CodeParameter> codes) {
+		this();
+		setDisplay(display);
+		if( codes != null ) {
+			setCodes( codes );
+		}
+	}
+	
+	public String getDisplay() {
+		return this.display;
+	}
+	
+	public ConceptParameter setDisplay(String display) {
+		this.display = display;
+		return this;
+	}
+	
+	public List<CodeParameter> getCodes() {
+		return codes;
+	}
+
+	public void setCodes(List<CodeParameter> codes) {
+		this.codes = codes;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		Concept concept = new Concept();
+		concept.withDisplay(this.display);
+		if( codes != null ) {
+			for( CodeParameter param : codes ) {
+				concept.withCode( (Code) param.toCqlType() );
+			}
+		}
+		return concept;
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DateParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DateParameter.java
@@ -1,0 +1,23 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import org.opencds.cqf.cql.engine.runtime.Date;
+
+public class DateParameter extends StringBackedParameter {
+	public DateParameter() {
+		setType(ParameterType.DATE);
+	}
+	public DateParameter(String value) {
+		this();
+		setValue(value);
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new Date(getValue());
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DatetimeParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DatetimeParameter.java
@@ -1,0 +1,27 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import java.time.ZoneOffset;
+
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+
+public class DatetimeParameter extends StringBackedParameter {
+	public static final String DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZZ";
+	
+	public DatetimeParameter() {
+		setType(ParameterType.DATETIME);
+	}
+	public DatetimeParameter(String value) {
+		this();
+		setValue(value);
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new DateTime(getValue().replace("@",""), ZoneOffset.UTC);
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DecimalParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/DecimalParameter.java
@@ -1,0 +1,23 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import java.math.BigDecimal;
+
+public class DecimalParameter extends StringBackedParameter {
+	public DecimalParameter() {
+		setType(ParameterType.DECIMAL);
+	}
+	public DecimalParameter(String value) {
+		this();
+		setValue( value );
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new BigDecimal(getValue());
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/IntegerParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/IntegerParameter.java
@@ -1,0 +1,36 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.constraints.NotNull;
+
+public class IntegerParameter extends Parameter {
+	
+	@NotNull
+	private Integer value;
+	
+	public IntegerParameter() {
+		setType(ParameterType.INTEGER);
+	}
+	
+	public IntegerParameter(int value) { 
+		this();
+		setValue(value);
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public void setValue(int value) {
+		this.value = value;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return value;
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/IntervalParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/IntervalParameter.java
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+public class IntervalParameter extends Parameter {
+	@NotNull
+	@Valid
+	private Parameter start;
+	private boolean startInclusive = true;
+	@NotNull
+	@Valid
+	private Parameter end;	
+	private boolean endInclusive = true;
+	
+	public IntervalParameter() { 
+		setType(ParameterType.INTERVAL);
+	}
+	
+	public IntervalParameter( Parameter start, boolean startInclusive, Parameter end, boolean endInclusive ) {
+		this();
+		setStart(start);
+		setStartInclusive(startInclusive);
+		setEnd(end);
+		setEndInclusive(endInclusive);
+	}
+	
+	public Parameter getStart() {
+		return start;
+	}
+	public IntervalParameter setStart(Parameter start) {
+		this.start = start;
+		return this;
+	}
+
+	public boolean isStartInclusive() {
+		return startInclusive;
+	}
+	public IntervalParameter setStartInclusive(boolean startInclusive) {
+		this.startInclusive = startInclusive;
+		return this;
+	}
+	
+	public Parameter getEnd() {
+		return end;
+	}
+	public IntervalParameter setEnd(Parameter end) {
+		this.end = end;
+		return this;
+	}
+
+	public boolean isEndInclusive() {
+		return endInclusive;
+	}
+
+	public IntervalParameter setEndInclusive(boolean endInclusive) {
+		this.endInclusive = endInclusive;
+		return this;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new Interval( start.toCqlType(), startInclusive, end.toCqlType(), endInclusive );
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/Parameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/Parameter.java
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.EXISTING_PROPERTY)
+@JsonSubTypes({
+	@JsonSubTypes.Type( value = IntegerParameter.class, name = ParameterType.INTEGER ),
+	@JsonSubTypes.Type( value = DecimalParameter.class, name = ParameterType.DECIMAL ),
+	@JsonSubTypes.Type( value = StringParameter.class, name = ParameterType.STRING ),
+	@JsonSubTypes.Type( value = BooleanParameter.class, name = ParameterType.BOOLEAN ),
+	@JsonSubTypes.Type( value = DatetimeParameter.class, name = ParameterType.DATETIME ),
+	@JsonSubTypes.Type( value = DateParameter.class, name = ParameterType.DATE ),
+	@JsonSubTypes.Type( value = TimeParameter.class, name = ParameterType.TIME ),
+	@JsonSubTypes.Type( value = QuantityParameter.class, name = ParameterType.QUANTITY ),
+	@JsonSubTypes.Type( value = RatioParameter.class, name = ParameterType.RATIO ),
+	@JsonSubTypes.Type( value = IntervalParameter.class, name = ParameterType.INTERVAL ),
+	@JsonSubTypes.Type( value = CodeParameter.class, name = ParameterType.CODE ),
+	@JsonSubTypes.Type( value = ConceptParameter.class, name = ParameterType.CONCEPT )
+	
+})
+public abstract class Parameter {
+	private String type;
+	
+	public String getType() {
+		return type;
+	}
+	public Parameter setType(String type) {
+		this.type = type;
+		return this;
+	}
+	
+	public abstract Object toCqlType();
+	
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+	
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/ParameterType.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/ParameterType.java
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+public class ParameterType {
+	private ParameterType() {}
+	
+	public static final String INTEGER = "integer";
+	public static final String DECIMAL = "decimal";
+	public static final String BOOLEAN = "boolean";
+	public static final String STRING = "string";
+	public static final String DATETIME = "datetime";
+	public static final String DATE = "date";
+	public static final String TIME = "time";
+	public static final String QUANTITY = "quantity";
+	public static final String RATIO = "ratio";
+	public static final String CODE = "code";
+	public static final String CONCEPT = "concept";
+	public static final String INTERVAL = "interval";
+	public static final String SIMPLE = "simple";
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/QuantityParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/QuantityParameter.java
@@ -1,0 +1,49 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import java.math.BigDecimal;
+
+import javax.validation.constraints.NotNull;
+
+import org.opencds.cqf.cql.engine.runtime.Quantity;
+
+public class QuantityParameter extends Parameter {
+	@NotNull
+	private String amount;
+	@NotNull
+	private String unit;
+	
+	public QuantityParameter() { 
+		setType(ParameterType.QUANTITY);
+	}
+	
+	public QuantityParameter(String amount, String unit) {
+		this();
+		setAmount(amount);
+		setUnit(unit);
+	}
+	
+	public String getAmount() {
+		return amount;
+	}
+	public QuantityParameter setAmount(String amount) {
+		this.amount = amount;
+		return this;
+	}
+	public String getUnit() {
+		return unit;
+	}
+	public QuantityParameter setUnit(String unit) {
+		this.unit = unit;
+		return this;
+	}	
+	
+	@Override
+	public Object toCqlType() {
+		return new Quantity().withUnit(unit).withValue(new BigDecimal(amount));
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/RatioParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/RatioParameter.java
@@ -1,0 +1,52 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.opencds.cqf.cql.engine.runtime.Quantity;
+import org.opencds.cqf.cql.engine.runtime.Ratio;
+
+public class RatioParameter extends Parameter {
+	@NotNull
+	@Valid
+	private QuantityParameter numerator;
+	@NotNull
+	@Valid
+	private QuantityParameter denominator;
+	
+	public RatioParameter() { 
+		setType(ParameterType.RATIO);
+	}
+	
+	public RatioParameter(QuantityParameter numerator, QuantityParameter denominator) {
+		this();
+		setNumerator( numerator );
+		setDenominator( denominator );
+	}
+	
+	public QuantityParameter getNumerator() {
+		return numerator;
+	}
+	public RatioParameter setNumerator(QuantityParameter numerator) {
+		this.numerator = numerator;
+		return this;
+	}
+	
+	public QuantityParameter getDenominator() {
+		return denominator;
+	}
+	public RatioParameter setDenominator(QuantityParameter denominator) {
+		this.denominator = denominator;
+		return this;
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new Ratio().setNumerator((Quantity)numerator.toCqlType()).setDenominator((Quantity)denominator.toCqlType());
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/StringBackedParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/StringBackedParameter.java
@@ -1,0 +1,30 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import javax.validation.constraints.NotNull;
+
+public abstract class StringBackedParameter extends Parameter {
+	@NotNull
+	private String value;
+	
+	public StringBackedParameter() {
+		setType(ParameterType.SIMPLE);
+	}
+	
+	public StringBackedParameter(String value) {
+		this();
+		setValue(value);
+	}
+	
+	public String getValue() {
+		return value;
+	}
+	public Parameter setValue(String value) {
+		this.value = value;
+		return this;
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/StringParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/StringParameter.java
@@ -1,0 +1,22 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+public class StringParameter extends StringBackedParameter {
+	public StringParameter() {
+		setType(ParameterType.STRING);
+	}
+	
+	public StringParameter(String value) {
+		this();
+		setValue(value);
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return getValue();
+	}
+}

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/TimeParameter.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/parameters/TimeParameter.java
@@ -1,0 +1,23 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import org.opencds.cqf.cql.engine.runtime.Time;
+
+public class TimeParameter extends StringBackedParameter {
+	public TimeParameter() {
+		setType(ParameterType.TIME);
+	}
+	public TimeParameter(String value) {
+		this();
+		setValue(value);
+	}
+	
+	@Override
+	public Object toCqlType() {
+		return new Time(getValue().replace("@", ""));
+	}
+}

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlContextFactoryTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlContextFactoryTest.java
@@ -20,6 +20,9 @@ import org.opencds.cqf.cql.engine.execution.Context;
 
 import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.evaluation.CqlContextFactory.ContextCacheKey;
+import com.ibm.cohort.cql.evaluation.parameters.IntegerParameter;
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
+import com.ibm.cohort.cql.evaluation.parameters.StringParameter;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor.Format;
@@ -53,9 +56,9 @@ public class CqlContextFactoryTest {
         
         Pair<String,String> contextData = Pair.of("Patient", "123");
         
-        Map<String,Object> expectedParams = new HashMap<>();
-        expectedParams.put("P1", "MyString");
-        expectedParams.put("P2", 10);
+        Map<String,Parameter> expectedParams = new HashMap<>();
+        expectedParams.put("P1", new StringParameter("MyString"));
+        expectedParams.put("P2", new IntegerParameter(10));
         
         CqlContextFactory cqlContextFactory = spy(CqlContextFactory.class);
         
@@ -70,9 +73,9 @@ public class CqlContextFactoryTest {
         assertEquals(topLevelLibrary.getLibraryId(), context.getCurrentLibrary().getIdentifier().getId());
         assertEquals(topLevelLibrary.getVersion(), context.getCurrentLibrary().getIdentifier().getVersion());
         
-        for( Map.Entry<String, Object> entry : expectedParams.entrySet() ) {
+        for( Map.Entry<String, Parameter> entry : expectedParams.entrySet() ) {
             Object actualValue = context.resolveParameterRef(null, entry.getKey());
-            assertEquals( entry.getValue(), actualValue );
+            assertEquals( entry.getValue().toCqlType(), actualValue );
         }
         
         // Once more just to check that caching is working. Using a different data provider because that is
@@ -92,7 +95,7 @@ public class CqlContextFactoryTest {
         
         CqlLibraryDescriptor topLevelLibrary = new CqlLibraryDescriptor().setLibraryId("Test").setVersion("1.0.0").setFormat(Format.ELM);
         
-        Map<String,Object> parameters = new HashMap<>();
+        Map<String,Parameter> parameters = new HashMap<>();
         ZonedDateTime evaluationDateTime = ZonedDateTime.now();
         
         

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequestsTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequestsTest.java
@@ -9,18 +9,22 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import com.ibm.cohort.cql.evaluation.parameters.DecimalParameter;
+import com.ibm.cohort.cql.evaluation.parameters.IntegerParameter;
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
+import com.ibm.cohort.cql.evaluation.parameters.StringParameter;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 
 public class CqlEvaluationRequestsTest {
     @Test
     public void testSetGet() {
-        Map<String,Object> globalParameters = new HashMap<>();
-        globalParameters.put("String", "Hello,World");
-        globalParameters.put("Integer", 10);
+        Map<String,Parameter> globalParameters = new HashMap<>();
+        globalParameters.put("String", new StringParameter("Hello,World"));
+        globalParameters.put("Integer", new IntegerParameter(10));
         
-        Map<String,Object> localParameters = new HashMap<>();
-        localParameters.put("String", "Goodbye, Cruel World");
-        localParameters.put("Float", 1.29f);
+        Map<String,Parameter> localParameters = new HashMap<>();
+        localParameters.put("String", new StringParameter("Goodbye, Cruel World"));
+        localParameters.put("Float", new DecimalParameter("1.29f"));
         
         CqlLibraryDescriptor desc = new CqlLibraryDescriptor().setLibraryId("SampleLibrary").setVersion("1.0.0");
         

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
@@ -6,15 +6,20 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import com.ibm.cohort.cql.data.CqlDataProvider;
+import com.ibm.cohort.cql.evaluation.parameters.IntegerParameter;
+import com.ibm.cohort.cql.evaluation.parameters.Parameter;
 import com.ibm.cohort.cql.library.CqlLibrary;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor.Format;
@@ -49,7 +54,7 @@ public class CqlEvaluatorTest {
         
         CqlLibrary library = new CqlLibrary()
                 .setDescriptor(libraryDescriptor)
-                .setContent("library \"Sample\" version '1.0.0'\ndefine \"Something\":1<10\ndefine \"OtherThing\":10<1");
+                .setContent("library \"Sample\" version '1.0.0'\nparameter MinimumAge Integer\n\ndefine \"Something\":1<10\ndefine \"OtherThing\":10<1\ndefine EchoParam: MinimumAge");
         
         CqlTerminologyProvider terminologyProvider = mock(CqlTerminologyProvider.class);
         CqlDataProvider dataProvider = mock(CqlDataProvider.class); 
@@ -65,15 +70,81 @@ public class CqlEvaluatorTest {
                 .setDataProvider(dataProvider)
                 .setLibraryProvider(translatingProvider);
         
-        Map<String,Object> parameters = new HashMap<>();
-        parameters.put("MinimumAge", 17);
+        int expectedMinimumAge = 17;
+        
+        Map<String,Parameter> parameters = new HashMap<>();
+        parameters.put("MinimumAge", new IntegerParameter(expectedMinimumAge));
         
         Pair<String,String> context = Pair.of("Patient", "123");
         
         CqlEvaluationResult result = evaluator.evaluate(libraryDescriptor, parameters, context);
         assertNotNull(result);
+        assertEquals(3, result.getExpressionResults().size());
+        assertEquals(true, result.getExpressionResults().get("Something"));
+        assertEquals(expectedMinimumAge, result.getExpressionResults().get("EchoParam"));
+    }
+    
+    @Test
+    public void testBatchEvaluation() {
+        
+        CqlLibraryDescriptor libraryDescriptor = new CqlLibraryDescriptor()
+                .setLibraryId("Sample")
+                .setVersion("1.0.0")
+                .setFormat(Format.CQL);
+        
+        CqlLibrary library = new CqlLibrary()
+                .setDescriptor(libraryDescriptor)
+                .setContent("library \"Sample\" version '1.0.0'\nparameter MinimumAge Integer\n\ndefine \"Something\":1<10\ndefine \"OtherThing\":10<1\ndefine EchoParam: MinimumAge");
+        
+        CqlTerminologyProvider terminologyProvider = mock(CqlTerminologyProvider.class);
+        CqlDataProvider dataProvider = mock(CqlDataProvider.class); 
+        
+        CqlLibraryProvider libraryProvider = mock(CqlLibraryProvider.class);
+        when(libraryProvider.getLibrary(libraryDescriptor)).thenReturn(library);
+        
+        CqlToElmTranslator translator = new CqlToElmTranslator();
+        TranslatingCqlLibraryProvider translatingProvider = new TranslatingCqlLibraryProvider(libraryProvider, translator);
+        
+        CqlEvaluator evaluator = new CqlEvaluator()
+                .setTerminologyProvider(terminologyProvider)
+                .setDataProvider(dataProvider)
+                .setLibraryProvider(translatingProvider);
+
+        String parameterName = "MinimumAge";
+        int expectedMinimumAge = 17;
+        int expectedGlobalMinimumAge = expectedMinimumAge + 10;
+        
+        Map<String,Parameter> parameters = new HashMap<>();
+        parameters.put(parameterName, new IntegerParameter(expectedMinimumAge));
+        
+        Pair<String,String> context = Pair.of("Patient", "123");
+        
+        CqlEvaluationRequest request = new CqlEvaluationRequest();
+        request.setDescriptor(libraryDescriptor);
+        request.setExpressions(Arrays.asList("Something", "EchoParam").stream().collect(Collectors.toSet()));
+        request.setParameters(parameters);
+        request.setContextKey(context.getKey());
+        request.setContextValue(context.getValue());
+        
+        CqlEvaluationRequests requests = new CqlEvaluationRequests();
+        requests.setEvaluations(Arrays.asList(request));
+        requests.setGlobalParameters(Collections.singletonMap(parameterName, new IntegerParameter(expectedGlobalMinimumAge)));
+        
+        // First do a full request with parameter override
+        List<Pair<CqlEvaluationRequest,CqlEvaluationResult>> results = evaluator.evaluate(requests);
+        assertEquals(1, results.size());
+        CqlEvaluationResult result = results.get(0).getRight();
+        assertNotNull(result);
         assertEquals(2, result.getExpressionResults().size());
         assertEquals(true, result.getExpressionResults().get("Something"));
+        assertEquals(expectedMinimumAge, result.getExpressionResults().get("EchoParam"));
+        
+        // Now use the global parameter value instead
+        request.getParameters().clear();
+        results = evaluator.evaluate(requests);
+        assertEquals(1, results.size());
+        result = results.get(0).getRight();
+        assertEquals(expectedGlobalMinimumAge, result.getExpressionResults().get("EchoParam"));
     }
     
     @Test

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/parameters/ParameterTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/parameters/ParameterTest.java
@@ -1,0 +1,299 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.evaluation.parameters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opencds.cqf.cql.engine.runtime.DateTime;
+import org.opencds.cqf.cql.engine.runtime.Interval;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ParameterTest {
+	protected static Validator validator = null;
+	
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		// See https://openliberty.io/guides/bean-validation.html
+		//TODO: The validator below is recommended to be injected using CDI in the guide
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		validator = factory.getValidator();
+	}
+	
+	@Test
+	public void when_serialize_deserialize___properties_remain_the_same() throws Exception {
+		Parameter integer = new IntegerParameter(10);
+		Parameter decimal = new DecimalParameter("+100.99e10");
+		Parameter bool = new BooleanParameter(true);
+		Parameter str = new StringParameter("StringValueHere");
+		Parameter date = new DateParameter("2020-07-04");
+		Parameter datetime = new DatetimeParameter("2020-07-04T23:00:00-05:00");
+		Parameter time = new TimeParameter("@T23:00:00");
+
+		QuantityParameter quantity = new QuantityParameter("10", "mg/mL");
+		QuantityParameter denominator = new QuantityParameter("100", "mg/mL");
+		Parameter ratio = new RatioParameter(quantity, denominator);
+		Parameter end = new IntegerParameter(1000);
+		Parameter interval = new IntervalParameter(integer, true, end, false);
+		CodeParameter code = new CodeParameter("http://hl7.org/terminology/blob", "1234", "Blob", "1.0.0");
+		Parameter concept = new ConceptParameter("MyConcept", code);
+		
+		List<Parameter> parameters = Arrays.asList(integer, decimal, bool, str, date, datetime, time, quantity, denominator, ratio, interval, code, concept);
+		
+		ObjectMapper mapper = new ObjectMapper();
+		String serialized = mapper.writeValueAsString(parameters);
+		System.out.println(serialized);
+		assertFalse( serialized.contains("com.ibm") );
+		
+		List<Parameter> deserialized = mapper.readValue(serialized, new TypeReference<List<Parameter>>(){});
+		assertEquals( parameters.size(), deserialized.size() );
+		
+		for( int i=0; i<deserialized.size(); i++ ) {
+			Parameter expected = parameters.get(i);
+			Parameter actual = deserialized.get(i);
+			
+			assertEquals( expected, actual );
+		}
+		
+		for( Parameter param : deserialized ) {
+			assertNotNull( param.toCqlType() );
+		}
+	}
+	
+	@Test
+	public void datetime_interval_with_non_inclusive_end___ends_just_before_value() {
+		IntervalParameter parameter = new IntervalParameter(
+				new DatetimeParameter("2020-03-14T00:00:00.0-05:00"),
+				true,
+				new DatetimeParameter("2021-03-14T00:00:00.0-05:00"),
+				false
+				);
+		
+		Interval interval = (Interval) parameter.toCqlType();
+		assertEquals("2021-03-13T23:59:59.999", interval.getEnd().toString());
+	}
+
+	@Test
+	public void datetime_with_no_time_or_timezone___defaults_to_midnight_UTC() {
+		DatetimeParameter parameter = new DatetimeParameter("2020-01-01");
+
+		DateTime dateTime = (DateTime) parameter.toCqlType();
+
+		DateTime expectedDateTime = new DateTime(OffsetDateTime.of(LocalDate.of(2020, 1,1), LocalTime.MIN, ZoneOffset.UTC));
+		assertEquals(ZoneOffset.UTC, dateTime.getDateTime().getOffset());
+		assertEquals(expectedDateTime.toJavaDate(), dateTime.toJavaDate());
+	}
+
+	@Test
+	public void datetime_with_no_timezone___defaults_to_UTC() {
+		DatetimeParameter parameter = new DatetimeParameter("2020-01-01T00:00:00.0");
+
+		DateTime dateTime = (DateTime) parameter.toCqlType();
+
+		DateTime expectedDateTime = new DateTime(OffsetDateTime.of(LocalDate.of(2020, 1,1), LocalTime.MIN, ZoneOffset.UTC));
+		assertEquals(ZoneOffset.UTC, dateTime.getDateTime().getOffset());
+		assertEquals(expectedDateTime.toJavaDate(), dateTime.toJavaDate());
+	}
+	
+	@Test
+	public void boolean_parameter_no_value___fails_validation() {
+		BooleanParameter param = new BooleanParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void boolean_parameter_with_value___passes_validation() {
+		BooleanParameter param = new BooleanParameter(false);
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void code_parameter_no_value___fails_validation() {
+		CodeParameter param = new CodeParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void code_parameter_with_value___passes_validation() {
+		CodeParameter param = new CodeParameter();
+		param.setValue("initial-population");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void concept_parameter_null_codes___fails_validation() {
+		ConceptParameter param = new ConceptParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void concept_parameter_empty_codes___fails_validation() {
+		ConceptParameter param = new ConceptParameter("dislay", Collections.emptyList());
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void concept_parameter_with_codes___passes_validation() {
+		CodeParameter code = new CodeParameter("system", "value", "display", "version");
+		ConceptParameter param = new ConceptParameter("myconcept", Arrays.asList(code));
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void date_parameter_no_value___fails_validation() {
+		DateParameter param = new DateParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void date_parameter_with_value___passes_validation() {
+		DateParameter param = new DateParameter("@2020-10-10");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void datetime_parameter_no_value___fails_validation() {
+		DatetimeParameter param = new DatetimeParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void datetime_parameter_with_value___passes_validation() {
+		DatetimeParameter param = new DatetimeParameter("@2020-10-10T00:00:00.0-05:00");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void decimal_parameter_no_value___fails_validation() {
+		DecimalParameter param = new DecimalParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void decimal_parameter_with_value___passes_validation() {
+		DecimalParameter param = new DecimalParameter("1.09e-123");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void integer_parameter_no_value___fails_validation() {
+		IntegerParameter param = new IntegerParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void integer_parameter_with_value___passes_validation() {
+		IntegerParameter param = new IntegerParameter(10);
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void interval_parameter_no_value___fails_validation() {
+		IntervalParameter param = new IntervalParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(2, violations.size());
+	}
+	
+	@Test
+	public void interval_parameter_with_value___passes_validation() {
+		IntervalParameter param = new IntervalParameter(new IntegerParameter(10), true, new IntegerParameter(100), false);
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void quantity_parameter_no_value___fails_validation() {
+		QuantityParameter param = new QuantityParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(2, violations.size());
+	}
+	
+	@Test
+	public void quantity_parameter_with_value___passes_validation() {
+		QuantityParameter param = new QuantityParameter("10", "mg/mL");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void ratio_parameter_no_value___fails_validation() {
+		RatioParameter param = new RatioParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(2, violations.size());
+	}
+	
+	@Test
+	public void ratio_parameter_with_value___passes_validation() {
+		QuantityParameter numerator = new QuantityParameter("10", "mg/mL");
+		QuantityParameter denominator = new QuantityParameter("100", "mg/mL");
+		
+		RatioParameter param = new RatioParameter(numerator, denominator);
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void string_parameter_no_value___fails_validation() {
+		StringParameter param = new StringParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void string_parameter_with_value___passes_validation() {
+		StringParameter param = new StringParameter("mystring");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+	
+	@Test
+	public void time_parameter_no_value___fails_validation() {
+		StringParameter param = new StringParameter();
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(1, violations.size());
+	}
+	
+	@Test
+	public void time_parameter_with_value___passes_validation() {
+		StringParameter param = new StringParameter("T20:30:40.500");
+		Set<ConstraintViolation<Parameter>> violations = validator.validate(param);
+		assertEquals(0, violations.size());
+	}
+}


### PR DESCRIPTION
I used the existing classes from from the cql-engine project. I didn't
want to link in the classes from the cql-engine directly because that
project has a number of HAPI FHIR dependencies that we don't want to
depend on in the spark application. I could certainly jump through some
hoops with dependency management, but I think this is the best plan for
now. Long-term plan I want to migrate all of the functionality from the
cql-engine to new projects like this one (probably at least one more for
measure-evaluator) and then do away with that project.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>