### PR TITLE
Wffhcohort 491 spark history log cleanup

### DIFF
--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -49,6 +49,14 @@ spec:
           value: {{ .Values.sparkHistoryServer.s3.bucket }}
         - name: AWS_LOG_PATH
           value: {{ .Values.sparkHistoryServer.s3.eventsDir }}
+        - name: SPARK_HISTORY_FS_CLEANER_MAXAGE
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxAge }}
+        - name: SPARK_HISTORY_FS_CLEANER_ENABLED
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerEnabled }}
+        - name: SPARK_HISTORY_FS_CLEANER_INTERVAL
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerInterval }}
+        - name: SPARK_HISTORY_FS_CLEANER_MAXNUM
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxNum }}
         - name: AWS_ACCESS_KEY
           valueFrom:
             secretKeyRef:
@@ -59,14 +67,6 @@ spec:
             secretKeyRef:
               name: {{ .Values.sparkHistoryServer.s3.secret.name }}
               key: {{ .Values.sparkHistoryServer.s3.secret.secretKeyId }}
-        - name: SPARK_HISTORY_FS_CLEANER_ENABLED
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerEnabled }}
-        - name: SPARK_HISTORY_FS_CLEANER_INTERVAL
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerInterval }}
-        - name: SPARK_HISTORY_FS_CLEANER_MAXAGE
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxAge }}
-          - name: SPARK_HISTORY_FS_CLEANER_MAXNUM
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxNum }}
         ports:
         - name: historyport
           containerPort: 18080

--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -49,14 +49,8 @@ spec:
           value: {{ .Values.sparkHistoryServer.s3.bucket }}
         - name: AWS_LOG_PATH
           value: {{ .Values.sparkHistoryServer.s3.eventsDir }}
-        - name: SPARK_HISTORY_FS_CLEANER_MAXAGE
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxAge }}
-        - name: SPARK_HISTORY_FS_CLEANER_ENABLED
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerEnabled }}
-        - name: SPARK_HISTORY_FS_CLEANER_INTERVAL
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerInterval }}
-        - name: SPARK_HISTORY_FS_CLEANER_MAXNUM
-          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxNum }}
+        - name: SPARK_HISTORY_OPTS
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryOpts }}
         - name: AWS_ACCESS_KEY
           valueFrom:
             secretKeyRef:

--- a/chart/cohort/templates/spark-history-server/deployment.yaml
+++ b/chart/cohort/templates/spark-history-server/deployment.yaml
@@ -59,6 +59,14 @@ spec:
             secretKeyRef:
               name: {{ .Values.sparkHistoryServer.s3.secret.name }}
               key: {{ .Values.sparkHistoryServer.s3.secret.secretKeyId }}
+        - name: SPARK_HISTORY_FS_CLEANER_ENABLED
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerEnabled }}
+        - name: SPARK_HISTORY_FS_CLEANER_INTERVAL
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerInterval }}
+        - name: SPARK_HISTORY_FS_CLEANER_MAXAGE
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxAge }}
+          - name: SPARK_HISTORY_FS_CLEANER_MAXNUM
+          value: {{ .Values.sparkHistoryServer.logs.sparkHistoryFsCleanerMaxNum }}
         ports:
         - name: historyport
           containerPort: 18080

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -85,3 +85,9 @@ sparkHistoryServer:
     endpointId: "https://s3.us.cloud-object-storage.appdomain.cloud"
     bucket: cohort-spark-history
     eventsDir: "/"
+  
+  logs:
+    sparkHistoryFsCleanerEnabled: true
+    sparkHistoryFsCleanerInterval: 1d
+    sparkHistoryFsCleanerMaxAge: 120d
+    sparkHistoryFsCleanerMaxNum: Int.MaxValue

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -86,6 +86,10 @@ sparkHistoryServer:
     bucket: cohort-spark-history
     eventsDir: "/"
   
+# The spark.history.fs.cleaner.* options control
+# how often the spark history server cleans up old event logs.
+# See https://spark.apache.org/docs/latest/monitoring.html#spark-history-server-configuration-options
+# for more information
   logs:
     sparkHistoryOpts: >
       -Dspark.history.fs.cleaner.enabled=true

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -90,4 +90,4 @@ sparkHistoryServer:
     sparkHistoryFsCleanerEnabled: true
     sparkHistoryFsCleanerInterval: 1d
     sparkHistoryFsCleanerMaxAge: 120d
