### PR TITLE
Output multi-line xml in TranslationCLI

### DIFF
--- a/cohort-cli/pom.xml
+++ b/cohort-cli/pom.xml
@@ -43,12 +43,6 @@
 			<artifactId>cohort-evaluator-hapi-fhir</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>com.ibm.cohort</groupId>
-			<artifactId>cql-engine-addons</artifactId>
-			<version>${project.version}</version>
-		</dependency>
 		
 		<dependency>
 			<groupId>com.ibm.cohort</groupId>

--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/TranslationCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/TranslationCLI.java
@@ -27,12 +27,10 @@ import com.ibm.cohort.cql.translation.CqlToElmTranslator;
 import com.ibm.cohort.cql.translation.CqlTranslationResult;
 import com.ibm.cohort.cql.provider.ProviderBasedCqlLibrarySourceProvider;
 import org.apache.commons.io.IOUtils;
-import org.cqframework.cql.elm.execution.Library;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.internal.DefaultConsole;
-import com.ibm.cohort.cql.OptimizedCqlLibraryReader;
 
 public class TranslationCLI {
 
@@ -86,10 +84,8 @@ public class TranslationCLI {
 				.setContent(content);
 		CqlTranslationResult result = translator.translate(library, new ProviderBasedCqlLibrarySourceProvider(libraryProvider));
 
-		Library translatedLibrary = OptimizedCqlLibraryReader.read(result.getMainLibrary().getContent());
-
 		out.println("Translated Library: ");
-		out.println(translatedLibrary.toString());
+		out.println(result.getMainLibrary().getContent());
 	}
 
 	public static void main(String[] args) throws Exception {

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
@@ -23,6 +23,8 @@ import com.ibm.cohort.engine.BasePatientTest;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
 public class TranslationCLITest extends BasePatientTest {
+	
+	private static final String END_OF_TRANSLATED_LIBRARY = "</library>";
 
 	@Test
 	public void basicFunctionalityCheck() throws Exception {
@@ -38,7 +40,7 @@ public class TranslationCLITest extends BasePatientTest {
 		}
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split("\r?\n");
-		assertEquals("</library>", lines[lines.length - 1]);
+		assertEquals(END_OF_TRANSLATED_LIBRARY, lines[lines.length - 1]);
 	}
 
 	@Test
@@ -56,6 +58,6 @@ public class TranslationCLITest extends BasePatientTest {
 		}
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split("\r?\n");
-		assertEquals("</library>", lines[lines.length - 1]);
+		assertEquals(END_OF_TRANSLATED_LIBRARY, lines[lines.length - 1]);
 	}
 }

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
@@ -38,7 +38,7 @@ public class TranslationCLITest extends BasePatientTest {
 		}
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split("\r?\n");
-		assertEquals(2, lines.length);
+		assertEquals("</library>", lines[lines.length - 1]);
 	}
 
 	@Test
@@ -56,6 +56,6 @@ public class TranslationCLITest extends BasePatientTest {
 		}
 		String output = new String(baos.toByteArray());
 		String[] lines = output.split("\r?\n");
-		assertEquals(2, lines.length);
+		assertEquals("</library>", lines[lines.length - 1]);
 	}
 }


### PR DESCRIPTION
The `toString()` on the `Library` object was not human readable in the `TranslationCLI`. I made a change to just dump out the multi-line XML to the console so it should be easier to scroll through and be more human readable. 