### PR TITLE
Fix expression language classpath issue in Spark App

### DIFF
--- a/cohort-evaluator-spark/Dockerfile
+++ b/cohort-evaluator-spark/Dockerfile
@@ -33,6 +33,8 @@ RUN mv "${SPARK_VERSION}-${SPARK_DIST}" "${SPARK_HOME}"
 RUN mv "${SPARK_HOME}/kubernetes/dockerfiles/spark/entrypoint.sh" "${SPARK_HOME}"
 # Move decom.sh to SPARK_HOME
 RUN mv "${SPARK_HOME}/kubernetes/dockerfiles/spark/decom.sh" "${SPARK_HOME}"
+# Delete troublesome JSP-2.1 API JAR. It will be upgraded to JSP 2.2 when we copy our dependencies
+RUN rm "${SPARK_HOME}/jars/jsp-api-2.1.jar"
 # Remove the `tini` use from entrypoint.sh.  Tini is unavailable on Red Hat.
 RUN sed -i 's_/usr/bin/tini -s --__g' "${SPARK_HOME}/entrypoint.sh"
 

--- a/cohort-evaluator-spark/pom.xml
+++ b/cohort-evaluator-spark/pom.xml
@@ -27,11 +27,35 @@
         <job.name>simple-job</job.name>
     </properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- We get jsp-api:2.1 transitively from our hadoop-common dependency. 
+				JSP 2.1 includes API classes for an early version of the javax.el unified 
+				expression language. That version conflicts with the newer version that is 
+				needed by recent Hibernate Validator implementations. Rather than backdate 
+				our Hibernate Validator all the way to 4.2.0.Final (which would be necessary 
+				to work with JSP 2.1), I am upgrading the JSP API to 2.2. -->
+			<dependency>
+				<groupId>javax.servlet.jsp</groupId>
+				<artifactId>jsp-api</artifactId>
+				<version>2.2</version>
+			</dependency>	
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.cohort</groupId>
 			<artifactId>cohort-evaluator</artifactId>
 			<version>${project.version}</version>
+			<exclusions>
+				<!-- Spark ships with Jersey and Jersey uses an ever-so-slightly newer 
+					version of the validation API, so we are preferring the Jersey version. -->
+				<exclusion>
+					<groupId>javax.validation</groupId>
+					<artifactId>validation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -44,34 +68,17 @@
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>engine</artifactId>
 		</dependency>
-		
-		<dependency>
-			<groupId>javax.validation</groupId>
-			<artifactId>validation-api</artifactId>
-		</dependency>
-		
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-validator</artifactId>
-		</dependency>
-
-		<!-- This needs to be before Spark because spark pulls in JSP 2.1 and JSP 
-			2.1 has an embedded version of the javax.el API -->
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>javax.el</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.spark</groupId>
 			<artifactId>spark-sql_${spark.scala.version}</artifactId>
 		</dependency>
 
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-kubernetes_${spark.scala.version}</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-kubernetes_${spark.scala.version}</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>io.delta</groupId>
@@ -96,6 +103,28 @@
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-aws</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>2.0.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.validation</groupId>
+					<artifactId>validation-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.glassfish</groupId>
+			<artifactId>javax.el</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Spark includes hadoop-common which includes the JSP 2.1 API JAR. The JSP
2.1 API JAR has some javax.el API classes in it that are not compatible
with modern implementations of the EL classes. I had a choice to either
backlevel our javax.validation dependency to 4.2.1.Final and javax.el to
1.0.0.GA or increment our JSP version to 2.2. I went with the later.
This required an update to the Dockerfile to remove the JSP API version
included with the Spark distribution and some dependency management to
make sure we had the necessary JARs in the Spark application classpath.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>