-    sparkHistoryFsCleanerMaxNum: 'Int.MaxValue'
+    sparkHistoryFsCleanerMaxNum: Int.MaxValue

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -87,7 +87,8 @@ sparkHistoryServer:
     eventsDir: "/"
   
   logs:
-    sparkHistoryFsCleanerEnabled: true
-    sparkHistoryFsCleanerInterval: 1d
-    sparkHistoryFsCleanerMaxAge: 120d
-    sparkHistoryFsCleanerMaxNum: Int.MaxValue
+    sparkHistoryOpts: >
+      -Dspark.history.fs.cleaner.enabled=true
+      -Dspark.history.fs.cleaner.interval=1d
+      -Dspark.history.fs.cleaner.maxAge=120d
+      -Dspark.history.fs.cleaner.maxNum=Int.MaxValue

--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -90,4 +90,4 @@ sparkHistoryServer:
     sparkHistoryFsCleanerEnabled: true
     sparkHistoryFsCleanerInterval: 1d
     sparkHistoryFsCleanerMaxAge: 120d
-    sparkHistoryFsCleanerMaxNum: Int.MaxValue
+    sparkHistoryFsCleanerMaxNum: 'Int.MaxValue'

--- a/docker/spark-history-server/entrypoint.sh
+++ b/docker/spark-history-server/entrypoint.sh
@@ -10,10 +10,6 @@ export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
     -Dspark.history.fs.logDirectory=s3a://$AWS_BUCKET$AWS_LOG_PATH \
     -Dspark.hadoop.fs.s3a.endpoint=$AWS_ENDPOINT \
     -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY \
-    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY \
-    -Dspark.history.fs.cleaner.enabled=$SPARK_HISTORY_FS_CLEANER_ENABLED \
-    -Dspark.history.fs.cleaner.interval=$SPARK_HISTORY_FS_CLEANER_INTERVAL \ 
-    -Dspark.history.fs.cleaner.maxAge=$SPARK_HISTORY_FS_CLEANER_MAXAGE \
-    -Dspark.history.fs.cleaner.maxNum=$SPARK_HISTORY_FS_CLEANER_MAXNUM;"
+    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY;"
 
 /opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer;

--- a/docker/spark-history-server/entrypoint.sh
+++ b/docker/spark-history-server/entrypoint.sh
@@ -10,6 +10,6 @@ export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
     -Dspark.history.fs.logDirectory=s3a://$AWS_BUCKET$AWS_LOG_PATH \
     -Dspark.hadoop.fs.s3a.endpoint=$AWS_ENDPOINT \
     -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY \
-    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY;"
+    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY";
 
 /opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer;

--- a/docker/spark-history-server/entrypoint.sh
+++ b/docker/spark-history-server/entrypoint.sh
@@ -10,6 +10,10 @@ export SPARK_HISTORY_OPTS="$SPARK_HISTORY_OPTS \
     -Dspark.history.fs.logDirectory=s3a://$AWS_BUCKET$AWS_LOG_PATH \
     -Dspark.hadoop.fs.s3a.endpoint=$AWS_ENDPOINT \
     -Dspark.hadoop.fs.s3a.access.key=$AWS_ACCESS_KEY \
-    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY";
+    -Dspark.hadoop.fs.s3a.secret.key=$AWS_SECRET_KEY \
+    -Dspark.history.fs.cleaner.enabled=$SPARK_HISTORY_FS_CLEANER_ENABLED \
+    -Dspark.history.fs.cleaner.interval=$SPARK_HISTORY_FS_CLEANER_INTERVAL \ 
+    -Dspark.history.fs.cleaner.maxAge=$SPARK_HISTORY_FS_CLEANER_MAXAGE \
+    -Dspark.history.fs.cleaner.maxNum=$SPARK_HISTORY_FS_CLEANER_MAXNUM;"
 
 /opt/spark/bin/spark-class org.apache.spark.deploy.history.HistoryServer;


### PR DESCRIPTION
Pass in the parameters needed to enable spark history server log cleanup.  SPARK_HISTORY_OPTS was already being set in the entrypoint.sh file called by the history server Dockerfile, so just needed to set the parms and pass them in via the helm chart.