### PR TITLE
Wffhcohort-738: Add correlation id to logging statements

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -290,7 +290,7 @@ public class SparkCqlEvaluator implements Serializable {
         
         SparkSession.Builder sparkBuilder = SparkSession.builder();
         try (SparkSession spark = sparkBuilder.getOrCreate()) {
-            spark.sparkContext().setLocalProperty("mdc." + CORRELATION_ID, MDC.get("CorrelationId"));
+            spark.sparkContext().setLocalProperty("mdc." + CORRELATION_ID, MDC.get(CORRELATION_ID));
             boolean useJava8API = Boolean.valueOf(spark.conf().get("spark.sql.datetime.java8API.enabled"));
             this.typeConverter = new SparkTypeConverter(useJava8API);
             this.hadoopConfiguration = new SerializableConfiguration(spark.sparkContext().hadoopConfiguration());

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -857,7 +857,7 @@ public class SparkCqlEvaluator implements Serializable {
             }
         }
         finally {
-            MDC.remove("CorrelationId");
+            MDC.remove(CORRELATION_ID);
         }
     }
 }

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -291,6 +291,7 @@ public class SparkCqlEvaluator implements Serializable {
         SparkSession.Builder sparkBuilder = SparkSession.builder();
         try (SparkSession spark = sparkBuilder.getOrCreate()) {
             spark.sparkContext().setLocalProperty("mdc." + CORRELATION_ID, MDC.get(CORRELATION_ID));
+            evaluationSummary.setCorrelationId(MDC.get(CORRELATION_ID));
             boolean useJava8API = Boolean.valueOf(spark.conf().get("spark.sql.datetime.java8API.enabled"));
             this.typeConverter = new SparkTypeConverter(useJava8API);
             this.hadoopConfiguration = new SerializableConfiguration(spark.sparkContext().hadoopConfiguration());

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
@@ -96,6 +96,6 @@ public class SparkCqlEvaluatorArgs implements Serializable {
     @Parameter(names = { "--key-parameters" }, description = "One or more parameter names that should be included in the parameters column for output rows that are generated.", required = false)
     public List<String> keyParameterNames = null;
 
-    @Parameter(names = { "--correlation-id" }, description = "Identifier consistent between all logs of a single job", required = false)
+    @Parameter(names = { "--correlation-id" }, description = "This correlation ID will be written with any log messages created by the application", required = false)
     public String correlationId = null;
 }

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
@@ -96,6 +96,6 @@ public class SparkCqlEvaluatorArgs implements Serializable {
     @Parameter(names = { "--key-parameters" }, description = "One or more parameter names that should be included in the parameters column for output rows that are generated.", required = false)
     public List<String> keyParameterNames = null;
 
-    @Parameter(names = { "--correlation-id" }, description = "This correlation ID will be written with any log messages created by the application", required = false)
+    @Parameter(names = { "--correlation-id" }, description = "This correlation ID will be written with any log messages created by the application and also to the batch summary file that is created ", required = false)
     public String correlationId = null;
 }

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorArgs.java
@@ -95,4 +95,7 @@ public class SparkCqlEvaluatorArgs implements Serializable {
     
     @Parameter(names = { "--key-parameters" }, description = "One or more parameter names that should be included in the parameters column for output rows that are generated.", required = false)
     public List<String> keyParameterNames = null;
+
+    @Parameter(names = { "--correlation-id" }, description = "Identifier consistent between all logs of a single job", required = false)
+    public String correlationId = null;
 }

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
@@ -27,7 +27,8 @@ public class EvaluationSummary {
 	private Map<String, Long> executionsPerContext = new HashMap<>();
 	private Map<String, Long> runtimeMillisPerContext = new HashMap<>();
 	private String applicationId;
-	
+	private String correlationId;
+
 	public EvaluationSummary() {
 		
 	}
@@ -96,6 +97,14 @@ public class EvaluationSummary {
 		this.applicationId = applicationId;
 	}
 
+	public String getCorrelationId() {
+		return correlationId;
+	}
+
+	public void setCorrelationId(String correlationId) {
+		this.correlationId = correlationId;
+	}
+
 	public void addContextCount(String contextName, long count) {
 		executionsPerContext.put(contextName, count);
 	}
@@ -107,7 +116,6 @@ public class EvaluationSummary {
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
-
 		if (o == null || getClass() != o.getClass()) return false;
 
 		EvaluationSummary that = (EvaluationSummary) o;
@@ -121,6 +129,7 @@ public class EvaluationSummary {
 				.append(executionsPerContext, that.executionsPerContext)
 				.append(runtimeMillisPerContext, that.runtimeMillisPerContext)
 				.append(applicationId, that.applicationId)
+				.append(correlationId, that.correlationId)
 				.isEquals();
 	}
 
@@ -135,6 +144,7 @@ public class EvaluationSummary {
 				.append(executionsPerContext)
 				.append(runtimeMillisPerContext)
 				.append(applicationId)
+				.append(correlationId)
 				.toHashCode();
 	}
 
@@ -148,7 +158,8 @@ public class EvaluationSummary {
 		sb.append(", totalContexts=").append(totalContexts);
 		sb.append(", executionsPerContext=").append(executionsPerContext);
 		sb.append(", runtimeMillisPerContext=").append(runtimeMillisPerContext);
-		sb.append(", applicationId='").append(applicationId).append('\'');
+		sb.append(", applicationId='").append(applicationId);
+		sb.append(", correlationId='").append(correlationId).append('\'');
 		sb.append('}');
 		return sb.toString();
 	}

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
@@ -158,7 +158,7 @@ public class EvaluationSummary {
 		sb.append(", totalContexts=").append(totalContexts);
 		sb.append(", executionsPerContext=").append(executionsPerContext);
 		sb.append(", runtimeMillisPerContext=").append(runtimeMillisPerContext);
-		sb.append(", applicationId='").append(applicationId);
+		sb.append(", applicationId='").append(applicationId).append('\'');
 		sb.append(", correlationId='").append(correlationId).append('\'');
 		sb.append('}');
 		return sb.toString();

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
@@ -435,6 +435,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
           "-n", "10",
           "--output-format", "parquet",
           "--overwrite-output-for-contexts",
+          "--correlation-id", "Spark1234",
           "--metadata-output-path", metadataDir.toURI().toString()
         };
 
@@ -1033,6 +1034,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
                 "-i", "D=" + new File(inputDir, "testdata/test-D.parquet").toURI().toString(),
                 "-o", "Patient=" + patientFile.toURI().toString(),
                 "-n", "10",
+                "--correlation-id", "Spark1234",
                 "--overwrite-output-for-contexts",
                 "--metadata-output-path", metadataDir.toURI().toString()
         };
@@ -1054,6 +1056,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
             EvaluationSummary evaluationSummary = mapper.readValue(fileInputStream, EvaluationSummary.class);
             
             assertNotNull(evaluationSummary.getApplicationId());
+            assertNotNull(evaluationSummary.getCorrelationId());
             assertTrue(evaluationSummary.getStartTimeMillis() > 0);
             assertTrue(evaluationSummary.getEndTimeMillis() > 0);
             assertTrue(evaluationSummary.getRuntimeMillis() > 0);

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
@@ -149,6 +149,7 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
                 "-o", "Patient=" + new File(outputLocation).toURI().toString(),
                 "--output-format", "delta",
                 "--overwrite-output-for-contexts",
+                "--correlation-id", "Spark1234",
                 "--metadata-output-path", outputLocation
         };
 

--- a/cohort-evaluator-spark/src/test/resources/log4j.properties
+++ b/cohort-evaluator-spark/src/test/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.appender.console.layout.ConversionPattern=%X{CorrelationId}%X{mdc.CorrelationId} %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
 # Set the default spark-shell/spark-sql log level to WARN. When running the
 # spark-shell/spark-sql, the log level for these classes is used to overwrite


### PR DESCRIPTION
Note: There are some spark log classes that don't accept the mdc property, such as TaskSetManager or certain scheduler logs. These logs don't look like they'd be particularly vital for everyday use (for example, `Registering RDD 5 (toString at String.java:2994) as input to shuffle 0` ), but I think it's important to keep in mind.