### PR TITLE
Int.MaxValue was causing an exception in the spark history server.

### DIFF
--- a/chart/cohort/values.yaml
+++ b/chart/cohort/values.yaml
@@ -95,4 +95,3 @@ sparkHistoryServer:
       -Dspark.history.fs.cleaner.enabled=true
       -Dspark.history.fs.cleaner.interval=1d
       -Dspark.history.fs.cleaner.maxAge=120d
-      -Dspark.history.fs.cleaner.maxNum=Int.MaxValue


### PR DESCRIPTION
Int.MaxValue (while listed in the documentation as the default, but apparently not to be put in literally) causes an exception in the history server on cleanup attempts after the first attempt (not sure why it work on the first attempt, but not subsequent ones). I had added it as informational so people would more easily see it as an option, but since it is causing a problem, I'm just removing it.

Signed-off-by: TimBishop <tabishop@us.ibm.com>