### PR TITLE
WFFHCOHORT-706

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextRetriever.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextRetriever.java
@@ -66,7 +66,7 @@ public class ContextRetriever {
     public JavaPairRDD<Object, List<Row>> retrieveContext(ContextDefinition contextDefinition) {
         List<JavaPairRDD<Object, Row>> rddList = gatherRDDs(contextDefinition);
 		if(rddList.isEmpty()){
-			throw new RuntimeException("Gosh I feel like there ought to have been data there");
+			throw new IllegalStateException("Provided context " + contextDefinition.getName() + " returned zero readable RDDs");
 		}
 
         JavaPairRDD<Object, Row> allData = unionPairRDDs(rddList);

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextRetriever.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/aggregation/ContextRetriever.java
@@ -65,6 +65,9 @@ public class ContextRetriever {
      */
     public JavaPairRDD<Object, List<Row>> retrieveContext(ContextDefinition contextDefinition) {
         List<JavaPairRDD<Object, Row>> rddList = gatherRDDs(contextDefinition);
+		if(rddList.isEmpty()){
+			throw new RuntimeException("Gosh I feel like there ought to have been data there");
+		}
 
         JavaPairRDD<Object, Row> allData = unionPairRDDs(rddList);
 


### PR DESCRIPTION
I added this exception, then tried to write a test where it could ever be hit. I wasn't successful, and I don't think it would be possible to hit it. I could also move this exception to within gatherRDDs (throw IllegalState if it tries to return an empty list), they seemed about on par to me, though I could see someone preferring an empty list check at the end of a method rather than the beginning aesthetically. 

I also, while trying to experiment, ignored the error within sonarcloud that believed the list could be empty. I expected that the "bug" would come back if another branch produced the same issue, but that doesn't seem to be the case: https://sonarcloud.io/summary/new_code?branch=cql-spark-evaluator&id=Alvearie_quality-measure-and-cohort-service 

Personally, I think that since this error should not be possible that we don't need to add an unnecessary check, but I want to give other people the opportunity to say one way or the other.

- [ ] Remove sonar-test branch from sonar workflow file