### PR TITLE
Refactor `CqlEvaluator::evaluate` API

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/CohortCLI.java
@@ -35,6 +35,7 @@ import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
 import com.ibm.cohort.cql.library.CqlLibrary;
 import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import com.ibm.cohort.cql.library.MapCqlLibraryProvider;
 import com.ibm.cohort.cql.library.MapCqlLibraryProviderFactory;
 import com.ibm.cohort.cql.library.PriorityCqlLibraryProvider;
@@ -188,10 +189,7 @@ public class CohortCLI extends BaseCLI {
 				parameters = parseParameterArguments(arguments.parameters);
 			}
 
-			CqlLibraryDescriptor libraryDescriptor = new CqlLibraryDescriptor()
-					.setLibraryId(arguments.libraryName)
-					.setVersion(arguments.libraryVersion)
-					.setFormat(Format.ELM);
+            CqlVersionedIdentifier libraryIdentifier = new CqlVersionedIdentifier(arguments.libraryName, arguments.libraryVersion);
 
 			List<Pair<String, String>> contexts;
 			if (arguments.contextIds == null || arguments.contextIds.isEmpty()) {
@@ -224,7 +222,7 @@ public class CohortCLI extends BaseCLI {
 					String contextLabel = context == null ? "null" : context.getRight();
 					out.println("Context: " + contextLabel);
 					CqlEvaluationResult result = wrapper.evaluate(
-							libraryDescriptor,
+							libraryIdentifier,
 							parameters,
 							context,
 							arguments.expressions,

--- a/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
+++ b/cohort-engine-api-web/src/main/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandler.java
@@ -942,7 +942,7 @@ public class CohortEngineRestHandler {
 		for (String patientId : patients) {
 			Pair<String, String> contextPair = new ImmutablePair<>(ContextNames.PATIENT, patientId);
 			CqlEvaluationResult result = evaluator.evaluate(
-					topLevelLibrary,
+					topLevelLibrary.getVersionedIdentifier(),
 					evaluationRequest.getParameters(),
 					contextPair,
 					expressions,

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/BasePatientTest.java
@@ -10,9 +10,7 @@ import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.evaluation.ContextNames;
 import com.ibm.cohort.cql.evaluation.CqlEvaluator;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
-import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
-import com.ibm.cohort.cql.library.Format;
 import com.ibm.cohort.cql.terminology.CqlTerminologyProvider;
 import com.ibm.cohort.cql.translation.CqlToElmTranslator;
 import com.ibm.cohort.cql.translation.TranslatingCqlLibraryProvider;
@@ -73,13 +71,6 @@ public class BasePatientTest extends BaseFhirTest {
 		}
 
 		return evaluator;
-	}
-
-	protected CqlLibraryDescriptor newDescriptor(String id, String version, Format format) {
-		return new CqlLibraryDescriptor()
-				.setLibraryId(id)
-				.setVersion(version)
-				.setFormat(format);
 	}
 
 	protected Pair<String, String> newPatientContext(String patientId) {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorIntegrationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorIntegrationTest.java
@@ -18,7 +18,7 @@ import com.ibm.cohort.cql.evaluation.parameters.IntegerParameter;
 import com.ibm.cohort.cql.evaluation.parameters.IntervalParameter;
 import com.ibm.cohort.cql.evaluation.parameters.Parameter;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
-import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import com.ibm.cohort.cql.library.Format;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -54,7 +54,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "Female";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("Test", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("Test", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -72,7 +72,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "Female";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("Test", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("Test", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -89,13 +89,8 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         CqlEvaluator evaluator = setupTestFor(patient, "cql.basic");
         String expression = "Female";
 
-        CqlLibraryDescriptor descriptor = new CqlLibraryDescriptor()
-                .setLibraryId("Test")
-                .setVersion("bad-version")
-                .setFormat(Format.ELM);
-
         evaluator.evaluate(
-                descriptor,
+                new CqlVersionedIdentifier("Test", "bad-version"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -112,7 +107,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         parameters.put("MaxAge", new IntegerParameter(40));
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestWithParams", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("TestWithParams", "1.0.0"),
                 parameters,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -133,7 +128,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         parameters.put("MaxAge", new IntegerParameter(50));
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestWithParams", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("TestWithParams", "1.0.0"),
                 parameters,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -151,7 +146,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "Female";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestWithParams", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("TestWithParams", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -172,7 +167,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         parameters.put("Unused", new IntegerParameter(100));
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestWithParams", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("TestWithParams", "1.0.0"),
                 parameters,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -191,7 +186,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "Female";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("Test", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("Test", "1.0.0"),
                 null,
                 new ImmutablePair<>("Patient", "123"),
                 Collections.singleton(expression)
@@ -223,7 +218,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "HasActiveCondition";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestStatusActive", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("TestStatusActive", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -262,7 +257,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "ConditionInInterval";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestDateQuery", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("TestDateQuery", "1.0.0"),
                 parameters,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -305,7 +300,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
 
         CqlEvaluator evaluator = setupTestFor(patient, fhirConfig, "cql.basic");
         evaluator.evaluate(
-                newDescriptor("Test", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("Test", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton("Female")
@@ -319,7 +314,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "Female";
 
         evaluator.evaluate(
-                newDescriptor("NotCorrect", "1.0.0", Format.ELM),
+                new CqlVersionedIdentifier("NotCorrect", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -334,7 +329,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "QueryByGender";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestUSCore", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("TestUSCore", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -358,7 +353,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "IsEqual";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestUOMCompare", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("TestUOMCompare", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -379,7 +374,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "AreEquivalent";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestUOMCompare", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("TestUOMCompare", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -400,7 +395,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "UpConvert";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("TestUOMCompare", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("TestUOMCompare", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)
@@ -444,7 +439,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
 
         CqlEvaluator evaluator = setupTestFor(patient, "cql.valueset", ClasspathCqlLibraryProvider.FHIR_HELPERS_CLASSPATH);
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("Test", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("Test", "1.0.0"),
                 newPatientContext("123")
         );
 
@@ -505,7 +500,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
 
         CqlException ex = assertThrows("Missing expected exception", CqlException.class, () -> {
             evaluator.evaluate(
-                    newDescriptor("TestUnsupported", "1.0.0", Format.CQL),
+                    new CqlVersionedIdentifier("TestUnsupported", "1.0.0"),
                     null,
                     newPatientContext("123"),
                     Collections.singleton(expression)
@@ -531,7 +526,7 @@ public class CqlEvaluatorIntegrationTest extends BasePatientTest {
         String expression = "LHS Starts RHS";
 
         CqlEvaluationResult actual = evaluator.evaluate(
-                newDescriptor("IntervalStartsInterval", "1.0.0", Format.CQL),
+                new CqlVersionedIdentifier("IntervalStartsInterval", "1.0.0"),
                 null,
                 newPatientContext("123"),
                 Collections.singleton(expression)

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import com.ibm.cohort.cql.evaluation.CqlEvaluationResult;
 import com.ibm.cohort.cql.evaluation.CqlEvaluator;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
-import com.ibm.cohort.cql.library.Format;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.DateTimeType;
@@ -59,7 +59,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "Observations Exist";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test1", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test1", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -92,7 +92,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "Observations Exist";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test1", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test1", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -124,7 +124,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ObservationWithin30DaysOfCondition";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test2", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test2", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -156,7 +156,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ObservationWithin30DaysOfCondition";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test2", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test2", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -186,7 +186,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ValidEncounters2";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test3", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test3", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -216,7 +216,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ValidEncounters2";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test3", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test3", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -240,7 +240,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "NotFollowedByCondition";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test4", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test4", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -264,7 +264,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "NotFollowedByCondition";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test4", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test4", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -312,7 +312,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ValidObservation within 4 days";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test5", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test5", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)
@@ -358,7 +358,7 @@ public class CqlTemporalTests extends BasePatientTest {
 		String expression = "ValidObservation not within 4 days";
 
 		CqlEvaluationResult actual = evaluator.evaluate(
-				newDescriptor("Test5", "1.0.0", Format.ELM),
+				new CqlVersionedIdentifier("Test5", "1.0.0"),
 				null,
 				newPatientContext("123"),
 				Collections.singleton(expression)

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlContextFactory.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlContextFactory.java
@@ -27,9 +27,9 @@ import org.opencds.cqf.cql.engine.execution.LibraryLoader;
 import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.data.CqlSystemDataProvider;
 import com.ibm.cohort.cql.evaluation.parameters.Parameter;
-import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryDeserializationException;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import com.ibm.cohort.cql.library.ProviderBasedLibraryLoader;
 import com.ibm.cohort.cql.terminology.CqlTerminologyProvider;
 
@@ -45,19 +45,19 @@ public class CqlContextFactory {
         final public CqlLibraryProvider libraryProvider;
         final public CqlTerminologyProvider terminologyProvider;
         final public ExternalFunctionProvider externalFunctionProvider;
-        final public CqlLibraryDescriptor topLevelLibrary;
+        final public CqlVersionedIdentifier topLevelLibraryIdentifier;
         final public ZonedDateTime evaluationDateTime;
         final public Map<String,Parameter> parameters;
 
         public ContextCacheKey(
             CqlLibraryProvider libraryProvider,
-            CqlLibraryDescriptor topLevelLibrary,
+            CqlVersionedIdentifier topLevelLibraryIdentifier,
             CqlTerminologyProvider terminologyProvider,
             ExternalFunctionProvider externalFunctionProvider,
             ZonedDateTime evaluationDateTime,
             Map<String, Parameter> parameters ) {
             this.libraryProvider = libraryProvider;
-            this.topLevelLibrary = topLevelLibrary;
+            this.topLevelLibraryIdentifier = topLevelLibraryIdentifier;
             this.terminologyProvider = terminologyProvider;
             this.externalFunctionProvider = externalFunctionProvider;
             this.evaluationDateTime = evaluationDateTime;
@@ -71,7 +71,7 @@ public class CqlContextFactory {
             if( o2 instanceof ContextCacheKey ) {
                 ContextCacheKey k2 = (ContextCacheKey) o2;
 
-                isEqual = Objects.equals(topLevelLibrary, k2.topLevelLibrary) &&
+                isEqual = Objects.equals(topLevelLibraryIdentifier, k2.topLevelLibraryIdentifier) &&
                         Objects.equals( libraryProvider, k2.libraryProvider ) &&
                         Objects.equals( terminologyProvider, k2.terminologyProvider ) &&
                         Objects.equals( externalFunctionProvider, k2.externalFunctionProvider ) &&
@@ -85,7 +85,7 @@ public class CqlContextFactory {
 
         @Override
         public int hashCode() {
-            return Objects.hash(topLevelLibrary, libraryProvider, terminologyProvider, externalFunctionProvider, evaluationDateTime, parameters);
+            return Objects.hash(topLevelLibraryIdentifier, libraryProvider, terminologyProvider, externalFunctionProvider, evaluationDateTime, parameters);
         }
     }
 
@@ -132,31 +132,31 @@ public class CqlContextFactory {
     /**
      * Initialize a CQL Engine Context object with the provided settings.
      *
-     * @param libraryProvider     Provider for CQL library resources
-     * @param topLevelLibrary     Library descriptor for the top level library
-     * @param terminologyProvider Provider for CQL terminology resources
-     * @param dataProvider        Provider for data that underlies the evaluation
-     * @param evaluationDateTime  Date and time that will be considered "now" during
-     *                            CQL evaluation. If null, then ZonedDateTime.now()
-     *                            will be used each time a context object is
-     *                            initialized.
-     * @param contextData         Name-Value pair of context name + context value
-     *                            corresponding to the unique ID of an individual
-     *                            context that is being evaluated. In a Patient
-     *                            context, this would be the Patient ID, etc.
-     * @param parameters          Optional input parameters for the CQL evaluation
-     * @param debug               Debug configuration.
+     * @param libraryProvider           Provider for CQL library resources
+     * @param topLevelLibraryIdentifier Identifier for the top level library
+     * @param terminologyProvider       Provider for CQL terminology resources
+     * @param dataProvider              Provider for data that underlies the evaluation
+     * @param evaluationDateTime        Date and time that will be considered "now" during
+     *                                  CQL evaluation. If null, then ZonedDateTime.now()
+     *                                  will be used each time a context object is
+     *                                  initialized.
+     * @param contextData               Name-Value pair of context name + context value
+     *                                  corresponding to the unique ID of an individual
+     *                                  context that is being evaluated. In a Patient
+     *                                  context, this would be the Patient ID, etc.
+     * @param parameters                Optional input parameters for the CQL evaluation
+     * @param debug                     Debug configuration.
      * @return initialized Context object
      * @throws CqlLibraryDeserializationException if the specified library cannot be
      *                                            loaded
      */
-    public Context createContext(CqlLibraryProvider libraryProvider, CqlLibraryDescriptor topLevelLibrary,
+    public Context createContext(CqlLibraryProvider libraryProvider, CqlVersionedIdentifier topLevelLibraryIdentifier,
             CqlTerminologyProvider terminologyProvider, CqlDataProvider dataProvider, ZonedDateTime evaluationDateTime,
             Pair<String, String> contextData, Map<String, Parameter> parameters, CqlDebug debug)
             throws CqlLibraryDeserializationException {
         ContextCacheKey key = new ContextCacheKey(
                 libraryProvider,
-                topLevelLibrary,
+                topLevelLibraryIdentifier,
                 terminologyProvider,
                 this.externalFunctionProvider,
                 evaluationDateTime,
@@ -207,8 +207,8 @@ public class CqlContextFactory {
     protected Context createContext(ContextCacheKey contextKey) throws CqlLibraryDeserializationException {
         LibraryLoader libraryLoader = new ProviderBasedLibraryLoader(contextKey.libraryProvider);
 
-        VersionedIdentifier vid = new VersionedIdentifier().withId(contextKey.topLevelLibrary.getLibraryId())
-                .withVersion(contextKey.topLevelLibrary.getVersion());
+        VersionedIdentifier vid = new VersionedIdentifier().withId(contextKey.topLevelLibraryIdentifier.getId())
+                .withVersion(contextKey.topLevelLibraryIdentifier.getVersion());
 
         Library entryPoint = libraryLoader.load(vid);
         Context cqlContext;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluator.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/evaluation/CqlEvaluator.java
@@ -24,9 +24,9 @@ import org.opencds.cqf.cql.engine.execution.Context;
 
 import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.evaluation.parameters.Parameter;
-import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryDeserializationException;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import com.ibm.cohort.cql.terminology.CqlTerminologyProvider;
 
 public class CqlEvaluator {
@@ -66,38 +66,38 @@ public class CqlEvaluator {
     }
     
     public CqlEvaluationResult evaluate( CqlEvaluationRequest request ) {
-        return evaluate( request.getDescriptor(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), DEFAULT_CQL_DEBUG, null );
+        return evaluate( request.getDescriptor().getVersionedIdentifier(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), DEFAULT_CQL_DEBUG, null );
     }
     
     public CqlEvaluationResult evaluate( CqlEvaluationRequest request, CqlDebug debug ) {
-        return evaluate( request.getDescriptor(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), debug, null );
+        return evaluate( request.getDescriptor().getVersionedIdentifier(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), debug, null );
     }
 
     public CqlEvaluationResult evaluate( CqlEvaluationRequest request, CqlDebug debug, ZonedDateTime batchDateTime ) {
-        return evaluate( request.getDescriptor(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), debug, batchDateTime );
+        return evaluate( request.getDescriptor().getVersionedIdentifier(), request.getParameters(), Pair.of(request.getContextKey(), request.getContextValue()), request.getExpressionNames(), debug, batchDateTime );
     }
 
-    public CqlEvaluationResult evaluate( CqlLibraryDescriptor topLevelLibrary) throws CqlLibraryDeserializationException {
-        return evaluate(topLevelLibrary, null);
+    public CqlEvaluationResult evaluate( CqlVersionedIdentifier topLevelLibraryIdentifier) throws CqlLibraryDeserializationException {
+        return evaluate(topLevelLibraryIdentifier, null);
     }
     
-    public CqlEvaluationResult evaluate( CqlLibraryDescriptor topLevelLibrary, Pair<String,String> context) throws CqlLibraryDeserializationException {
-        return evaluate(topLevelLibrary, null, context, null, DEFAULT_CQL_DEBUG, null);
+    public CqlEvaluationResult evaluate( CqlVersionedIdentifier topLevelLibraryIdentifier, Pair<String,String> context) throws CqlLibraryDeserializationException {
+        return evaluate(topLevelLibraryIdentifier, null, context, null, DEFAULT_CQL_DEBUG, null);
     }
     
-    public CqlEvaluationResult evaluate( CqlLibraryDescriptor topLevelLibrary, Pair<String,String> context, Set<String> expressions) throws CqlLibraryDeserializationException {
-        return evaluate(topLevelLibrary, null, context, expressions, DEFAULT_CQL_DEBUG, null);
+    public CqlEvaluationResult evaluate( CqlVersionedIdentifier topLevelLibraryIdentifier, Pair<String,String> context, Set<String> expressions) throws CqlLibraryDeserializationException {
+        return evaluate(topLevelLibraryIdentifier, null, context, expressions, DEFAULT_CQL_DEBUG, null);
     }
     
-    public CqlEvaluationResult evaluate( CqlLibraryDescriptor topLevelLibrary, Map<String,Parameter> parameters, Pair<String,String> context) throws CqlLibraryDeserializationException {
-        return evaluate(topLevelLibrary, parameters, context, null, DEFAULT_CQL_DEBUG, null);
+    public CqlEvaluationResult evaluate( CqlVersionedIdentifier topLevelLibraryIdentifier, Map<String,Parameter> parameters, Pair<String,String> context) throws CqlLibraryDeserializationException {
+        return evaluate(topLevelLibraryIdentifier, parameters, context, null, DEFAULT_CQL_DEBUG, null);
     }
 
-    public CqlEvaluationResult evaluate( CqlLibraryDescriptor topLevelLibrary, Map<String,Parameter> parameters, Pair<String,String> context, Set<String> expressions) throws CqlLibraryDeserializationException {
-        return evaluate(topLevelLibrary, parameters, context, expressions, DEFAULT_CQL_DEBUG, null);
+    public CqlEvaluationResult evaluate( CqlVersionedIdentifier topLevelLibraryIdentifier, Map<String,Parameter> parameters, Pair<String,String> context, Set<String> expressions) throws CqlLibraryDeserializationException {
+        return evaluate(topLevelLibraryIdentifier, parameters, context, expressions, DEFAULT_CQL_DEBUG, null);
     }
 
-    public CqlEvaluationResult evaluate(CqlLibraryDescriptor topLevelLibrary, Map<String, Parameter> parameters,
+    public CqlEvaluationResult evaluate(CqlVersionedIdentifier topLevelLibraryIdentifier, Map<String, Parameter> parameters,
             Pair<String, String> context, Set<String> expressions, CqlDebug debug, ZonedDateTime batchDateTime)
             throws CqlLibraryDeserializationException {
         if (this.libraryProvider == null) {
@@ -109,15 +109,15 @@ public class CqlEvaluator {
         else if (this.terminologyProvider == null) {
             throw new IllegalArgumentException("Missing terminologyProvider");
         }
-        else if (topLevelLibrary == null) {
-            throw new IllegalArgumentException("Missing library");
+        else if (topLevelLibraryIdentifier == null) {
+            throw new IllegalArgumentException("Missing library identifier");
         }
 
         CqlContextFactory contextFactory = new CqlContextFactory();
         contextFactory.setExternalFunctionProvider(this.externalFunctionProvider);
         contextFactory.setCacheContexts(cacheContexts);
 
-        Context cqlContext = contextFactory.createContext(libraryProvider, topLevelLibrary,
+        Context cqlContext = contextFactory.createContext(libraryProvider, topLevelLibraryIdentifier,
                 terminologyProvider, dataProvider, batchDateTime, context, parameters, debug);
         
         if( expressions == null ) {

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlLibraryDescriptor.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlLibraryDescriptor.java
@@ -13,6 +13,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class CqlLibraryDescriptor implements Serializable {
     private static final long serialVersionUID = 1L;
     
@@ -47,7 +49,11 @@ public class CqlLibraryDescriptor implements Serializable {
         return this;
     }
 
-    
+    @JsonIgnore
+    public CqlVersionedIdentifier getVersionedIdentifier() {
+        return new CqlVersionedIdentifier(libraryId, version);
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder()

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlVersionedIdentifier.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlVersionedIdentifier.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 public class CqlVersionedIdentifier implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    protected String id;
-    protected String version;
+    private String id;
+    private String version;
 
     public CqlVersionedIdentifier(String id, String version) {
         this.id = id;

--- a/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlVersionedIdentifier.java
+++ b/cohort-evaluator/src/main/java/com/ibm/cohort/cql/library/CqlVersionedIdentifier.java
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright IBM Corp. 2022, 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.cohort.cql.library;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class CqlVersionedIdentifier implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected String id;
+    protected String version;
+
+    public CqlVersionedIdentifier(String id, String version) {
+        this.id = id;
+        this.version = version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CqlVersionedIdentifier that = (CqlVersionedIdentifier) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version);
+    }
+
+    @Override
+    public String toString() {
+        return "CqlVersionedIdentifier{" +
+            "id='" + id + '\'' +
+            ", version='" + version + '\'' +
+            '}';
+    }
+}

--- a/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
+++ b/cohort-evaluator/src/test/java/com/ibm/cohort/cql/evaluation/CqlEvaluatorTest.java
@@ -85,7 +85,7 @@ public class CqlEvaluatorTest {
         
         Pair<String,String> context = Pair.of("Patient", "123");
         
-        CqlEvaluationResult result = evaluator.evaluate(libraryDescriptor, parameters, context);
+        CqlEvaluationResult result = evaluator.evaluate(libraryDescriptor.getVersionedIdentifier(), parameters, context);
         assertNotNull(result);
         assertEquals(3, result.getExpressionResults().size());
         assertEquals(true, result.getExpressionResults().get("Something"));
@@ -188,7 +188,7 @@ public class CqlEvaluatorTest {
                 .setLibraryProvider(translatingProvider)
                 .setCacheContexts(false);
         
-        CqlEvaluationResult result = evaluator.evaluate(libraryDescriptor, null, new HashSet<>(Collections.singletonList("OtherThing")));
+        CqlEvaluationResult result = evaluator.evaluate(libraryDescriptor.getVersionedIdentifier(), null, new HashSet<>(Collections.singletonList("OtherThing")));
         assertNotNull(result);
         assertEquals(1, result.getExpressionResults().size());
         assertEquals(false, result.getExpressionResults().get("OtherThing"));

--- a/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowDataProviderTest.java
+++ b/cohort-model-datarow/src/test/java/com/ibm/cohort/datarow/engine/DataRowDataProviderTest.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
-import com.ibm.cohort.cql.library.Format;
 import org.junit.Test;
 import org.opencds.cqf.cql.engine.runtime.DateTime;
 
@@ -25,8 +24,8 @@ import com.ibm.cohort.cql.data.CompositeCqlDataProvider;
 import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.evaluation.CqlEvaluationResult;
 import com.ibm.cohort.cql.evaluation.CqlEvaluator;
-import com.ibm.cohort.cql.library.CqlLibraryDescriptor;
 import com.ibm.cohort.cql.library.CqlLibraryProvider;
+import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
 import com.ibm.cohort.cql.terminology.CqlTerminologyProvider;
 import com.ibm.cohort.cql.terminology.UnsupportedTerminologyProvider;
 import com.ibm.cohort.cql.translation.CqlToElmTranslator;
@@ -44,8 +43,7 @@ public class DataRowDataProviderTest {
         }
         CqlLibraryProvider libraryProvider = new TranslatingCqlLibraryProvider(backingProvider, translator);
 
-        CqlLibraryDescriptor topLevelLibrary = new CqlLibraryDescriptor().setLibraryId("SampleLibrary")
-                .setVersion("1.0.0").setFormat(Format.CQL);
+        CqlVersionedIdentifier topLevelLibraryIdentifier = new CqlVersionedIdentifier("SampleLibrary", "1.0.0");
 
         CqlTerminologyProvider terminologyProvider = new UnsupportedTerminologyProvider();
 
@@ -67,7 +65,7 @@ public class DataRowDataProviderTest {
                 .setDataProvider(dataProvider)
                 .setCacheContexts(false);
 
-        CqlEvaluationResult result = evaluator.evaluate(topLevelLibrary);
+        CqlEvaluationResult result = evaluator.evaluate(topLevelLibraryIdentifier);
         assertEquals(2, result.getExpressionResults().size());
         
         Object perDefineResult = result.getExpressionResults().get("IsFemale");


### PR DESCRIPTION
to use `CqlVersionedIdentifier` instead of `CqlLibraryDescriptor`
as the `format` field is not needed as a part of cohort evaluation

---

## references
- [WFFHCOHORT-852: Remove the use of CqlLibraryDescriptor from CqlEvaluator](https://jira.wh-sdlc.watson-health.ibm.com/browse/WFFHCOHORT-852)