### PR TITLE
Disable sonar in the toolchain

### DIFF
--- a/pipeline.config
+++ b/pipeline.config
@@ -26,6 +26,7 @@ CI:
   # could remove when we switch to using main branch
   RELEASE_NAME_NO_GIT_BRANCH: "true"
   USEHADOLINT: "true"
+  SONARQUBE_ENABLED: "false"
 CIVALIDATE:
   BUILD_FILE: "cohort-parent/pom.xml"
   BUILD_OPTIONS: "package -s /workspace/.toolchain.maven.settings.xml"


### PR DESCRIPTION
Tested in a CIVALIDATE run and confirmed the sonar pods do not come back.

I will open PRs in other projects for the remaining CI toolchains that run in our cluster.