### PR TITLE
Wffhcohort 649 - Capture CQL evaluation errors

### DIFF
--- a/cohort-evaluator-spark/pom.xml
+++ b/cohort-evaluator-spark/pom.xml
@@ -114,6 +114,11 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<scope>compile</scope>
+		</dependency>
 		
 		<dependency>
 			<groupId>xpp3</groupId>
@@ -177,6 +182,12 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -349,7 +349,8 @@ public class SparkCqlEvaluator implements Serializable {
             }
             
             if (errorAccumulator != null) {
-                EvaluationSummary evaluationSummary = new EvaluationSummary(errorAccumulator.value());
+                // Failed tasks may possibly cause duplicate entries in the errorAccumulator
+                EvaluationSummary evaluationSummary = new EvaluationSummary(errorAccumulator.value().stream().distinct().collect(Collectors.toList()));
 
                 ObjectMapper mapper = new ObjectMapper();
                 ObjectWriter writer = mapper.writer(new DefaultPrettyPrinter());

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
@@ -80,6 +80,12 @@ public class SparkCqlEvaluatorArgs implements Serializable {
     "--terminology-path" }, description = "Filesystem path to the location containing the ValueSet definitions in FHIR XML or JSON format.")
     public String terminologyPath;
 
+    @Parameter(names = {"--success-marker-path"}, description = "Directory where a _SUCCESS marker file will be written to if there are no errors during CQL evaluation")
+    public String successMarkerPath = null;
+
+    @Parameter(names = {"--batch-summary-path"}, description = "Directory where a batch summary file (cql-evaluation-summary.json) that contains any CQL evaluation errors will be written. When this option is provided, errors during CQL evaluation will not cause the overall program to fail.")
+    public String batchSummaryPath = null;
+
     @Parameter(names = { "--debug" }, description = "Enables CQL debug logging")
     public boolean debug = false;
 }

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationError.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationError.java
@@ -1,0 +1,73 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.spark.errors;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class EvaluationError implements Serializable {
+	private static final long serialVersionUID = -1300727992961144423L;
+	
+	private String contextName;
+	private Object contextId;
+	private String outputColumn;
+	private String exception;
+	
+	public EvaluationError() {
+		
+	}
+
+	public EvaluationError(String contextName, Object contextId, String outputColumn, String exception) {
+		this.contextName = contextName;
+		this.contextId = contextId;
+		this.outputColumn = outputColumn;
+		this.exception = exception;
+	}
+
+	public String getContextName() {
+		return contextName;
+	}
+
+	public Object getContextId() {
+		return contextId;
+	}
+
+	public String getOutputColumn() {
+		return outputColumn;
+	}
+
+	public String getException() {
+		return exception;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (o == null || getClass() != o.getClass()) return false;
+
+		EvaluationError that = (EvaluationError) o;
+
+		return new EqualsBuilder()
+				.append(contextName, that.contextName)
+				.append(contextId, that.contextId)
+				.append(outputColumn, that.outputColumn)
+				.append(exception, that.exception)
+				.isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(17, 37)
+				.append(contextName)
+				.append(contextId)
+				.append(outputColumn)
+				.append(exception)
+				.toHashCode();
+	}
+}

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationSummary.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationSummary.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.cql.spark.errors;
+
+import java.util.List;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+public class EvaluationSummary {
+	private List<EvaluationError> errorList;
+	
+	public EvaluationSummary() {
+		
+	}
+	
+	public EvaluationSummary(List<EvaluationError> errorList) {
+		this.errorList = errorList;
+	}
+
+	public List<EvaluationError> getErrorList() {
+		return errorList;
+	}
+
+	public void setErrorList(List<EvaluationError> errorList) {
+		this.errorList = errorList;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+
+		if (o == null || getClass() != o.getClass()) return false;
+
+		EvaluationSummary that = (EvaluationSummary) o;
+
+		return new EqualsBuilder()
+				.append(errorList, that.errorList)
+				.isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder(17, 37)
+				.append(errorList)
+				.toHashCode();
+	}
+}

