### PR TITLE
HIWHC-5353 NiFi not able to use _SUCCESS file with 0 byte

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/BaseOutputMetadataWriter.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/BaseOutputMetadataWriter.java
@@ -11,6 +11,7 @@ import org.apache.commons.collections.CollectionUtils;
 public abstract class BaseOutputMetadataWriter implements OutputMetadataWriter{
     
     public static final String SUCCESS_MARKER = "_SUCCESS";
+    public static final String SUCCESS_FLAG = "SUCCESS";
     public static final String BATCH_SUMMARY_PREFIX = "batch_summary-";
 
     @Override

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/HadoopPathOutputMetadataWriter.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/HadoopPathOutputMetadataWriter.java
@@ -35,6 +35,7 @@ public class HadoopPathOutputMetadataWriter extends BaseOutputMetadataWriter {
     @Override
     protected void createSuccessMarker() {
         try(FSDataOutputStream outputStream = metadataPath.getFileSystem(hadoopConfig).create(metadataPath.suffix("/" + SUCCESS_MARKER))) {
+            outputStream.write(SUCCESS_FLAG.getBytes());
         } catch (IOException e) {
             throw new RuntimeException("Error writing the success marker file", e);
         }


### PR DESCRIPTION
 - The success marker file is created with a content to mitigate an issue in NiFi