### PR TITLE
Setup CodeQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          queries: +security-extended
+          languages: java
       - name: Cache Maven packages
         uses: actions/cache@v1
         with:
@@ -28,4 +33,5 @@ jobs:
         run: mvn clean install -T 2 -f cohort-parent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, setup-codeql ]
+    branches: [ main ]
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,35 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main, setup-codeql ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        queries: +security-extended
+        languages: ${{ matrix.language }}
+    
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/tests/src/main/python/TestDriver_CohortCLI.py
+++ b/tests/src/main/python/TestDriver_CohortCLI.py
@@ -66,7 +66,6 @@ class Test(object):
         for val in targets:
             callDetails.append("-c")
             callDetails.append(val)
-        print("callDetails: " + " ".join(callDetails))
         out = subprocess.Popen(callDetails, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         tmpout=""
         for line in out.stdout:

--- a/tests/src/main/python/TestDriver_MeasureCLI.py
+++ b/tests/src/main/python/TestDriver_MeasureCLI.py
@@ -69,7 +69,6 @@ class Test(object):
         for val in targets:
             callDetails.append("-c")
             callDetails.append(val)
-        print("callDetails: " + " ".join(callDetails))
         out = subprocess.Popen(callDetails, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         tmpout=""
         for line in out.stdout:

--- a/tests/src/main/python/TestDriver_MeasurePerformance.py
+++ b/tests/src/main/python/TestDriver_MeasurePerformance.py
@@ -44,7 +44,6 @@ class Test(object):
         for val in targets:
             callDetails.append("-c")
             callDetails.append(val)
-        print("callDetails: " + " ".join(callDetails))
         process = subprocess.Popen(callDetails, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
         decodedOutput = set()


### PR DESCRIPTION
## Overview
I separated the workflows for the `Java` and `Python` analyses, just to get a bit of parallelism there.
I experimented with a few different [QL Packs](https://codeql.github.com/docs/codeql-cli/about-ql-packs/) and configurations
and felt that the `security-extended` suite made the most sense for now.

## Existing Vulnerabilities
There were four existing "high" severity vulnerabilities that CodeQL picked up.
[Security > code-scanning](https://github.com/Alvearie/quality-measure-and-cohort-service/security/code-scanning?query=is%3Aopen+branch%3Asetup-codeql++)

Three of them were _Clear-text logging of sensitive information_ in various `python` test classes,
and the other flagged `SHA-256` as a "weak cryptographic algorithm" 
(but we are just using it to generate version ids, so I'm not sure there's a whole lot of risk there)

I was planning on just dismissing the them as "won't fix".
I think it would make sense to remove those, `print` calls in the `python` issues,
but I wasn't sure if any of the `FVT` and such relied on that for whatever reason.
Appreciate any have any feedback you might have.

**_update:_**
Jai let me know that those `print` statements were primarily for debugging
and can be removed.

## Todo
- [x] remove `setup-codeql` branch from workflow trigger

## References
- [WFFHCOHORT-673](https://jira.wh-sdlc.watson-health.ibm.com/browse/WFFHCOHORT-673)
- [Additional Notes | Confluence](https://confluence.wh-sdlc.watson-health.ibm.com/display/COH/CodeQL+setup+overview)