### PR TITLE
Wffhcohort 700

### DIFF
--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/JobStatus.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/JobStatus.java
@@ -1,0 +1,6 @@
+package com.ibm.cohort.cql.spark;
+
+public enum JobStatus {
+	FAIL,
+	SUCCESS
+}

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/SparkCqlEvaluator.java
@@ -372,21 +372,6 @@ public class SparkCqlEvaluator implements Serializable {
                     }
                 }
 
-                long endTimeMillis = System.currentTimeMillis();
-                evaluationSummary.setEndTimeMillis(endTimeMillis);
-                evaluationSummary.setRuntimeMillis(endTimeMillis - startTimeMillis);
-
-                if (args.metadataOutputPath != null) {
-                    if (errorAccumulator != null) {
-                        evaluationSummary.setErrorList(errorAccumulator.value());
-                    }
-
-                    evaluationSummary.setTotalContexts(contextAccum.value());
-
-                    OutputMetadataWriter writer = getOutputMetadataWriter();
-                    writer.writeMetadata(evaluationSummary);
-                }
-
                 CustomMetricSparkPlugin.currentlyEvaluatingContextGauge.setValue(0);
 
                 try {

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationError.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/errors/EvaluationError.java
@@ -10,6 +10,9 @@ import java.io.Serializable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EvaluationError implements Serializable {
 	private static final long serialVersionUID = -1300727992961144423L;
 	

--- a/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
+++ b/cohort-evaluator-spark/src/main/java/com/ibm/cohort/cql/spark/metadata/EvaluationSummary.java
@@ -14,9 +14,10 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.ibm.cohort.cql.spark.JobStatus;
 import com.ibm.cohort.cql.spark.errors.EvaluationError;
 
-@JsonPropertyOrder({"applicationId", "startTimeMillis", "endTimeMillis", "runtimeMillis", "totalContexts", "executionsPerContext", "runtimeMillisPerContext", "errorList"})
+@JsonPropertyOrder({"applicationId", "startTimeMillis", "endTimeMillis", "runtimeMillis", "jobStatus", "totalContexts", "executionsPerContext", "runtimeMillisPerContext", "errorList"})
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EvaluationSummary {
 	private List<EvaluationError> errorList;
@@ -28,6 +29,7 @@ public class EvaluationSummary {
 	private Map<String, Long> runtimeMillisPerContext = new HashMap<>();
 	private String applicationId;
 	private String correlationId;
+	private JobStatus jobStatus;
 
 	public EvaluationSummary() {
 		
@@ -103,6 +105,14 @@ public class EvaluationSummary {
 
 	public void setCorrelationId(String correlationId) {
 		this.correlationId = correlationId;
+	}
+
+	public JobStatus getJobStatus() {
+		return jobStatus;
+	}
+
+	public void setJobStatus(JobStatus jobStatus) {
+		this.jobStatus = jobStatus;
 	}
 
 	public void addContextCount(String contextName, long count) {

--- a/docs/user-guide/spark-user-guide.md
+++ b/docs/user-guide/spark-user-guide.md
@@ -188,6 +188,13 @@ The data tables that are used as input to the Spark CQL Evaluator application ar
 
 Aggregation contexts are defined in a JSON-formatted configuration file that we typically call `context-definitions.json` though the name isn't prescribed. In the `context-definitions.json` file, you define a primary data type and all of the relationships to related data that will be needed for CQL evaluation. Each record of the primary data type should be uniquely keyed and the related data types can be joined in using one-to-many or many-to-many semantics. In the one-to-many join scenario, data for a related data type is assumed to have a direct foreign key to the primary data type table. In the many-to-many join scenario, data for a related data type is assumed to be once removed from the primary data type table. Join logic is performed first on an "association" table and then again via a different key value on the true related data type.
 
+Both one-to-many and many-to-many joins may specify an optional `whereClause` field which is used to limit which 
+rows are included in the results of a join. For example, we may wish to join the primary data type to a related data
+type only where a particular column is equal to a given value. In that case, the join in the context definition could
+specify `"whereClause": "a_column = 'a_value'"`. The join would be performed as normal, and then filtered down to
+only the cases for which the `whereClause` is true. This feature is meant to cover some advanced use cases and will
+likely not be needed for a majority of joins.
+
 An example context-definitions.json file might look like this..
 ```json
 {
@@ -216,7 +223,17 @@ An example context-definitions.json file might look like this..
 					"relatedDataType": "Patient",
 					"relatedKeyColumn": "patient_id"
 				}]
-        }]
+        },{
+                 "name": "Encounter",
+                 "primaryDataType": "Patient",
+                 "primaryKeyColumn": "patient_id",
+                 "relationships":[{
+                     "type": "OneToMany",
+                     "relatedDataType": "Encounter",
+                     "relatedKeyColumn": "patient_id",
+                     "whereClause": "status = 'COMPLETE'"
+                 }]
+         }]
 }
 ```
 


### PR DESCRIPTION
This PR makes it so the batch output summary is created even when `--halt-on-error` is used during a run. I would recommend ignoring whitespace in the diff for an easier time reviewing.

One thing to note about this change is that the accumulator used to track errors is not reported back to the driver when there is a failure. This is why I am catching any exception that is thrown and doing my best to get the message(s) out of the exception and into the `EvaluationSummary` object used to create the output report.