--- a/docs/user-guide/spark-user-guide.md
+++ b/docs/user-guide/spark-user-guide.md
@@ -20,6 +20,11 @@ Usage: SparkCqlEvaluator [options]
       One or more context names, as defined in the context-definitions file, 
       that should be run in this evaluation. Defaults to all evaluations.
       Default: []
+    --batch-summary-path
+      Directory where a batch summary file (cql-evaluation-summary.json) that 
+      contains any CQL evaluation errors will be written. When this option is 
+      provided, errors during CQL evaluation will not cause the overall 
+      program to fail.
   * -d, --context-definitions
       Filesystem path to the context-definitions file.
   * -c, --cql-path
@@ -76,6 +81,12 @@ Usage: SparkCqlEvaluator [options]
       WARNING: NOT RECOMMENDED FOR PRODUCTION USE. If option is set, program 
       overwrites existing output when writing result data.
       Default: false
+    --success-marker-path
+      Directory where a _SUCCESS marker file will be written to if there are 
+      no errors during CQL evaluation
+    -t, --terminology-path
+      Filesystem path to the location containing the ValueSet definitions in 
+      FHIR XML or JSON format.
 ```
 
 The typical mode of invocation is to run the program using the spark-submit script from SPARK_HOME\bin to submit a job to a target Spark cluster. The simplest invocation for a Windows user will look like this...
@@ -304,6 +315,51 @@ The type information for output columns is read directly from the translated CQL
 By default Spark is configured to disallow overwrites of data files. However, it can be useful for testing purposes to write to the same data path more than one time. If users wish to use overwrite behavior, they can specify the `--overwrite-output-for-contexts` program option.
 
 Depending on a number of factors including the amount of data in the input, how the input data is organized, and how spark parallelism is configured, output tables might end up with a large amount of partitions yielding a large number of output files. In these cases, it might be desirable to compact data prior to writing it to storage. A program option `-n` is provided that, when specified, will cause output data to be compacted into the specified number of partitions.
+
+#### Optional Output
+
+There are options that, if specified, may result in additional files being output once the Spark program finishes execution.
+
+Using the
+`--batch-summary-path` option will prevent the Spark program from failing due to errors during CQL evaluations.
+Instead, a file named `cql-evaluation-summary.json` will be written out in the directory specified for the argument.
+The file will contain information about any errors that occurred during CQL evaluations along with identifying
+information (context name, context id, output column being calculated) for each error. If no errors occur, the summary
+file will be created, but the list of errors in the file will be empty.
+
+
+Example file with errors:
+```json
+{
+  "errorList" : [
+    {
+      "contextName" : "ContextA",
+      "contextId" : "id_123",
+      "outputColumn" : "cohort",
+      "exception" : "Expected a list with at most one element, but found a list with multiple elements."
+    },
+    {
+      "contextName" : "ContextB",
+      "contextId" : "xxxyyyzzz",
+      "outputColumn" : "CqlDefinition-1.0.0|InDenominator",
+      "exception" : "CQL Exception: Bad format for Integer literal"
+    }
+  ]
+}
+```
+
+Example file without errors:
+```json
+{
+  "errorList" : []
+}
+```
+
+The `--success-marker-path` option may also result in an additional marker file being output by the Spark program.
+If all CQL evaluations finish successfully and without any errors during evaluation, then a blank file named `_SUCCESS`
+will be written in the directory specified for the `--success-marker-path` option. No `_SUCCESS` file will be written
+if either 1) The `--success-marker-path` is not used when running the Spark program, or 2) one or more errors occur
+during CQL evaluation.
 
 ### Debugging
 


### PR DESCRIPTION
These changes allow a user to:

1. Optionally prevent the Spark program from failing due to errors during CQL evaluation and write out a summary or any errors encountered.
2. Optionally output a `_SUCCESS` marker file to a configured location if the Spark program finishes execution without encountering any errors.

Using Jackson and `EvaluationSummary` might be a little overkill for this task, but my thought was that `EvaluationSummary` might grow over time and could be a container for any sort of extra summary information we wish to include from a particular run.