### PR TITLE
Add support for reading config files from COS

### DIFF
--- a/cohort-evaluator-spark/pom.xml
+++ b/cohort-evaluator-spark/pom.xml
@@ -159,6 +159,16 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/library/HadoopBasedCqlLibraryProvider.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/library/HadoopBasedCqlLibraryProvider.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.cohort.cql.library;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+public class HadoopBasedCqlLibraryProvider implements CqlLibraryProvider {
+
+	private Path directory;
+	private Configuration configuration;
+
+	public HadoopBasedCqlLibraryProvider(Path directory, Configuration configuration) {
+		this.directory = directory;
+		this.configuration = configuration;
+	}
+
+	@Override
+	public Collection<CqlLibraryDescriptor> listLibraries() {
+		try {
+			FileSystem fileSystem = directory.getFileSystem(configuration);
+			RemoteIterator<LocatedFileStatus> fileStatusIterator = fileSystem.listFiles(directory, false);
+			Set<CqlLibraryDescriptor> retVal = new HashSet<>();
+			while(fileStatusIterator.hasNext()) {
+				LocatedFileStatus fileStatus = fileStatusIterator.next();
+				String name = fileStatus.getPath().getName();
+				CqlLibraryDescriptor libraryDescriptor = CqlLibraryHelpers.filenameToLibraryDescriptor(name);
+				if (libraryDescriptor != null) {
+					retVal.add(libraryDescriptor);
+				}
+			}
+			return retVal;
+
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public CqlLibrary getLibrary(CqlLibraryDescriptor libraryDescriptor) {
+		CqlLibrary library = null;
+
+		try {
+			FileSystem fileSystem = directory.getFileSystem(configuration);
+			Path path = new Path(directory, new Path(CqlLibraryHelpers.libraryDescriptorToFilename(libraryDescriptor)));
+			if (fileSystem.exists(path)) {
+				try (FSDataInputStream f = fileSystem.open(path)) {
+					library = new CqlLibrary()
+							.setDescriptor(libraryDescriptor)
+							.setContent(IOUtils.toString(f, Charset.defaultCharset()));
+				}
+			}
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to deserialize library " + libraryDescriptor, e);
+		}
+
+		return library;
+	}
+}

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.io.Reader;
 import java.io.Serializable;
@@ -28,7 +29,11 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.deploy.SparkHadoopUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -36,6 +41,7 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.LongAccumulator;
+import org.apache.spark.util.SerializableConfiguration;
 import org.opencds.cqf.cql.engine.data.ExternalFunctionProvider;
 import org.opencds.cqf.cql.engine.data.SystemExternalFunctionProvider;
 import org.slf4j.Logger;
@@ -54,6 +60,7 @@ import com.ibm.cohort.cql.functions.AnyColumn;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
 import com.ibm.cohort.cql.library.DirectoryBasedCqlLibraryProvider;
+import com.ibm.cohort.cql.library.HadoopBasedCqlLibraryProvider;
 import com.ibm.cohort.cql.library.PriorityCqlLibraryProvider;
 import com.ibm.cohort.cql.spark.aggregation.ContextDefinition;
 import com.ibm.cohort.cql.spark.aggregation.ContextDefinitions;
@@ -89,6 +96,8 @@ public class SparkCqlEvaluator implements Serializable {
     protected SparkCqlEvaluatorArgs args;
 
     protected SparkTypeConverter typeConverter;
+
+    protected SerializableConfiguration hadoopConfiguration;
     
     protected static ThreadLocal<SparkOutputColumnEncoder> sparkOutputColumnEncoder = new ThreadLocal<>();
 
@@ -245,6 +254,7 @@ public class SparkCqlEvaluator implements Serializable {
         try (SparkSession spark = sparkBuilder.getOrCreate()) {
             boolean useJava8API = Boolean.valueOf(spark.conf().get("spark.sql.datetime.java8API.enabled"));
             this.typeConverter = new SparkTypeConverter(useJava8API);
+            this.hadoopConfiguration = new SerializableConfiguration(SparkHadoopUtil.get().newConfiguration(SparkContext.getOrCreate().conf()));
 
             SparkOutputColumnEncoder columnEncoder = getSparkOutputColumnEncoder();
             
@@ -330,7 +340,11 @@ public class SparkCqlEvaluator implements Serializable {
      */
     protected ContextDefinitions readContextDefinitions(String path) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(new File(path), ContextDefinitions.class);
+        Path filePath = new Path(path);
+        FileSystem fileSystem = filePath.getFileSystem(this.hadoopConfiguration.value());
+        try (Reader r = new InputStreamReader(fileSystem.open(filePath))) {
+            return mapper.readValue(r, ContextDefinitions.class);
+        }
     }
 
     /**
@@ -469,15 +483,17 @@ public class SparkCqlEvaluator implements Serializable {
      */
     protected CqlLibraryProvider createLibraryProvider() throws IOException, FileNotFoundException {
         
-        CqlLibraryProvider fsBasedLp = new DirectoryBasedCqlLibraryProvider(new File(args.cqlPath));
+        CqlLibraryProvider hadoopBasedLp = new HadoopBasedCqlLibraryProvider(new Path(args.cqlPath), this.hadoopConfiguration.value());
         CqlLibraryProvider cpBasedLp = new ClasspathCqlLibraryProvider("org.hl7.fhir");
-        CqlLibraryProvider priorityLp = new PriorityCqlLibraryProvider( fsBasedLp, cpBasedLp );
+        CqlLibraryProvider priorityLp = new PriorityCqlLibraryProvider( hadoopBasedLp, cpBasedLp );
 
         // TODO - replace with cohort shared translation component
         final CqlToElmTranslator translator = new CqlToElmTranslator();
-        if (args.modelInfoPaths != null && args.modelInfoPaths.size() > 0) {
+        if (args.modelInfoPaths != null && !args.modelInfoPaths.isEmpty()) {
             for (String path : args.modelInfoPaths) {
-                try (Reader r = new FileReader(path)) {
+                Path filePath = new Path(path);
+                FileSystem modelInfoFilesystem = filePath.getFileSystem(this.hadoopConfiguration.value());
+                try (Reader r = new InputStreamReader(modelInfoFilesystem.open(filePath))) {
                     translator.registerModelInfo(r);
                 }
             }
@@ -518,8 +534,13 @@ public class SparkCqlEvaluator implements Serializable {
      */
     protected CqlEvaluationRequests readJobSpecification(String path) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        CqlEvaluationRequests requests = mapper.readValue(new File(path), CqlEvaluationRequests.class);
-        
+        Path filePath = new Path(path);
+        FileSystem fileSystem = filePath.getFileSystem(this.hadoopConfiguration.value());
+        CqlEvaluationRequests requests;
+        try (Reader r = new InputStreamReader(fileSystem.open(filePath))) {
+            requests = mapper.readValue(r, CqlEvaluationRequests.class);
+        }
+
         try( ValidatorFactory factory = Validation.buildDefaultValidatorFactory() ) { 
             Validator validator = factory.getValidator();
             

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.spark.SparkException;
+import org.apache.spark.deploy.SparkHadoopUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -35,11 +36,11 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.delta.DeltaLog;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.SerializableConfiguration;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cohort.cql.evaluation.CqlEvaluationRequest;
 import com.ibm.cohort.cql.evaluation.CqlEvaluationRequests;
 import com.ibm.cohort.cql.evaluation.parameters.DateParameter;
@@ -761,6 +762,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
         
         IntegerParameter minimumAge = new IntegerParameter(17);
         
+        evaluator.hadoopConfiguration = new SerializableConfiguration(SparkHadoopUtil.get().conf());
         CqlEvaluationRequests requests = evaluator.readJobSpecification("src/test/resources/simple-job/cql-jobs.json");
         assertNotNull(requests);
         assertEquals(measurementPeriod, requests.getGlobalParameters().get("Measurement Period"));
@@ -772,6 +774,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
     public void testReadFilteredJobs() throws Exception {
         evaluator.args.jobSpecPath = "src/test/resources/column-mapping-validation/metadata/cql-jobs.json";
 
+        evaluator.hadoopConfiguration = new SerializableConfiguration(SparkHadoopUtil.get().conf());
         CqlEvaluationRequests requests = evaluator.getFilteredJobSpecificationWithIds();
         assertNotNull(requests);
         assertEquals(3, requests.getEvaluations().size());
@@ -782,12 +785,14 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
     
     @Test
     public void testReadCqlJobsInvalid() throws Exception {
+        evaluator.hadoopConfiguration = new SerializableConfiguration(SparkHadoopUtil.get().conf());
         assertThrows(IllegalArgumentException.class,
                 () -> evaluator.readJobSpecification("src/test/resources/invalid/cql-jobs-invalid-global.json"));
     }
     
     @Test
     public void testReadContextDefinitions() throws Exception {
+        evaluator.hadoopConfiguration = new SerializableConfiguration(SparkHadoopUtil.get().conf());
         ContextDefinitions contextDefinitions = evaluator.readContextDefinitions("src/test/resources/alltypes/metadata/context-definitions.json");
         assertNotNull(contextDefinitions);
         assertEquals(5, contextDefinitions.getContextDefinitions().size());

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -549,6 +549,11 @@
 				<version>${hadoop.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-common</artifactId>
+				<version>${hadoop.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>io.delta</groupId>
 				<artifactId>delta-core_${spark.scala.version}</artifactId>
 				<version>1.0.0</version>


### PR DESCRIPTION
Here's the code to read input files (model info, context defs, jobs file, cql files) from either local disk or COS. Previously the code assumed these files would always be a local read.

My intention was to add a second fvt test for Spark that would run the existing test case again, but instead of passing in local paths to each input file the test would use s3a:// paths for the file reads. I've been having issues with the toolchain side of things for a couple days, so I figured I'd get the code in front of folks to start gathering feedback. 