### PR TITLE
Switch DataRowRetrieveProvider to use Code equivalence checking

### DIFF
--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/data/SparkDataRowTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/data/SparkDataRowTest.java
@@ -32,6 +32,7 @@ import com.ibm.cohort.cql.spark.BaseSparkTest;
 import com.ibm.cohort.datarow.exception.UnsupportedConversionException;
 
 public class SparkDataRowTest extends BaseSparkTest {
+    private static final String SNOMED = "http://snomed.info/sct";
     private static final long serialVersionUID = 1L;
 
     @Test
@@ -230,7 +231,7 @@ public class SparkDataRowTest extends BaseSparkTest {
                 .putString(SparkDataRow.DISPLAY_COL, "display")
                 .build();
 
-        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", "http://snomed.info/sct", "A Code");
+        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", SNOMED, "A Code");
         
         SparkDataRow sdr = runMetadataTest(pojo, codeMetadata);
         
@@ -242,9 +243,30 @@ public class SparkDataRowTest extends BaseSparkTest {
     }
     
     @Test
+    public void testConversionSemanticsAsCodeCodeAndDefaultSystem() {
+        Metadata codeMetadata = new MetadataBuilder()
+                .putBoolean(SparkDataRow.IS_CODE_COL, Boolean.TRUE)
+                .putString(SparkDataRow.SYSTEM, SNOMED)
+                .putString(SparkDataRow.SYSTEM_COL, null)
+                .putString(SparkDataRow.DISPLAY_COL, null)
+                .build();
+
+        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", null, null);
+        
+        SparkDataRow sdr = runMetadataTest(pojo, codeMetadata);
+        
+        Object converted = sdr.getValue("code");
+        Code code = (Code) converted;
+        assertEquals( pojo.getCodeStr(), code.getCode() );
+        assertEquals( SNOMED, code.getSystem() );
+        assertEquals( null, code.getDisplay() );
+        assertEquals( null, code.getVersion() );
+    }
+    
+    @Test
     public void testConversionSemanticsAsCodeOnlyCode() {
 
-        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", "http://snomed.info/sct", "A Code");
+        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", SNOMED, "A Code");
 
         Metadata codeMetadata = new MetadataBuilder()
                 .putBoolean(SparkDataRow.IS_CODE_COL, Boolean.TRUE)
@@ -263,7 +285,7 @@ public class SparkDataRowTest extends BaseSparkTest {
     @Test
     public void testConversionSemanticsAsCodeFalse() {
         
-        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", "http://snomed.info/sct", "A Code");
+        CodeWithMetadataPOJO pojo = new CodeWithMetadataPOJO("123", SNOMED, "A Code");
 
         Metadata codeMetadata = new MetadataBuilder()
                 .putBoolean(SparkDataRow.IS_CODE_COL, Boolean.FALSE)

--- a/cohort-model-datarow/pom.xml
+++ b/cohort-model-datarow/pom.xml
@@ -30,6 +30,12 @@
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/engine/DataRowRetrieveProvider.java
+++ b/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/engine/DataRowRetrieveProvider.java
@@ -23,7 +23,7 @@ import com.ibm.cohort.datarow.model.DataRow;
 
 /**
  * This is an implementation of the CQL RetrieveProvider interface for input
- * data that is a Map of <code>dataType</code> strings to lists of DataRow
+ * data that is a Map of <code>dataType</code> strings to lists of <code>DataRow<code>
  * objects. Retrieval is optionally filtered by the <code>codePath</code> when
  * provided. Codes are indexed on first use for faster retrieval on subsequent
  * data operations. Date range filtering is not supported.
@@ -70,14 +70,16 @@ public class DataRowRetrieveProvider implements RetrieveProvider {
                     for (Object obj : allRows) {
                         DataRow row = (DataRow) obj;
                         Object code = row.getValue(codePath);
-                        if (code instanceof String) {
-                            code = new CodeKey().withCode((String) code);
-                        } else if (code instanceof Code) {
-                            code = new CodeKey((Code) code);
+                        if( code != null ) {
+                            if (code instanceof Code) {
+                                code = new CodeKey((Code) code);
+                            } else {
+                                code = new CodeKey().withCode(String.valueOf(code));
+                            }
+    
+                            List<Object> list = codeMap.computeIfAbsent(code, codeKey -> new ArrayList<>());
+                            list.add(row);
                         }
-
-                        List<Object> list = codeMap.computeIfAbsent(code, codeKey -> new ArrayList<>());
-                        list.add(row);
                     }
                 }
                 return codeMap;

--- a/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/model/CodeKey.java
+++ b/cohort-model-datarow/src/main/java/com/ibm/cohort/datarow/model/CodeKey.java
@@ -9,9 +9,12 @@ package com.ibm.cohort.datarow.model;
 import org.opencds.cqf.cql.engine.runtime.Code;
 
 /**
- * The CQL Code type doesn't implement equals, so those objects don't make a
- * good index key. We provide an adapter here that implements the standard
- * equals and hashCode methods so that we can use codes as Map keys.
+ * This class is used as the map key for a cache in the retrieve provider that indexes
+ * data rows based on the codings contained in that data. Code equivalence checks
+ * are used for lookup per the CQL specification on filtered retrieves.
+ * 
+ * @see <a href="https://cql.hl7.org/02-authorsguide.html#filtering-with-terminology">Filtering with Terminology</a>
+ * @see <a href="https://cql.hl7.org/02-authorsguide.html#terminology-operators">Terminology Operations</a>
  */
 public class CodeKey extends Code {
 
@@ -26,7 +29,7 @@ public class CodeKey extends Code {
 
     @Override
     public boolean equals(Object o2) {
-        Boolean codeEquals = super.equal(o2);
+        Boolean codeEquals = super.equivalent(o2);
         return codeEquals != null && codeEquals;
     }
 
@@ -35,7 +38,6 @@ public class CodeKey extends Code {
         int hash = 7;
         hash = 31 * hash + (getCode() == null ? 0 : getCode().hashCode());
         hash = 31 * hash + (getSystem() == null ? 0 : getSystem().hashCode());
-        hash = 31 * hash + (getDisplay() == null ? 0 : getDisplay().hashCode());
         return hash;
     }
 }

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowRetrieveProviderTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowRetrieveProviderTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,16 +36,23 @@ public class DataRowRetrieveProviderTest {
 
     public static final String FIELD_PERSON_ID = "person_id";
     public static final String FIELD_GENDER = "gender";
+    public static final String FIELD_GENDER_CODE = "gender_code";
+    public static final String FIELD_AGE = "age";
+    public static final String FIELD_BIRTH_DATE = "birth_date";
 
     public static final String GENDER_FEMALE = "female";
     public static final String GENDER_MALE = "male";
 
+    LocalDate now;
+    
     DataRowRetrieveProvider retrieveProvider;
     TerminologyProvider termProvider;
     Map<String, Iterable<Object>> data;
 
     @Before
     public void setUp() {
+        now = LocalDate.now();
+        
         data = new HashMap<>();
         termProvider = mock(TerminologyProvider.class);
         retrieveProvider = new DataRowRetrieveProvider(data, termProvider);
@@ -52,11 +60,7 @@ public class DataRowRetrieveProviderTest {
 
     @Test
     public void testRetrieveNoCodeFilterHasDataKnownDataType() {
-        List<Object> people = new ArrayList<>();
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
@@ -66,11 +70,7 @@ public class DataRowRetrieveProviderTest {
 
     @Test
     public void testRetrieveNoCodeFilterUnknownDataType() {
-        List<Object> people = new ArrayList<>();
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, "unknown", null, null,
@@ -79,19 +79,13 @@ public class DataRowRetrieveProviderTest {
     }
 
     @Test
-    public void testRetrieveFilterByProvidedCodes() {
-        List<Object> people = new ArrayList<>();
-
+    public void testRetrieveFilterByProvidedCodes_dataForCodeIsString() {
         String maleId = "789";
-
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person(maleId, GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
-
+        
+        List<Object> people = makePeopleTestData(maleId);
         data.put(DATATYPE_PERSON, people);
 
-        List<Code> codes = Arrays.asList(GENDER_MALE).stream().map(g -> new Code().withCode(g))
+        List<Code> codes = Arrays.asList(GENDER_MALE).stream().map(this::code)
                 .collect(Collectors.toList());
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
@@ -106,44 +100,11 @@ public class DataRowRetrieveProviderTest {
     }
 
     @Test
-    public void testRetrieveFilterByCQLCodeColumn() {
-        List<Object> people = new ArrayList<>();
-
-        String maleId = "789";
-
-        people.add(person("123", code(GENDER_FEMALE)));
-        people.add(person("456", code(GENDER_FEMALE)));
-        people.add(person(maleId, code(GENDER_MALE)));
-        people.add(person("012", code(GENDER_FEMALE)));
-
+    public void testRetrieveFilterByProvidedCodes_noMatch() {
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
-        List<Code> codes = Arrays.asList(GENDER_MALE).stream().map(g -> new Code().withCode(g))
-                .collect(Collectors.toList());
-
-        Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
-                FIELD_GENDER, codes, null, null, null, null, null);
-        int count = 0;
-        for (Object obj : rows) {
-            count++;
-            DataRow actual = (DataRow) obj;
-            assertEquals(maleId, actual.getValue(FIELD_PERSON_ID));
-        }
-        assertEquals(1, count);
-    }
-
-    @Test
-    public void testRetrieveFilterByProvidedCodesNoMatch() {
-        List<Object> people = new ArrayList<>();
-
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
-
-        data.put(DATATYPE_PERSON, people);
-
-        List<Code> codes = Arrays.asList("unknown").stream().map(g -> new Code().withCode(g))
+        List<Code> codes = Arrays.asList("unknown").stream().map(this::code)
                 .collect(Collectors.toList());
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
@@ -152,20 +113,54 @@ public class DataRowRetrieveProviderTest {
     }
 
     @Test
-    public void testRetrieveFilterByProvidedCodesUnknownDataType() {
-        List<Object> people = new ArrayList<>();
-
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
-
+    public void testRetrieveFilterByProvidedCodes_unknownDataType() {
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
-        List<Code> codes = Arrays.asList("unknown").stream().map(g -> new Code().withCode(g))
+        List<Code> codes = Arrays.asList("unknown").stream().map(this::code)
                 .collect(Collectors.toList());
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, "unknown", null,
+                FIELD_GENDER, codes, null, null, null, null, null);
+        assertEquals(0, count(rows));
+    }
+    
+    @Test
+    public void testRetrieveFilterByProvidedCodes_dataForCodeIsInt() {
+        List<Object> people = makePeopleTestData();
+        data.put(DATATYPE_PERSON, people);
+
+        List<Code> codes = Arrays.asList("8").stream().map(this::code)
+                .collect(Collectors.toList());
+
+        Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
+                FIELD_AGE, codes, null, null, null, null, null);
+        assertEquals(1, count(rows));
+    }
+    
+    @Test
+    public void testRetrieveFilterByProvidedCodes_dataForCodeIsNull() {
+        List<Object> people = makePeopleTestData();
+        people.add(person("999", null, 104));
+        data.put(DATATYPE_PERSON, people);
+
+        List<Code> codes = Arrays.asList("female").stream().map(this::code)
+                .collect(Collectors.toList());
+
+        Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
+                FIELD_GENDER, codes, null, null, null, null, null);
+        assertEquals(3, count(rows));
+    }
+    
+    @Test
+    public void testRetrieveFilterByProvidedCodes_codesHaveSystem_dataForCodeDoesNot() {
+        List<Object> people = makePeopleTestData();
+        data.put(DATATYPE_PERSON, people);
+
+        List<Code> codes = Arrays.asList(GENDER_FEMALE).stream().map(this::code).map(c -> c.withSystem("http://snomed.info/sct"))
+                .collect(Collectors.toList());
+
+        Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
                 FIELD_GENDER, codes, null, null, null, null, null);
         assertEquals(0, count(rows));
     }
@@ -173,17 +168,11 @@ public class DataRowRetrieveProviderTest {
     @Test
     public void testRetrieveFilterByValueSet() {
         String valueSetId = "urn:oid:allowed-genders";
-        List<Code> codes = Arrays.asList(GENDER_MALE).stream().map(g -> new Code().withCode(g))
+        List<Code> codes = Arrays.asList(GENDER_MALE).stream().map(this::code)
                 .collect(Collectors.toList());
         when(termProvider.expand(argThat(a -> a.getId().equals(valueSetId)))).thenReturn(codes);
 
-        List<Object> people = new ArrayList<>();
-
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
-
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
         Iterable<Object> rows = retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID, null, DATATYPE_PERSON, null,
@@ -196,26 +185,55 @@ public class DataRowRetrieveProviderTest {
         String valueSetId = "urn:oid:allowed-genders";
         when(termProvider.expand(argThat(a -> a.getId().equals(valueSetId)))).thenReturn(null);
 
-        List<Object> people = new ArrayList<>();
-
-        people.add(person("123", GENDER_FEMALE));
-        people.add(person("456", GENDER_FEMALE));
-        people.add(person("789", GENDER_MALE));
-        people.add(person("012", GENDER_FEMALE));
-
+        List<Object> people = makePeopleTestData();
         data.put(DATATYPE_PERSON, people);
 
         assertThrows(IllegalArgumentException.class, () -> retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID,
                 null, DATATYPE_PERSON, null, FIELD_GENDER, null, valueSetId, null, null, null, null));
     }
+    
+    @Test
+    public void testRetrieveFilterByDateFilteringUnsupported() {
+        String valueSetId = "urn:oid:allowed-genders";
+        when(termProvider.expand(argThat(a -> a.getId().equals(valueSetId)))).thenReturn(null);
 
-    protected DataRow person(String id, Object gender) {
-        DataRow row;
-        Map<String, Object> female = new HashMap<>();
-        female.put(FIELD_PERSON_ID, id);
-        female.put(FIELD_GENDER, gender);
-        row = new SimpleDataRow(female);
-        return row;
+        List<Object> people = makePeopleTestData();
+        data.put(DATATYPE_PERSON, people);
+
+        // datePath
+        assertThrows(UnsupportedOperationException.class, () -> retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID,
+                null, DATATYPE_PERSON, null, FIELD_GENDER, null, valueSetId, FIELD_BIRTH_DATE, null, null, null));
+        
+        // dateLowPath
+        assertThrows(UnsupportedOperationException.class, () -> retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID,
+                null, DATATYPE_PERSON, null, FIELD_GENDER, null, valueSetId, null, FIELD_BIRTH_DATE, null, null));
+        
+        // dateHighPath
+        assertThrows(UnsupportedOperationException.class, () -> retrieveProvider.retrieve(CONTEXT_CLAIM, FIELD_PERSON_ID,
+                null, DATATYPE_PERSON, null, FIELD_GENDER, null, valueSetId, null, null, FIELD_BIRTH_DATE, null));
+    }
+    
+    protected List<Object> makePeopleTestData() {
+        return makePeopleTestData("789");
+    }
+
+    protected List<Object> makePeopleTestData(String maleId) {
+        List<Object> people = new ArrayList<>();
+        people.add(person("123", GENDER_FEMALE, 65));
+        people.add(person("456", GENDER_FEMALE, 42));
+        people.add(person("789", GENDER_MALE, 43));
+        people.add(person("012", GENDER_FEMALE, 8));
+        return people;
+    }
+    
+    protected DataRow person(String id, String gender, int age) {
+        Map<String, Object> person = new HashMap<>();
+        person.put(FIELD_PERSON_ID, id);
+        person.put(FIELD_GENDER, gender);
+        person.put(FIELD_GENDER_CODE, code(gender));
+        person.put(FIELD_AGE, age);
+        person.put(FIELD_BIRTH_DATE, now.minusYears(age));
+        return new SimpleDataRow(person);
     }
 
     protected Code code(String code) {

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/model/CodeKeyTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/model/CodeKeyTest.java
@@ -42,7 +42,8 @@ public class CodeKeyTest {
         map.put(new CodeKey().withCode("123").withSystem("http://snomed.info/sct"), "SNOMED");
         map.put(new CodeKey().withCode("123").withSystem("http://snomed.info/sct").withDisplay("display"), "Display");
 
-        assertEquals(6, map.size());
+        // We did 6 puts, but one only differed by display value which is not part of the key
+        assertEquals(5, map.size());
         String value = map.get(new CodeKey().withCode("123"));
         assertNotNull("Lookup by CodeKey failed", value);
         assertEquals("123", value);
@@ -79,5 +80,41 @@ public class CodeKeyTest {
         CodeKey codeKeyWithoutSystem = new CodeKey(data.withSystem(null));
 
         assertNotEquals(codeKeyWithSystem, codeKeyWithoutSystem);
+    }
+    
+    @Test
+    public void testCodeKeysEqualDifferentDisplay() {
+        Code baseline = new Code().withCode("123").withSystem("http://snomed.info/sct").withDisplay("display")
+                .withVersion("20200809");
+        
+        CodeKey left = new CodeKey(baseline);
+        
+        CodeKey right = new CodeKey(baseline);
+        right.withDisplay( right.getDisplay() + " does not match");
+
+        assertEquals(left, right);
+    }
+    
+    @Test
+    public void testCodeKeysEqualDifferentVersion() {
+        Code baseline = new Code().withCode("123").withSystem("http://snomed.info/sct").withDisplay("display")
+                .withVersion("20200809");
+        
+        CodeKey left = new CodeKey(baseline);
+        
+        CodeKey right = new CodeKey(baseline);
+        right.withVersion( right.getVersion() + ".rc1");
+
+        assertEquals(left, right);
+    }
+    
+    @Test
+    public void testCodeKeysEqualCodeOnly() {
+        Code baseline = new Code().withCode("123");
+        
+        CodeKey left = new CodeKey(baseline);
+        CodeKey right = new CodeKey(baseline);
+
+        assertEquals(left, right);
     }
 }


### PR DESCRIPTION
For retrieves that are filtered by codes, the DataRowRetrieveProvider
indexes the codes in the _codePath_ column on first access. The CodeKey
object is used as the index key. CodeKey extends the CQL Code object and
implements hashCode and equals so it works as a Map key. It *was* using
the CQL Engine's Code.equal method for equality checks. Code.equal
takes into account all fields in the Code including version and display.
Per the [CQL spec](https://cql.hl7.org/02-authorsguide.html#filtering-with-terminology), the retrieve filtering should use equivalence checking
instead. I updated CodeKey.equals to use Code.equivalent and fixed the
hashCode method so that it only considers the system and code fields.

I made a small change to the DataRowRetrieveProvider to handle null
values and to allow users to specify any type of column in codePath. If
the column is non-null and not already a Code, a Code will be created
and the value will be set to the toString of the codePath object.

The DataRowRetrieveProviderTest was refactored to avoid a bunch of
unnecessary duplication of test data initialization. I then fleshed out
the tests so that we have complete code coverage of all the code paths.

I also added a unit test to SparkDataRow for the case where column
metadata is used and the user specifies a default system for all
codes in that column.