### PR TITLE
add wrapper around SystemExternalFunctionProvider

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/functions/CohortExternalFunctionProvider.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/functions/CohortExternalFunctionProvider.java
@@ -1,0 +1,35 @@
+package com.ibm.cohort.cql.functions;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+
+import org.opencds.cqf.cql.engine.data.SystemExternalFunctionProvider;
+
+/**
+ * Wrapper around SystemExternalFunctionProvider that implements equals and hashCode
+ * so that it can be cached.
+ *
+ */
+public class CohortExternalFunctionProvider extends SystemExternalFunctionProvider {
+
+    private final List<Method> functions;
+
+    public CohortExternalFunctionProvider(List<Method> staticFunctions) {
+        super(staticFunctions);
+        functions = staticFunctions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CohortExternalFunctionProvider that = (CohortExternalFunctionProvider) o;
+        return Objects.equals(functions, that.functions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(functions);
+    }
+}


### PR DESCRIPTION
implementing `equals` and `hashCode` so that the object can be used as a map key

was causing `OOM` in Toolchain because of the extra [CONTEXT_CACHE](https://github.com/Alvearie/quality-measure-and-cohort-service/blob/e93154c19d54f1c690028864d80c93cb2659ed9b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlContextFactory.java#L90) entries.
(thanks @msargentibm for catching this)

## references
- [CI run (pending)](https://cloud.ibm.com/devops/pipelines/tekton/8e4d7f43-6050-43ea-936c-63af1bed1858/runs/82c3378b-70c1-457c-adab-5dacc905abbf?env_id=ibm:yp:us-east)