### PR TITLE
Wffhcohort 540 enhanced health check

### DIFF
--- a/cohort-engine-api-web/launchers/cohort-engine-api-web-VT.launch
+++ b/cohort-engine-api-web/launchers/cohort-engine-api-web-VT.launch
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
-    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/cohort-engine-api-web"/>
-    </listAttribute>
-    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
-        <listEntry value="4"/>
-    </listAttribute>
-    <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=cohort-engine-api-web"/>
-    <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
-    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="cohort-engine-api-web"/>
-    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dtest.host=localhost -Dtest.httpPort=9080 -Dtest.httpSslPort=9443 -Dtest.contextRoot=services/cohort -Dtest.enabledDarkFeatures=none"/>
+<?xml version="1.0" encoding="UTF-8"?><launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/cohort-engine-api-web"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=cohort-engine-api-web"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="cohort-engine-api-web"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dtest.host=localhost -Dtest.httpPort=9080 -Dtest.httpSslPort=9443 -Dtest.contextRoot=services/cohort -Dtest.enabledDarkFeatures=none"/>
 </launchConfiguration>

--- a/cohort-engine-api-web/pom.xml
+++ b/cohort-engine-api-web/pom.xml
@@ -200,6 +200,11 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
 
 		
 		<dependency>

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -48,9 +48,9 @@ import com.ibm.cohort.engine.ZipStreamLibrarySourceProvider;
 import com.ibm.cohort.engine.api.service.model.CohortEvaluation;
 import com.ibm.cohort.engine.api.service.model.CohortResult;
 import com.ibm.cohort.engine.api.service.model.MeasureEvaluation;
-import com.ibm.cohort.engine.api.service.model.PatientListMeasureEvaluation;
 import com.ibm.cohort.engine.api.service.model.MeasureParameterInfo;
 import com.ibm.cohort.engine.api.service.model.MeasureParameterInfoList;
+import com.ibm.cohort.engine.api.service.model.PatientListMeasureEvaluation;
 import com.ibm.cohort.engine.api.service.model.ServiceErrorList;
 import com.ibm.cohort.engine.measure.MeasureEvaluator;
 import com.ibm.cohort.engine.measure.R4DataProviderFactory;
@@ -59,7 +59,6 @@ import com.ibm.cohort.engine.measure.cache.DefaultRetrieveCacheContext;
 import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.r4.cache.R4FhirModelResolverFactory;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
