### PR TITLE
Wffhcohort-587: Return defaultValues in readable format

### DIFF
--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
@@ -40,7 +40,6 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
  */
 public class FHIRRestUtils {
 
-
 	/**
 	 * @param fhirEndpoint The REST endpoint for the FHIR server
 	 * @param fhirTenantIdHeader the header used by FHIR to identify the tenant

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
@@ -183,7 +183,7 @@ public class FHIRRestUtils {
 		complicatedTypes.add("Range");
 		complicatedTypes.add("Quantity");
 		MeasureParameterInfo retVal = new MeasureParameterInfo();
-		String defaultValue = complicatedTypes.contains(parameterDefinition.getType())? complicatedDefaultConstructor(parameterDefinition) : null;
+		String defaultValue = complicatedTypes.contains(parameterDefinition.getType())? complicatedTypeValueConstructor(parameterDefinition) : null;
 
 		retVal.name(parameterDefinition.getName())
 				.type(parameterDefinition.getType())
@@ -204,7 +204,7 @@ public class FHIRRestUtils {
 		return retVal;
 	}
 
-	static String complicatedDefaultConstructor(ParameterDefinition parameterDefinition){
+	static String complicatedTypeValueConstructor(ParameterDefinition parameterDefinition){
 		FhirContext context = FhirContext.forR4();
 		IParser parser = context.newJsonParser();
 		String retVal;

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/FHIRRestUtils.java
@@ -33,6 +33,7 @@ import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.IBMFhirServerConfig;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
@@ -43,6 +44,12 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
  */
 public class FHIRRestUtils {
 
+	private static final List<String> complicatedTypes = new ArrayList<>();
+	static {
+		complicatedTypes.add("Period");
+		complicatedTypes.add("Range");
+		complicatedTypes.add("Quantity");
+	}
 	/**
 	 * @param fhirEndpoint The REST endpoint for the FHIR server
 	 * @param fhirTenantIdHeader the header used by FHIR to identify the tenant
@@ -181,10 +188,7 @@ public class FHIRRestUtils {
 	}
 
 	private static MeasureParameterInfo toMeasureParameterInfo(ParameterDefinition parameterDefinition) {
-		List<String> complicatedTypes = new ArrayList<>();
-		complicatedTypes.add("Period");
-		complicatedTypes.add("Range");
-		complicatedTypes.add("Quantity");
+
 		MeasureParameterInfo retVal = new MeasureParameterInfo();
 		String defaultValue = complicatedTypes.contains(parameterDefinition.getType())? complicatedTypeValueConstructor(parameterDefinition) : null;
 
@@ -208,7 +212,7 @@ public class FHIRRestUtils {
 	}
 
 	static String complicatedTypeValueConstructor(ParameterDefinition parameterDefinition) {
-		FhirContext context = FhirContext.forR4();
+		FhirContext context = FhirContext.forCached(FhirVersionEnum.R4);
 		IParser parser = context.newJsonParser();
 		String valueKey;
 		//In order to use the hapi parser, we cannot translate an extension by itself. The patient object wraps the extension

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -15,11 +15,13 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
 import javax.ws.rs.core.HttpHeaders;
 
+import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.Measure;
@@ -46,6 +48,7 @@ import com.ibm.cohort.engine.measure.RestFhirMeasureResolutionProvider;
 import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
 /**
@@ -364,10 +367,15 @@ public class FHIRRestUtilsTest {
 		Extension extension = new Extension();
 		extension.setUrl("http://ibm.com/fhir/cdm/StructureDefinition/default-value");
 		Period period = new Period();
+
 		Date startDate = Date.from(LocalDate.of(2020,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+		DateTimeType startElement = new DateTimeType(startDate, TemporalPrecisionEnum.DAY);
+
 		Date endDate = Date.from(LocalDate.of(2021,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant());
-		period.setStart(startDate);
-		period.setEnd(endDate);
+		DateTimeType endElement = new DateTimeType(endDate, TemporalPrecisionEnum.DAY);
+
+		period.setStartElement(startElement);
+		period.setEndElement(endElement);
 		extension.setValue(period);
 
 		List<Extension> extensions = new ArrayList<>();
@@ -376,7 +384,7 @@ public class FHIRRestUtilsTest {
 		definition.setExtension(extensions);
 
 		String defaultResult = FHIRRestUtils.complicatedDefaultConstructor(definition);
-		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 		assertEquals("{\"start\":\"" + formatter.format(startDate) + "\",\"end\":\"" + formatter.format(endDate) + "\"}",defaultResult);
 	}
 

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -407,7 +407,7 @@ public class FHIRRestUtilsTest {
 		assertEquals("{\"value\":10,\"unit\":\"year\"}",defaultResult);
 	}
 
-	private Measure createMeasure(String inputString) throws JsonProcessingException {
+	private Measure createMeasure(String inputString) {
 		// Instantiate a new parser
 		ca.uhn.fhir.parser.IParser parser = ctx.newJsonParser();
 		// Parse it

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -354,7 +354,7 @@ public class FHIRRestUtilsTest {
 		extensions.add(extension);
 
 		definition.setExtension(extensions);
-		String defaultResult = FHIRRestUtils.complicatedDefaultConstructor(definition);
+		String defaultResult = FHIRRestUtils.complicatedTypeValueConstructor(definition);
 
 		assertEquals("{\"low\":{\"value\":10,\"unit\":\"year\"},\"high\":{\"value\":100,\"unit\":\"year\"}}",defaultResult);
 	}
@@ -382,7 +382,7 @@ public class FHIRRestUtilsTest {
 
 		definition.setExtension(extensions);
 
-		String defaultResult = FHIRRestUtils.complicatedDefaultConstructor(definition);
+		String defaultResult = FHIRRestUtils.complicatedTypeValueConstructor(definition);
 		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
 		assertEquals("{\"start\":\"" + formatter.format(startDate) + "\",\"end\":\"" + formatter.format(endDate) + "\"}",defaultResult);
 	}
@@ -402,7 +402,7 @@ public class FHIRRestUtilsTest {
 		extensions.add(extension);
 
 		definition.setExtension(extensions);
-		String defaultResult = FHIRRestUtils.complicatedDefaultConstructor(definition);
+		String defaultResult = FHIRRestUtils.complicatedTypeValueConstructor(definition);
 
 		assertEquals("{\"value\":10,\"unit\":\"year\"}",defaultResult);
 	}

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -15,7 +15,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -363,8 +364,10 @@ public class FHIRRestUtilsTest {
 		Extension extension = new Extension();
 		extension.setUrl("http://ibm.com/fhir/cdm/StructureDefinition/default-value");
 		Period period = new Period();
-		period.setStart(Date.from(LocalDate.of(2020,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
-		period.setEnd(Date.from(LocalDate.of(2021,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant()));
+		Date startDate = Date.from(LocalDate.of(2020,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+		Date endDate = Date.from(LocalDate.of(2021,1,1).atStartOfDay(ZoneId.systemDefault()).toInstant());
+		period.setStart(startDate);
+		period.setEnd(endDate);
 		extension.setValue(period);
 
 		List<Extension> extensions = new ArrayList<>();
@@ -373,8 +376,8 @@ public class FHIRRestUtilsTest {
 		definition.setExtension(extensions);
 
 		String defaultResult = FHIRRestUtils.complicatedDefaultConstructor(definition);
-
-		assertEquals("{\"start\":\"2020-01-01T00:00:00-05:00\",\"end\":\"2021-01-01T00:00:00-05:00\"}",defaultResult);
+		SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+		assertEquals("{\"start\":\"" + formatter.format(startDate) + "\",\"end\":\"" + formatter.format(endDate) + "\"}",defaultResult);
 	}
 
 	@Test


### PR DESCRIPTION
Return readable json for the value of object-level parameters. I ended up settling on this implementation for now, as it will be the easiest to add other parameters types that might be needed in the future.