### PR TITLE
Added copyright header to all files where it was missing.

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/helpers/MeasurementPeriodHelper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/helpers/MeasurementPeriodHelper.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.helpers;
 
 import java.time.ZoneOffset;

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/CQLToFHIRMeasureReportHelper.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/CQLToFHIRMeasureReportHelper.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 import java.math.BigDecimal;

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4ParameterDefinitionWithDefaultToCohortParameterConverter.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/measure/R4ParameterDefinitionWithDefaultToCohortParameterConverter.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 import java.util.stream.Collectors;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureEvaluationTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.cqfruler;
 
 import static org.hl7.fhir.r4.model.MeasureReport.MeasureReportType.SUBJECTLIST;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/helpers/MeasurementPeriodHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/helpers/MeasurementPeriodHelperTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.helpers;
 
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/CQLToFHIRMeasureReportHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/CQLToFHIRMeasureReportHelperTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureContextTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureContextTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/R4ParameterDefinitionWithDefaultToCohortParameterConverterTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/R4ParameterDefinitionWithDefaultToCohortParameterConverterTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure;
 
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeederTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/seed/MeasureEvaluationSeederTest.java
@@ -1,10 +1,13 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.measure.seed;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/R4RestFhirRetrieveProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/R4RestFhirRetrieveProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2020, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.engine.retrieve;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/aws/ObjectConsumer.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/aws/ObjectConsumer.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.aws;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextDefinition.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextDefinition.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.aggregation;
 
 import java.util.List;

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextDefinitions.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextDefinitions.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.aggregation;
 
 import java.util.List;

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/Join.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/Join.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ManyToMany.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ManyToMany.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.aggregation;
 
 public class ManyToMany extends Join {

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/OneToMany.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/OneToMany.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.aggregation;
 
 public class OneToMany extends Join {

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/util/MapUtils.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/util/MapUtils.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.util;
 
 import java.util.Map;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientConfigFactoryTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientConfigFactoryTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.aws;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientConfigTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientConfigTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.aws;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientFactoryTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientFactoryTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.aws;
 
 import static org.junit.Assert.assertNotNull;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientHelpersTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/aws/AWSClientHelpersTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.aws;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/library/s3/S3CqlLibraryProviderTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/library/s3/S3CqlLibraryProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library.s3;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/BaseSparkTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/BaseSparkTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark;
 
 import java.io.Serializable;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/data/Patient.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/data/Patient.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.spark.data;
 
 import java.time.LocalDate;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/data/CompositeCqlDataProvider.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/data/CompositeCqlDataProvider.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.data;
 
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlDebug.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlDebug.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 public enum CqlDebug {

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import java.util.Map;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequests.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequests.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import java.util.List;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/ClasspathCqlLibraryProvider.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/ClasspathCqlLibraryProvider.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library;
 
 import java.io.IOException;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/PriorityCqlLibraryProvider.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/PriorityCqlLibraryProvider.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library;
 
 import java.util.ArrayList;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlContextFactoryTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlContextFactoryTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequestsTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationRequestsTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationResultTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluationResultTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.evaluation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/CqlLibraryDeserializationExceptionTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/CqlLibraryDeserializationExceptionTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/DirectoryBasedCqlLibraryProviderTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/DirectoryBasedCqlLibraryProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/ProviderBasedLibraryLoaderTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/library/ProviderBasedLibraryLoaderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.library;
 
 import static org.junit.Assert.assertThrows;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/terminology/UnsupportedTerminologyProviderTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/terminology/UnsupportedTerminologyProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.terminology;
 
 import static org.junit.Assert.assertThrows;
@@ -5,7 +11,7 @@ import static org.junit.Assert.assertThrows;
 import org.junit.Before;
 import org.junit.Test;
 
-public class UnsupportedTerminologyTest {
+public class UnsupportedTerminologyProviderTest {
     CqlTerminologyProvider terminologyProvider;
     
     @Before

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/translation/CqlToElmTranslatorTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/translation/CqlToElmTranslatorTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.translation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/translation/TranslatingCqlLibraryProviderTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/translation/TranslatingCqlLibraryProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.cql.translation;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/engine/DataRowDataProvider.java
+++ b/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/engine/DataRowDataProvider.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.datarow.engine;
 
 import org.opencds.cqf.cql.engine.data.CompositeDataProvider;

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowDataProviderTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowDataProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.datarow.engine;
 
 import static org.junit.Assert.assertEquals;

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowModelResolverTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowModelResolverTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.cohort.datarow.engine;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
There were a bunch of files - mostly from new projects, but also some in the cql-engine project - missing a copyright header. I added the header wherever it was missing.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>