-import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
@@ -74,7 +73,6 @@ import com.ibm.watson.common.service.base.ServiceBaseUtility;
 import com.ibm.websphere.jaxrs20.multipart.IAttachment;
 import com.ibm.websphere.jaxrs20.multipart.IMultipartBody;
 
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import io.swagger.annotations.Api;
@@ -724,9 +722,8 @@ public class CohortEngineRestHandler {
 			validateBean(fhirServerConfig);
 			
 			//get the fhir client object used to call to FHIR
-			FhirContext ctx = FhirContext.forR4();
-			DefaultFhirClientBuilder builder = new DefaultFhirClientBuilder(ctx);
-			IGenericClient measureClient = builder.createFhirClient(fhirServerConfig);
+			FhirClientBuilder clientBuilder = FhirClientBuilderFactory.newInstance().newFhirClientBuilder();
+			IGenericClient measureClient = clientBuilder.createFhirClient(fhirServerConfig);
 			
 			//build the identifier object which is used by the fhir client
 			//to find the measure
@@ -797,9 +794,8 @@ public class CohortEngineRestHandler {
 			validateBean(fhirServerConfig);
 			
 			//get the fhir client object used to call to FHIR
-			FhirContext ctx = FhirContext.forR4();
-			DefaultFhirClientBuilder builder = new DefaultFhirClientBuilder(ctx);
-			IGenericClient measureClient = builder.createFhirClient(fhirServerConfig);
+			FhirClientBuilder clientBuilder = FhirClientBuilderFactory.newInstance().newFhirClientBuilder();
+			IGenericClient measureClient = clientBuilder.createFhirClient(fhirServerConfig);
 
 			//resolve the measure, and return the parameter info for all the libraries linked to by the measure
 			List<MeasureParameterInfo> parameterInfoList = FHIRRestUtils.getParametersForMeasureId(measureClient, measureId);
@@ -877,9 +873,8 @@ public class CohortEngineRestHandler {
 			validateBean(fhirServerConfig);
 
 			//get the fhir client object used to call to FHIR
-			FhirContext ctx = FhirContext.forR4();
-			DefaultFhirClientBuilder builder = new DefaultFhirClientBuilder(ctx);
-			IGenericClient terminologyClient = builder.createFhirClient(fhirServerConfig);
+			FhirClientBuilder clientBuilder = FhirClientBuilderFactory.newInstance().newFhirClientBuilder();
+			IGenericClient terminologyClient = clientBuilder.createFhirClient(fhirServerConfig);
 			
 			IAttachment valueSetAttachment = multipartBody.getAttachment(VALUE_SET_PART);
 			if (valueSetAttachment == null) {

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -920,7 +920,7 @@ public class CohortEngineRestHandler {
 		return response;
 	}
 	
-	private <T> void validateBean(T beanInput) {
+	protected static <T> void validateBean(T beanInput) {
 		// See https://openliberty.io/guides/bean-validation.html
 		// TODO: The validator below is recommended to be injected using CDI in the
 		// guide

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -278,7 +278,7 @@ public class CohortEngineRestHandler {
 			"etc.\n</pre>";
 
 	public static final String EXAMPLE_DATA_SERVER_CONFIG_JSON = "A configuration file containing information needed to connect to the FHIR server. "
-			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/getting-started.md#fhir-server-configuration for more details. \n"
+			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/fhir-server-config.md for more details. \n"
 			+ "Example Contents: \n <pre>{\n" + 
 			"    \"@class\": \"com.ibm.cohort.fhir.client.config.IBMFhirServerConfig\",\n" + 
 			"    \"endpoint\": \"https://fhir-internal.dev:9443/fhir-server/api/v4\",\n" + 

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
@@ -55,7 +55,7 @@ public class CohortEngineRestStatusHandler extends ServiceStatusHandler {
 	private static final String HEALTH_CHECK_ENHANCED_API_NOTES = "Checks the status of the cohorting service and any downstream services used by the cohorting service";
 
 	public static final String EXAMPLE_HEALTH_CHECK_DATA_SERVER_CONFIG_JSON = "A configuration file containing information needed to connect to the FHIR server. "
-			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/getting-started.md#fhir-server-configuration for more details. \n" +
+			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/fhir-server-config.md for more details. \n" +
 			"<p>Example Contents: \n <pre>{\n" +
 			"    \"dataServerConfig\": {\n" +
 			"        \"@class\": \"com.ibm.cohort.fhir.client.config.IBMFhirServerConfig\",\n" +

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
@@ -82,7 +82,7 @@ public class CohortEngineRestStatusHandler extends ServiceStatusHandler {
 			"}</pre></p>";
 	
 	public static final String FHIR_SERVER_CONNECTION_CONFIG = "fhir_server_connection_config";
-	public static String GET_HEALTH_CHECK_ENCHANCED = "getHealthCheckEnhanced";
+	public static final String GET_HEALTH_CHECK_ENCHANCED = "getHealthCheckEnhanced";
 	
 	
 	/**

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandler.java
@@ -5,13 +5,45 @@
  */
 package com.ibm.cohort.engine.api.service;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.ValueSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckInput;
+import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckResults;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirConnectionStatus;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirServerConfigType;
+import com.ibm.cohort.engine.api.service.model.ServiceErrorList;
+import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
+import com.ibm.cohort.fhir.client.config.FhirServerConfig;
+import com.ibm.watson.common.service.base.ServiceBaseConstants;
+import com.ibm.watson.common.service.base.ServiceBaseUtility;
 import com.ibm.watson.common.service.base.ServiceStatusHandler;
 import com.ibm.watson.service.base.model.ServiceStatus;
 import com.ibm.watson.service.base.model.ServiceStatus.ServiceState;
+import com.ibm.websphere.jaxrs20.multipart.IAttachment;
+import com.ibm.websphere.jaxrs20.multipart.IMultipartBody;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.annotations.Tag;
 
@@ -19,7 +51,39 @@ import io.swagger.annotations.Tag;
 @Api(value = "Status")
 @SwaggerDefinition(tags={@Tag(name = "Status", description = "Get the status of this service")})
 public class CohortEngineRestStatusHandler extends ServiceStatusHandler {
+	private static final Logger logger = LoggerFactory.getLogger(CohortEngineRestStatusHandler.class.getName());
+	private static final String HEALTH_CHECK_ENHANCED_API_NOTES = "Checks the status of the cohorting service and any downstream services used by the cohorting service";
 
+	public static final String EXAMPLE_HEALTH_CHECK_DATA_SERVER_CONFIG_JSON = "A configuration file containing information needed to connect to the FHIR server. "
+			+ "See https://github.com/Alvearie/quality-measure-and-cohort-service/blob/main/docs/user-guide/getting-started.md#fhir-server-configuration for more details. \n" +
+			"<p>Example Contents: \n <pre>{\n" +
+			"    \"dataServerConfig\": {\n" +
+			"        \"@class\": \"com.ibm.cohort.fhir.client.config.IBMFhirServerConfig\",\n" +
+			"        \"endpoint\": \"ENDPOINT\",\n" +
+			"        \"user\": \"USER\",\n" +
+			"        \"password\": \"PASSWORD\",\n" +
+			"        \"logInfo\": [\n" +
+			"            \"REQUEST_SUMMARY\",\n" +
+			"            \"RESPONSE_SUMMARY\"\n" +
+			"        ],\n" +
+			"        \"tenantId\": \"default\"\n" +
+			"    },\n" +
+			"    \"terminologyServerConfig\": {\n" +
+			"        \"@class\": \"com.ibm.cohort.fhir.client.config.IBMFhirServerConfig\",\n" +
+			"        \"endpoint\": \"ENDPOINT\",\n" +
+			"        \"user\": \"USER\",\n" +
+			"        \"password\": \"PASSWORD\",\n" +
+			"        \"logInfo\": [\n" +
+			"            \"REQUEST_SUMMARY\",\n" +
+			"            \"RESPONSE_SUMMARY\"\n" +
+			"        ],\n" +
+			"        \"tenantId\": \"default\"\n" +
+			"    }\n" +
+			"}</pre></p>";
+	
+	public static String GET_HEALTH_CHECK_ENCHANCED = "getHealthCheckEnhanced";
+	
+	
 	/**
 	 * Example to show how to modify the service status text.
 	 * This method should include code that verifies the service
@@ -32,6 +96,112 @@ public class CohortEngineRestStatusHandler extends ServiceStatusHandler {
 		//status.setStateDetails("Running normally");  // No need to set details when state is ok
 
 		return status;
+	}
+	
+	@POST
+	@Path("health_check_enhanced")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.MULTIPART_FORM_DATA)
+	@ApiOperation(value = "Get the status of the cohorting service and dependent downstream services", notes = CohortEngineRestStatusHandler.HEALTH_CHECK_ENHANCED_API_NOTES, response = EnhancedHealthCheckResults.class, nickname = "health_check_enhanced")
+	@ApiImplicitParams({
+		@ApiImplicitParam(name=CohortEngineRestHandler.FHIR_DATA_SERVER_CONFIG_PART, value=CohortEngineRestStatusHandler.EXAMPLE_HEALTH_CHECK_DATA_SERVER_CONFIG_JSON, dataTypeClass = EnhancedHealthCheckInput.class, required=true, paramType="form", type="file"),
+	})
+	@ApiResponses(value = {
+			@ApiResponse(code = 200, message = "Successful Operation", response = EnhancedHealthCheckResults.class),
+			@ApiResponse(code = 400, message = "Bad Request", response = ServiceErrorList.class),
+			@ApiResponse(code = 500, message = "Server Error", response = ServiceErrorList.class) })
+	public Response getHealthCheckEnhanced(
+			@ApiParam(value = ServiceBaseConstants.MINOR_VERSION_DESCRIPTION, required = true, defaultValue = ServiceBuildConstants.DATE) @QueryParam(CohortEngineRestHandler.VERSION) String version,
+			@ApiParam(hidden = true, type="file", required=true) IMultipartBody multipartBody)
+			{
+
+		final String methodName = CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED;
+		
+		Response response = null;
+		
+		try {
+			// Perform api setup
+			Response errorResponse = ServiceBaseUtility.apiSetup(version, logger, methodName);
+			if(errorResponse != null) {
+				return errorResponse;
+			}
+			
+			//initialize results object
+			EnhancedHealthCheckResults results = new EnhancedHealthCheckResults();
+			FhirServerConnectionStatusInfo dataServerConnectionResults = new FhirServerConnectionStatusInfo();
+			dataServerConnectionResults.setServerConfigType(FhirServerConfigType.dataServerConfig);
+			dataServerConnectionResults.setConnectionResults(FhirConnectionStatus.notAttempted);
+			
+			FhirServerConnectionStatusInfo terminologyServerConnectionResults = new FhirServerConnectionStatusInfo();
+			terminologyServerConnectionResults.setServerConfigType(FhirServerConfigType.terminologyServerConfig);
+			terminologyServerConnectionResults.setConnectionResults(FhirConnectionStatus.notAttempted);
+			
+			results.setDataServerConnectionResults(dataServerConnectionResults);
+			results.setTerminologyServerConnectionResults(terminologyServerConnectionResults);
+
+			IAttachment dataSourceAttachment = multipartBody.getAttachment(CohortEngineRestHandler.FHIR_DATA_SERVER_CONFIG_PART);
+			if( dataSourceAttachment == null ) {
+				throw new IllegalArgumentException(String.format("Missing '%s' MIME attachment", CohortEngineRestHandler.FHIR_DATA_SERVER_CONFIG_PART));
+			}
+			
+			// deserialize the request input
+			ObjectMapper om = new ObjectMapper();
+			EnhancedHealthCheckInput fhirServerConfigs = om.readValue( dataSourceAttachment.getDataHandler().getInputStream(), EnhancedHealthCheckInput.class );
+			
+			FhirServerConfig dataServerConfig = fhirServerConfigs.getDataServerConfig();
+			FhirServerConfig terminologyServerConfig = fhirServerConfigs.getTerminologyServerConfig();
+			
+			//validate the contents of the dataServerConfig
+			CohortEngineRestHandler.validateBean(dataServerConfig);
+			
+			//validate the contents of the terminologyServerConfig
+			if(terminologyServerConfig != null) {
+				CohortEngineRestHandler.validateBean(terminologyServerConfig);
+			}
+
+			//get the fhir client object used to call to FHIR
+			FhirContext ctx = FhirContext.forR4();
+			DefaultFhirClientBuilder builder = new DefaultFhirClientBuilder(ctx);
+			
+			//try a simple patient search to validate the connection info
+			IGenericClient dataClient = builder.createFhirClient(dataServerConfig);
+			try {
+				//used count=0 to minimize response size
+				dataClient.search().forResource(Patient.class).count(0).execute();
+				dataServerConnectionResults.setConnectionResults(FhirConnectionStatus.success);
+			} catch (Throwable ex) {
+				dataServerConnectionResults.setConnectionResults(FhirConnectionStatus.failure);
+				dataServerConnectionResults.setServiceErrorList(new CohortServiceExceptionMapper().toServiceErrorList(ex));
+			}
+
+			//if terminology server info is provided,
+			//try a simple valueset search to validate the connection info
+			if(terminologyServerConfig != null) {
+				try {
+					IGenericClient terminologyClient = builder.createFhirClient(terminologyServerConfig);
+					//used count=0 to minimize response size
+					terminologyClient.search().forResource(ValueSet.class).count(0).execute();
+					terminologyServerConnectionResults.setConnectionResults(FhirConnectionStatus.success);
+				} catch (Throwable ex) {
+					terminologyServerConnectionResults.setConnectionResults(FhirConnectionStatus.failure);
+					terminologyServerConnectionResults.setServiceErrorList(new CohortServiceExceptionMapper().toServiceErrorList(ex));
+				}
+			}
+
+			//return the results
+			response = Response.ok(results).build();
+		} catch (Throwable e) {
+			//map any exceptions caught into the proper REST error response objects
+			return new CohortServiceExceptionMapper().toResponse(e);
+		}finally {
+			// Perform api cleanup
+			Response errorResponse = ServiceBaseUtility.apiCleanup(logger, methodName);
+			if(errorResponse != null) {
+				response = errorResponse;
+			}
+		}
+		
+		return response;
 	}
 
 }

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortServiceExceptionMapper.java
@@ -37,6 +37,17 @@ public class CohortServiceExceptionMapper implements ExceptionMapper<Throwable>{
 
 	@Override
 	public Response toResponse(Throwable ex) {
+		ServiceErrorList serviceErrorList = toServiceErrorList(ex);
+
+		ResponseBuilder rb = Response.status(serviceErrorList.getStatusCode()).
+				entity(serviceErrorList).
+				type(MediaType.APPLICATION_JSON);
+
+		return rb.build();
+	}
+	
+
+	public ServiceErrorList toServiceErrorList(Throwable ex) {
 		List<ServiceError> errorsList = new ArrayList<>();
 		//The IBM Cloud API Handbook mandates that REST errors be returned using
 		//an error container model class (ServiceErrorList) which in turn contains
@@ -173,12 +184,8 @@ public class CohortServiceExceptionMapper implements ExceptionMapper<Throwable>{
 
 			errorsList.add(se);
 		}
-
-		ResponseBuilder rb = Response.status(serviceErrorList.getStatusCode()).
-				entity(serviceErrorList).
-				type(MediaType.APPLICATION_JSON);
-
-		return rb.build();
+		
+		return serviceErrorList;
 	}
 	
 	private void createServiceErrorsForExceptions(Throwable ex, int code, List<ServiceError> errorsList) {

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2020
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,17 +7,46 @@ package com.ibm.cohort.engine.api.service;
 
 import static org.junit.Assert.assertEquals;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.r4.model.Patient;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.agent.PowerMockAgent;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckResults;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirConnectionStatus;
+import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
+import com.ibm.watson.common.service.base.ServiceBaseUtility;
+import com.ibm.watson.common.service.base.security.TenantManager;
 import com.ibm.watson.service.base.model.ServiceStatus;
 import com.ibm.watson.service.base.model.ServiceStatus.ServiceState;
 
-public class CohortEngineRestStatusHandlerTest {
-
+public class CohortEngineRestStatusHandlerTest extends CohortHandlerBaseTest {
+	// Need to add below to get jacoco to work with powermockito
+	@Rule
+	public PowerMockRule rule = new PowerMockRule();
+	static {
+		PowerMockAgent.initializeIfNeeded();
+	}
+	
+	// We're using this to mock calls to CohortEngineRestStatusHandler, thus to make the mocking work, we need to use the same logger as that class
+	private static final Logger logger = LoggerFactory.getLogger(CohortEngineRestStatusHandler.class.getName());
+	private static final String VERSION = "version";
+		
 	@InjectMocks
 	private static CohortEngineRestStatusHandler cerSH;
 
@@ -27,7 +56,8 @@ public class CohortEngineRestStatusHandlerTest {
 	}
 
 	@BeforeClass
-	public static void setUpBeforeClass() throws Exception {
+	public static void setUpBeforeClass() {
+		BaseFhirTest.setUpBeforeClass();
 		cerSH = new CohortEngineRestStatusHandler();
 	}
 
@@ -43,5 +73,125 @@ public class CohortEngineRestStatusHandlerTest {
 		newStatus = cerSH.adjustServiceStatus(status);
 		assertEquals("The service state was not OK.", ServiceState.OK, newStatus.getServiceState());
 	}
+	
+	@PrepareForTest({ Response.class, TenantManager.class, ServiceBaseUtility.class, DefaultFhirClientBuilder.class })
+	@Test
+	/**
+	 * Test the setting of service status to OK.
+	 */
+	public void testEnhancedHealthCheckOK() throws Exception {
+		prepMocks(false);
+		
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		PowerMockito.when(ServiceBaseUtility.apiSetup(VERSION, logger, CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED)).thenReturn(null);
+		
+		CapabilityStatement metadata = getCapabilityStatement();
+		mockFhirResourceRetrieval("/metadata?_format=json", metadata);
+		
+		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
+		mockFhirResourceRetrieval("/Patient?_format=json", patient);
+		
+		//don't need to return a valueset since we only care that the call returns something
+		mockFhirResourceRetrieval("/ValueSet?_format=json", patient);
+		
+		Response response = cerSH.getHealthCheckEnhanced(VERSION, getEnhancedHealthCheckInputConfigFileBody(true));
+		
+		assertEquals(Status.OK.getStatusCode(), response.getStatus());
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getDataServerConnectionResults().getConnectionResults(), FhirConnectionStatus.success);
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getTerminologyServerConnectionResults().getConnectionResults(), FhirConnectionStatus.success);
+	}
+	
+	@PrepareForTest({ Response.class, TenantManager.class, ServiceBaseUtility.class, DefaultFhirClientBuilder.class })
+	@Test
+	/**
+	 * Test the service returns a failure when trying to connect to data and terminology servers
+	 */
+	public void testEnhancedHealthCheckFailed() throws Exception {
+		prepMocks(false);
+		
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		PowerMockito.when(ServiceBaseUtility.apiSetup(VERSION, logger, CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED)).thenReturn(null);
+		
+		CapabilityStatement metadata = getCapabilityStatement();
+		mockFhirResourceRetrieval("/metadata?_format=json", metadata);
+		
+		//return null to cause exception
+		mockFhirResourceRetrieval("/Patient?_format=json", null);
+		mockFhirResourceRetrieval("/ValueSet?_format=json", null);
+		
+		Response response = cerSH.getHealthCheckEnhanced(VERSION, getEnhancedHealthCheckInputConfigFileBody(true));
+		
+		assertEquals(Status.OK.getStatusCode(), response.getStatus());
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getDataServerConnectionResults().getConnectionResults(), FhirConnectionStatus.failure);
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getTerminologyServerConnectionResults().getConnectionResults(), FhirConnectionStatus.failure);
+	}
+	
+	@PrepareForTest({ Response.class, TenantManager.class, ServiceBaseUtility.class, DefaultFhirClientBuilder.class })
+	@Test
+	/**
+	 * Test a failure when invalid input provided
+	 */
+	public void testEnhancedHealthCheckFailedNoInput() throws Exception {
+		prepMocks(false);
+		
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		PowerMockito.when(ServiceBaseUtility.apiSetup(VERSION, logger, CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED)).thenReturn(null);
+		
+		CapabilityStatement metadata = getCapabilityStatement();
+		mockFhirResourceRetrieval("/metadata?_format=json", metadata);
+		
+		//return null to cause exception
+		mockFhirResourceRetrieval("/Patient?_format=json", null);
+		mockFhirResourceRetrieval("/ValueSet?_format=json", null);
+		
+		Response response = cerSH.getHealthCheckEnhanced(VERSION, null);
+		
+		assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+	}
+	
+	@PrepareForTest({ Response.class, TenantManager.class, ServiceBaseUtility.class, DefaultFhirClientBuilder.class })
+	@Test
+	/**
+	 * Test a failure connecting to data server and no terminology server provided
+	 */
+	public void testEnhancedHealthCheckFailNoTermServer() throws Exception {
+		prepMocks(false);
+		
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		PowerMockito.when(ServiceBaseUtility.apiSetup(VERSION, logger, CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED)).thenReturn(null);
+		
+		CapabilityStatement metadata = getCapabilityStatement();
+		mockFhirResourceRetrieval("/metadata?_format=json", metadata);
+		
+		mockFhirResourceRetrieval("/Patient?_format=json", null);
+		
+		Response response = cerSH.getHealthCheckEnhanced(VERSION, getEnhancedHealthCheckInputConfigFileBody(false));
+		
+		assertEquals(Status.OK.getStatusCode(), response.getStatus());
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getDataServerConnectionResults().getConnectionResults(), FhirConnectionStatus.failure);
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getTerminologyServerConnectionResults().getConnectionResults(), FhirConnectionStatus.notAttempted);
+	}
+	
+	@PrepareForTest({ Response.class, TenantManager.class, ServiceBaseUtility.class, DefaultFhirClientBuilder.class })
+	@Test
+	public void testEnhancedHealthCheckOKNoTermServer() throws Exception {
+		prepMocks(false);
+		
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		PowerMockito.when(ServiceBaseUtility.apiSetup(VERSION, logger, CohortEngineRestStatusHandler.GET_HEALTH_CHECK_ENCHANCED)).thenReturn(null);	
+		
+		CapabilityStatement metadata = getCapabilityStatement();
+		mockFhirResourceRetrieval("/metadata?_format=json", metadata);
+		
+		Patient patient = getPatient("123", AdministrativeGender.MALE, "1970-10-10");
+		mockFhirResourceRetrieval("/Patient?_format=json", patient);
+		
+		Response response = cerSH.getHealthCheckEnhanced(VERSION, getEnhancedHealthCheckInputConfigFileBody(false));
+		
+		assertEquals(Status.OK.getStatusCode(), response.getStatus());
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getDataServerConnectionResults().getConnectionResults(), FhirConnectionStatus.success);
+		assertEquals(((EnhancedHealthCheckResults)response.getEntity()).getTerminologyServerConnectionResults().getConnectionResults(), FhirConnectionStatus.notAttempted);
+	}
+	
 
 }

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerBaseTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerBaseTest.java
@@ -98,7 +98,7 @@ public class CohortHandlerBaseTest extends BaseFhirTest{
 		
 		// Assemble them together into a reasonable facsimile of the real request
 		IMultipartBody body = mock(IMultipartBody.class);
-		when( body.getAttachment(CohortEngineRestHandler.FHIR_DATA_SERVER_CONFIG_PART) ).thenReturn(rootPart);
+		when( body.getAttachment(CohortEngineRestStatusHandler.FHIR_SERVER_CONNECTION_CONFIG) ).thenReturn(rootPart);
 		
 		return body;
 	}

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerBaseTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerBaseTest.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  * (C) Copyright IBM Corp. 2022
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package com.ibm.cohort.engine.api.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.activation.DataHandler;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckInput;
+import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
+import com.ibm.watson.common.service.base.ServiceBaseUtility;
+import com.ibm.watson.common.service.base.security.Tenant;
+import com.ibm.watson.common.service.base.security.TenantManager;
+import com.ibm.websphere.jaxrs20.multipart.IAttachment;
+import com.ibm.websphere.jaxrs20.multipart.IMultipartBody;
+
+public class CohortHandlerBaseTest extends BaseFhirTest{
+
+	@Mock
+	protected static HttpServletRequest mockRequestContext;
+	@Mock
+	protected static HttpHeaders mockHttpHeaders;
+	@Mock
+	protected static DefaultFhirClientBuilder mockDefaultFhirClientBuilder;
+	
+	protected List<String> httpHeadersList = Arrays.asList("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
+	
+	public CohortHandlerBaseTest() {
+		// TODO Auto-generated constructor stub
+	}
+
+	
+	protected void prepMocks() {
+		prepMocks(true);
+	}
+
+	protected void prepMocks(boolean prepResponse) {
+		PowerMockito.mockStatic(ServiceBaseUtility.class);
+		if (prepResponse) {
+			PowerMockito.mockStatic(Response.class);
+		}
+		PowerMockito.mockStatic(TenantManager.class);
+
+		PowerMockito.when(TenantManager.getTenant()).thenReturn(new Tenant() {
+			@Override
+			public String getTenantId() {
+				return "JunitTenantId";
+			}
+
+			@Override
+			public String getUserId() {
+				return "JunitUserId";
+			}
+
+		});
+		when(mockRequestContext.getRemoteAddr()).thenReturn("1.1.1.1");
+		when(mockRequestContext.getLocalAddr()).thenReturn("1.1.1.1");
+		when(mockRequestContext.getRequestURL())
+				.thenReturn(new StringBuffer("http://localhost:9080/services/cohort/api/v1/evaluation"));
+		when(mockHttpHeaders.getRequestHeader(HttpHeaders.AUTHORIZATION)).thenReturn(httpHeadersList);
+		when(mockDefaultFhirClientBuilder.createFhirClient(ArgumentMatchers.any())).thenReturn(null);
+	}
+	
+	protected IMultipartBody getEnhancedHealthCheckInputConfigFileBody(boolean includeTerminologyServer) throws Exception {
+		// Create the metadata part of the request
+		ObjectMapper om = new ObjectMapper();
+		
+		EnhancedHealthCheckInput input = new EnhancedHealthCheckInput();
+		input.setDataServerConfig(getFhirServerConfig());
+		if (includeTerminologyServer) {
+			input.setTerminologyServerConfig(getFhirServerConfig());
+		}
+		
+		String json = om.writeValueAsString(input);
+		ByteArrayInputStream jsonIs = new ByteArrayInputStream(json.getBytes());
+		IAttachment rootPart = mockAttachment(jsonIs);
+		
+		// Assemble them together into a reasonable facsimile of the real request
+		IMultipartBody body = mock(IMultipartBody.class);
+		when( body.getAttachment(CohortEngineRestHandler.FHIR_DATA_SERVER_CONFIG_PART) ).thenReturn(rootPart);
+		
+		return body;
+	}
+	
+	protected IAttachment mockAttachment(InputStream multipartData) throws IOException {
+		IAttachment measurePart = mock(IAttachment.class);
+		DataHandler zipHandler = mock(DataHandler.class);
+		when( zipHandler.getInputStream() ).thenReturn(multipartData);
+		when( measurePart.getDataHandler() ).thenReturn( zipHandler );
+		return measurePart;
+	}
+}

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckInput.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckInput.java
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright IBM Corp. 2022, 2022
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.engine.api.service.model;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.ibm.cohort.annotations.Generated;
+import com.ibm.cohort.fhir.client.config.FhirServerConfig;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@Generated
+@ApiModel
+public class EnhancedHealthCheckInput {
+
+	@NotNull
+	@Valid
+	private FhirServerConfig dataServerConfig;
+	private FhirServerConfig terminologyServerConfig;
+	
+	@ApiModelProperty(required = true)
+	public FhirServerConfig getDataServerConfig() {
+		return this.dataServerConfig;
+	}
+
+	public void setDataServerConfig(FhirServerConfig dataServerConfig) {
+		this.dataServerConfig = dataServerConfig;
+	}
+
+	@ApiModelProperty(required = false)
+	public FhirServerConfig getTerminologyServerConfig() {
+		return this.terminologyServerConfig;
+	}
+
+	public void setTerminologyServerConfig(FhirServerConfig terminologyServerConfig) {
+		this.terminologyServerConfig = terminologyServerConfig;
+	}
+	
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+}

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResults.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResults.java
@@ -17,15 +17,13 @@ import com.ibm.cohort.annotations.Generated;
 import io.swagger.annotations.ApiModel;
 
 @Generated
-@ApiModel
+@ApiModel(value="EnhancedHealthCheckResults", description="An object containing the results of an attempt to connect to the FHIR data server and (optional) terminology server")
 public class EnhancedHealthCheckResults {
 
 	@NotNull
 	@Valid
 	private FhirServerConnectionStatusInfo dataServerConnectionResults;
 	private FhirServerConnectionStatusInfo terminologyServerConnectionResults;
-	
-	
 	
 	public FhirServerConnectionStatusInfo getDataServerConnectionResults() {
 		return dataServerConnectionResults;

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResults.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResults.java
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright IBM Corp. 2022, 2022
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.engine.api.service.model;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.ibm.cohort.annotations.Generated;
+
+import io.swagger.annotations.ApiModel;
+
+@Generated
+@ApiModel
+public class EnhancedHealthCheckResults {
+
+	@NotNull
+	@Valid
+	private FhirServerConnectionStatusInfo dataServerConnectionResults;
+	private FhirServerConnectionStatusInfo terminologyServerConnectionResults;
+	
+	
+	
+	public FhirServerConnectionStatusInfo getDataServerConnectionResults() {
+		return dataServerConnectionResults;
+	}
+
+	public void setDataServerConnectionResults(FhirServerConnectionStatusInfo dataServerConnectionResults) {
+		this.dataServerConnectionResults = dataServerConnectionResults;
+	}
+
+	public FhirServerConnectionStatusInfo getTerminologyServerConnectionResults() {
+		return terminologyServerConnectionResults;
+	}
+
+	public void setTerminologyServerConnectionResults(FhirServerConnectionStatusInfo terminologyServerConnectionResults) {
+		this.terminologyServerConnectionResults = terminologyServerConnectionResults;
+	}
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+}

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/FhirServerConnectionStatusInfo.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/FhirServerConnectionStatusInfo.java
@@ -9,12 +9,14 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ibm.cohort.annotations.Generated;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @Generated
-@ApiModel
+@ApiModel(value="FhirServerConnectionStatusInfo", description="An object containing the results of an attempt to connect to a FHIR server")
 public class FhirServerConnectionStatusInfo {
 
 	public static enum FhirServerConfigType {dataServerConfig, terminologyServerConfig};
@@ -24,7 +26,8 @@ public class FhirServerConnectionStatusInfo {
 	private FhirConnectionStatus connectionResults;
 	private ServiceErrorList serviceErrorList;
 
-	
+	@ApiModelProperty(value = "A string describing the type of FHIR server config")
+	@JsonProperty("serverConfigType")
 	public FhirServerConfigType getServerConfigType() {
 		return serverConfigType;
 	}
@@ -33,6 +36,8 @@ public class FhirServerConnectionStatusInfo {
 		this.serverConfigType = serverConfigType;
 	}
 
+	@ApiModelProperty(value = "Result of the connection attempt")
+	@JsonProperty("connectionResults")
 	public FhirConnectionStatus getConnectionResults() {
 		return connectionResults;
 	}

--- a/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/FhirServerConnectionStatusInfo.java
+++ b/cohort-engine-api/src/main/java/com/ibm/cohort/engine/api/service/model/FhirServerConnectionStatusInfo.java
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright IBM Corp. 2022, 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.cohort.engine.api.service.model;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import com.ibm.cohort.annotations.Generated;
+
+import io.swagger.annotations.ApiModel;
+
+@Generated
+@ApiModel
+public class FhirServerConnectionStatusInfo {
+
+	public static enum FhirServerConfigType {dataServerConfig, terminologyServerConfig};
+	public static enum FhirConnectionStatus {success, failure, notAttempted};
+	
+	private FhirServerConfigType serverConfigType;
+	private FhirConnectionStatus connectionResults;
+	private ServiceErrorList serviceErrorList;
+
+	
+	public FhirServerConfigType getServerConfigType() {
+		return serverConfigType;
+	}
+
+	public void setServerConfigType(FhirServerConfigType serverConfigType) {
+		this.serverConfigType = serverConfigType;
+	}
+
+	public FhirConnectionStatus getConnectionResults() {
+		return connectionResults;
+	}
+
+	public void setConnectionResults(FhirConnectionStatus connectionResults) {
+		this.connectionResults = connectionResults;
+	}
+
+	public ServiceErrorList getServiceErrorList() {
+		return serviceErrorList;
+	}
+
+	public void setServiceErrorList(ServiceErrorList serviceErrorList) {
+		this.serviceErrorList = serviceErrorList;
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeBuilder.reflectionHashCode(this);
+	}
+	
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
+	
+	@Override
+	public boolean equals(Object o) {
+		return EqualsBuilder.reflectionEquals(this, o);
+	}
+}

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckInputTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckInputTest.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  * (C) Copyright IBM Corp. 2022
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.ibm.cohort.engine.api.service.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.cohort.fhir.client.config.FhirServerConfig;
+
+public class EnhancedHealthCheckInputTest {
+
+	@Test
+	public void when_serialize_deserialize___properties_are_unchanged() throws Exception {
+
+		FhirServerConfig dataServerConfig = new FhirServerConfig();
+		dataServerConfig.setEndpoint("dataserver");
+
+		FhirServerConfig termServerConfig = new FhirServerConfig();
+		termServerConfig.setEndpoint("termserver");
+
+		EnhancedHealthCheckInput input = new EnhancedHealthCheckInput();
+		input.setDataServerConfig(dataServerConfig);
+		input.setTerminologyServerConfig(termServerConfig);
+
+		ObjectMapper om = new ObjectMapper();
+		String serialized = om.writeValueAsString(input);
+
+		EnhancedHealthCheckInput deserialized = om.readValue( serialized, EnhancedHealthCheckInput.class);
+		assertEquals( input, deserialized );
+	}
+
+}

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResultsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/model/EnhancedHealthCheckResultsTest.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * (C) Copyright IBM Corp. 2022
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package com.ibm.cohort.engine.api.service.model;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirConnectionStatus;
+import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirServerConfigType;
+import com.ibm.cohort.fhir.client.config.FhirServerConfig;
+
+public class EnhancedHealthCheckResultsTest {
+
+	@Test
+	public void when_serialize_deserialize___properties_are_unchanged() throws Exception {
+
+		FhirServerConfig dataServerConfig = new FhirServerConfig();
+		dataServerConfig.setEndpoint("dataserver");
+
+		FhirServerConfig termServerConfig = new FhirServerConfig();
+		termServerConfig.setEndpoint("termserver");
+
+		EnhancedHealthCheckResults results = new EnhancedHealthCheckResults();
+		FhirServerConnectionStatusInfo dataServerConnectionResults = new FhirServerConnectionStatusInfo();
+		dataServerConnectionResults.setServerConfigType(FhirServerConfigType.dataServerConfig);
+		dataServerConnectionResults.setConnectionResults(FhirConnectionStatus.notAttempted);
+		
+		FhirServerConnectionStatusInfo terminologyServerConnectionResults = new FhirServerConnectionStatusInfo();
+		terminologyServerConnectionResults.setServerConfigType(FhirServerConfigType.terminologyServerConfig);
+		terminologyServerConnectionResults.setConnectionResults(FhirConnectionStatus.notAttempted);
+		
+		results.setDataServerConnectionResults(dataServerConnectionResults);
+		results.setTerminologyServerConnectionResults(terminologyServerConnectionResults);
+
+		ObjectMapper om = new ObjectMapper();
+		String serialized = om.writeValueAsString(results);
+
+		EnhancedHealthCheckResults deserialized = om.readValue( serialized, EnhancedHealthCheckResults.class);
+		assertEquals( results, deserialized );
+	}
+
+}


### PR DESCRIPTION
Added new enhanced health check endpoint to the CohortEngineRestStatusHandler so it shows up under along side the other existing health check endpoints. Refactored a few classes to pull out some common test function. I added some custom exception checking because in certain cases the FHIR client hardcodes a 500 http status code and the authoring tool wanted to be able to distinguish timeout/failed connection/vs other problems so I added code to look for certain exceptions in the cause chain so I could set a specific error code in the errors we give back.

Below are some screenshots of the swagger interface to help illustrate how it will look:
![healthCheck1](https://user-images.githubusercontent.com/72571312/154510474-b61291eb-9726-4b7d-8d2d-85ef03b8c228.jpg)
![healthCheck2](https://user-images.githubusercontent.com/72571312/154510655-206d7340-5fbb-4349-9178-fc5d1db42b5d.jpg)

