### PR TITLE
WFFHCOHORT-864 Build changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn clean install -T 4 -f cohort-parent
+        run: mvn clean install -T 2 -f cohort-parent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn clean install -f cohort-parent
+        run: mvn clean install -T 4 -f cohort-parent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/R4FhirModelResolverFactory.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/r4/cache/R4FhirModelResolverFactory.java
@@ -10,11 +10,19 @@ import org.opencds.cqf.cql.engine.fhir.model.R4FhirModelResolver;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
 
 public class R4FhirModelResolverFactory {
+	/*
+	 * Caching the ModelResolver will prevent multiple FhirContext objects
+	 * from being created each time one of the methods are called.
+	 * This operation should be threadsafe given the way we currently use
+	 * these objects.
+	 */
+	private static final ModelResolver modelResolver = new R4FhirModelResolver();
+
 	public static ModelResolver createCachingResolver() {
-		return new CachingModelResolverDecorator(new R4FhirModelResolver());
+		return new CachingModelResolverDecorator(modelResolver);
 	}
 	
 	public static ModelResolver createNonCachingResolver() {
-		return new R4FhirModelResolver();
+		return modelResolver;
 	}
 }

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
@@ -23,8 +23,8 @@ import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 public class FhirClientTimeoutTest extends BaseFhirTest {
 
 	private static final String PATIENT_ID = "TimeoutTest-PatientId";
-	private static final int PATIENT_RETRIEVAL_DELAY_MILLIS = 3_000;
-	private static final int CONFIG_TIMEOUT_MILLIS = 1_000;
+	private static final int PATIENT_RETRIEVAL_DELAY_MILLIS = 200;
+	private static final int CONFIG_TIMEOUT_MILLIS = 100;
 	private static final int CONFIG_NO_TIMEOUT_MILLIS = 20_000;
 	
 	@Before

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/BaseSparkTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/BaseSparkTest.java
@@ -47,13 +47,15 @@ public abstract class BaseSparkTest implements Serializable {
         return initializeSession(Java8API.ENABLED);
     }
 
+    //  Partition settings will keep the task count down for each Spark job, which makes tests run faster.
     protected static SparkSession initializeSession(Java8API java8APIEnabled) {
         SparkSession.Builder builder = SparkSession.builder()
                 .appName("Local Application")
                 .master("local[4]")
                 .config("spark.sql.datetime.java8API.enabled", String.valueOf(java8APIEnabled.getValue()))
-                .config("spark.sql.sources.default", "delta");
-
+                .config("spark.sql.sources.default", "delta")
+                .config("spark.sql.shuffle.partitions", "8")
+                .config("spark.databricks.delta.snapshotPartitions", "8");
         return builder.getOrCreate();
     }
 }

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/aggregation/ContextRetrieverTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/aggregation/ContextRetrieverTest.java
@@ -993,11 +993,20 @@ public class ContextRetrieverTest extends BaseSparkTest {
 
     @SuppressWarnings({"unchecked","rawtypes"})
     private void assertOutput(List<Tuple2<Object, List<Row>>> expected, List<Tuple2<Object, List<Row>>> actual) {
-        // Sort the `actual` outer list.
-        // Even with one task, Spark likes to jumble the order of the results.
-        // There may be a need to sort the inner Row lists in the future, but there is no need right now.
+        // Sort the outer and inner lists for the equals check.
+        List<Tuple2<Object, List<Row>>> sortedExpected = new ArrayList<>(expected);
+        sortedExpected.sort(Comparator.comparing(x -> (Comparable)x._1));
+        for (Tuple2<Object, List<Row>> tuple : sortedExpected) {
+            List<Row> rows = tuple._2();
+            rows.sort(Comparator.comparing(x -> x.getAs(0)));
+        }
+
         List<Tuple2<Object, List<Row>>> sortedActual = new ArrayList<>(actual);
         sortedActual.sort(Comparator.comparing(x -> (Comparable)x._1));
+        for (Tuple2<Object, List<Row>> tuple : sortedActual) {
+            List<Row> rows = tuple._2();
+            rows.sort(Comparator.comparing(x -> x.getAs(0)));
+        }
 
         // Row.equals() does not compare schemas.
         Assert.assertEquals("Data mismatch", expected, sortedActual);

--- a/preDockerBuild.sh
+++ b/preDockerBuild.sh
@@ -12,4 +12,4 @@ set -xe
 # in github packages and also the cql engine libraries
 # actual git credential values are stored in key protect in the cloud cluster
 # and injected via env variables when the toolchain runs
-mvn clean install -f cohort-parent -s .toolchain.maven.settings.xml
+mvn clean install -T 4 -f cohort-parent -s .toolchain.maven.settings.xml

--- a/preDockerBuild.sh
+++ b/preDockerBuild.sh
@@ -12,4 +12,4 @@ set -xe
 # in github packages and also the cql engine libraries
 # actual git credential values are stored in key protect in the cloud cluster
 # and injected via env variables when the toolchain runs
-mvn clean install -T 4 -f cohort-parent -s .toolchain.maven.settings.xml
+mvn clean install -T 2 -f cohort-parent -s .toolchain.maven.settings.xml


### PR DESCRIPTION
This PR implements some of the build changes discussed during our standup. Primary changes are:

- Using the maven `-T` option to build modules in parallel.
- Using a shared `ModelResolver` in `R4FhirModelResolverFactory`.
- Lowering the timeouts in `FhirClientTimeoutTest`.
- Configuring fewer partitions in `BaseSparkTest` so that Spark tests create fewer tasks and run faster.
  - Changing the number of partitions caused a sorting change in `ContextRetrieverTest`.

I ran these changes multiple times with both GitHub and our toolchain. GitHub builds sped up by about 2 min (about 6:06 maven build time). IBM Cloud builds sped up by about 4-5 min (about 15 min. maven build time).