### PR TITLE
Fixing sonar blocker codesmells

### DIFF
--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/CohortCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/CohortCLITest.java
@@ -33,12 +33,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.BasePatientTest;
+import com.ibm.cohort.engine.PatientTestBase;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
 import ca.uhn.fhir.parser.IParser;
 
-public class CohortCLITest extends BasePatientTest {
+public class CohortCLITest extends PatientTestBase {
 	@Test
 	public void testMainWithParams() throws Exception {
 		Patient patient = getPatient("123", Enumerations.AdministrativeGender.FEMALE, null);

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/MeasureCLITest.java
@@ -36,9 +36,9 @@ import org.opencds.cqf.common.evaluation.MeasurePopulationType;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.cohort.cql.helpers.CanonicalHelper;
-import com.ibm.cohort.engine.measure.BaseMeasureTest;
+import com.ibm.cohort.engine.measure.MeasureTestBase;
 
-public class MeasureCLITest extends BaseMeasureTest {
+public class MeasureCLITest extends MeasureTestBase {
 	private static final String TMP_MEASURE_CONFIG_FILE_LOCATION = "target/measure-configurations.json";
 	
 	@Test

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/TranslationCLITest.java
@@ -11,18 +11,13 @@ package com.ibm.cohort.cli;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileWriter;
 import java.io.PrintStream;
-import java.io.Writer;
 
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.BasePatientTest;
-import com.ibm.cohort.fhir.client.config.FhirServerConfig;
+import com.ibm.cohort.engine.PatientTestBase;
 
-public class TranslationCLITest extends BasePatientTest {
+public class TranslationCLITest extends PatientTestBase {
 	
 	private static final String END_OF_TRANSLATED_LIBRARY = "</library>";
 

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandlerTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestHandlerTest.java
@@ -84,7 +84,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
  * Junit class to test the CohortEngineRestHandler.
  */
 
-public class CohortEngineRestHandlerTest extends CohortHandlerBaseTest {
+public class CohortEngineRestHandlerTest extends CohortHandlerTestBase {
 	// Need to add below to get jacoco to work with powermockito
 	@Rule
 	public PowerMockRule rule = new PowerMockRule();

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
@@ -26,7 +26,7 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckResults;
 import com.ibm.cohort.engine.api.service.model.FhirServerConnectionStatusInfo.FhirConnectionStatus;
 import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
@@ -35,7 +35,7 @@ import com.ibm.watson.common.service.base.security.TenantManager;
 import com.ibm.watson.service.base.model.ServiceStatus;
 import com.ibm.watson.service.base.model.ServiceStatus.ServiceState;
 
-public class CohortEngineRestStatusHandlerTest extends CohortHandlerBaseTest {
+public class CohortEngineRestStatusHandlerTest extends  {
 	// Need to add below to get jacoco to work with powermockito
 	@Rule
 	public PowerMockRule rule = new PowerMockRule();
@@ -57,7 +57,7 @@ public class CohortEngineRestStatusHandlerTest extends CohortHandlerBaseTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() {
-		BaseFhirTest.setUpBeforeClass();
+		FhirTestBase.setUpBeforeClass();
 		cerSH = new CohortEngineRestStatusHandler();
 	}
 

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortEngineRestStatusHandlerTest.java
@@ -35,7 +35,7 @@ import com.ibm.watson.common.service.base.security.TenantManager;
 import com.ibm.watson.service.base.model.ServiceStatus;
 import com.ibm.watson.service.base.model.ServiceStatus.ServiceState;
 
-public class CohortEngineRestStatusHandlerTest extends  {
+public class CohortEngineRestStatusHandlerTest extends CohortHandlerTestBase {
 	// Need to add below to get jacoco to work with powermockito
 	@Rule
 	public PowerMockRule rule = new PowerMockRule();

--- a/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerTestBase.java
+++ b/cohort-engine-api-web/src/test/java/com/ibm/cohort/engine/api/service/CohortHandlerTestBase.java
@@ -26,7 +26,7 @@ import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.api.service.model.EnhancedHealthCheckInput;
 import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 import com.ibm.watson.common.service.base.ServiceBaseUtility;
@@ -35,7 +35,7 @@ import com.ibm.watson.common.service.base.security.TenantManager;
 import com.ibm.websphere.jaxrs20.multipart.IAttachment;
 import com.ibm.websphere.jaxrs20.multipart.IMultipartBody;
 
-public class CohortHandlerBaseTest extends BaseFhirTest{
+public class CohortHandlerTestBase extends FhirTestBase {
 
 	@Mock
 	protected static HttpServletRequest mockRequestContext;
@@ -46,7 +46,7 @@ public class CohortHandlerBaseTest extends BaseFhirTest{
 	
 	protected List<String> httpHeadersList = Arrays.asList("Basic dXNlcm5hbWU6cGFzc3dvcmQ=");
 	
-	public CohortHandlerBaseTest() {
+	public CohortHandlerTestBase() {
 		// TODO Auto-generated constructor stub
 	}
 

--- a/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
+++ b/cohort-engine-api/src/test/java/com/ibm/cohort/engine/api/service/FHIRRestUtilsTest.java
@@ -124,28 +124,25 @@ public class FHIRRestUtilsTest {
 	@PrepareForTest({ FHIRRestUtils.class, DefaultFhirClientBuilder.class })
 	@Test
 	public void testGetFHIRClient() throws Exception {
+		String fhirEndpoint = "fhirEndpoint";
+		FhirContext mockFhirContext = Mockito.mock(FhirContext.class);
+		PowerMockito.whenNew(FhirContext.class).withAnyArguments().thenReturn(mockFhirContext);
 
-		DefaultFhirClientBuilder mockDefaultFhirClientBuilder = Mockito.mock(DefaultFhirClientBuilder.class);
-		PowerMockito.whenNew(DefaultFhirClientBuilder.class).withAnyArguments()
-				.thenReturn(mockDefaultFhirClientBuilder);
-		when(mockDefaultFhirClientBuilder.createFhirClient(ArgumentMatchers.any())).thenReturn(null);
+		IGenericClient fhirClient = FHIRRestUtils.getFHIRClient(fhirEndpoint, "userName", "password", "", "fhirTenantId", "", "fhirDataSourceId");
 
-		FHIRRestUtils.getFHIRClient("fhirEndpoint", "userName", "password", "", "fhirTenantId", "", "fhirDataSourceId");
-
+		assertEquals(fhirClient.getServerBase(), fhirEndpoint);
 	}
 
 	@PrepareForTest({ FHIRRestUtils.class, DefaultFhirClientBuilder.class })
 	@Test
 	public void testGetFHIRClientEmptyHeaders() throws Exception {
+		String fhirEndpoint = "fhirEndpoint";
+		FhirContext mockFhirContext = Mockito.mock(FhirContext.class);
+		PowerMockito.whenNew(FhirContext.class).withAnyArguments().thenReturn(mockFhirContext);
 
-		DefaultFhirClientBuilder mockDefaultFhirClientBuilder = Mockito.mock(DefaultFhirClientBuilder.class);
-		PowerMockito.whenNew(DefaultFhirClientBuilder.class).withAnyArguments()
-				.thenReturn(mockDefaultFhirClientBuilder);
-		when(mockDefaultFhirClientBuilder.createFhirClient(ArgumentMatchers.any())).thenReturn(null);
+		IGenericClient fhirClient = FHIRRestUtils.getFHIRClient(fhirEndpoint, "userName", "password", null, "fhirTenantId", null, "fhirDataSourceId");
 
-		FHIRRestUtils.getFHIRClient("fhirEndpoint", "userName", "password", null, "fhirTenantId", null,
-				"fhirDataSourceId");
-
+		assertEquals(fhirClient.getServerBase(), fhirEndpoint);
 	}
 
 	@PrepareForTest({ FHIRRestUtils.class, DefaultFhirClientBuilder.class })

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorIntegrationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlEvaluatorIntegrationTest.java
@@ -19,7 +19,6 @@ import com.ibm.cohort.cql.evaluation.parameters.IntervalParameter;
 import com.ibm.cohort.cql.evaluation.parameters.Parameter;
 import com.ibm.cohort.cql.library.ClasspathCqlLibraryProvider;
 import com.ibm.cohort.cql.library.CqlVersionedIdentifier;
-import com.ibm.cohort.cql.library.Format;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -45,7 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class CqlEvaluatorIntegrationTest extends BasePatientTest {
+public class CqlEvaluatorIntegrationTest extends PatientTestBase {
 
     @Test
     public void testPatientIsFemaleTrue() throws Exception {

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/CqlTemporalTests.java
@@ -30,7 +30,7 @@ import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import java.util.Calendar;
 import java.util.Map;
 
-public class CqlTemporalTests extends BasePatientTest {
+public class CqlTemporalTests extends PatientTestBase {
 
 	private final Condition CONDITION_IN = getCondition(2015, 1, 10);
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/FhirTestBase.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/FhirTestBase.java
@@ -72,7 +72,7 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class BaseFhirTest {
+public class FhirTestBase {
 
 	public static String DEFAULT_RESOURCE_VERSION = "1.0.0";
 	

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/PatientTestBase.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/PatientTestBase.java
@@ -26,7 +26,7 @@ import org.hl7.fhir.r4.model.Patient;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import com.ibm.cohort.fhir.client.config.IBMFhirServerConfig;
 
-public class BasePatientTest extends BaseFhirTest {
+public class PatientTestBase extends FhirTestBase {
 	protected CqlEvaluator setupTestFor(Patient patient, String firstPackage, String... packages) {
 		IBMFhirServerConfig fhirConfig = new IBMFhirServerConfig();
 		fhirConfig.setEndpoint("http://localhost:" + HTTP_PORT);

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureSupplementalDataEvaluationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/cqfruler/MeasureSupplementalDataEvaluationTest.java
@@ -32,9 +32,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.opencds.cqf.cql.engine.runtime.Code;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 
-public class MeasureSupplementalDataEvaluationTest extends BaseFhirTest {
+public class MeasureSupplementalDataEvaluationTest extends FhirTestBase {
 	private static final String MALE_CODE = "M";
 	private static final String FEMALE_CODE = "F";
 	private static final String WHITE_CODE = "2106-3";

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/data/R4DataProviderFactoryTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/data/R4DataProviderFactoryTest.java
@@ -21,14 +21,14 @@ import org.junit.Test;
 import org.opencds.cqf.cql.engine.data.DataProvider;
 
 import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.measure.cache.DefaultRetrieveCacheContext;
 import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class R4DataProviderFactoryTest extends BaseFhirTest {
+public class R4DataProviderFactoryTest extends FhirTestBase {
 
 	private static final String PATIENT_ID = "R4DataProviderFactoryTest-PatientId";
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/CDMMeasureEvaluationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/CDMMeasureEvaluationTest.java
@@ -29,13 +29,13 @@ import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.Type;
 import org.junit.Test;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.cdm.CDMConstants;
 import com.ibm.cohort.engine.cqfruler.CDMContext;
 import com.ibm.cohort.engine.measure.evidence.MeasureEvidenceHelper;
 import com.ibm.cohort.engine.measure.evidence.MeasureEvidenceOptions.DefineReturnOptions;
 
-public class CDMMeasureEvaluationTest extends BaseFhirTest {
+public class CDMMeasureEvaluationTest extends FhirTestBase {
 	@Test
 	public void testDefinesOnMeasureReport() {
 		MeasureReport report = new MeasureReport();

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FHIRClientContextTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FHIRClientContextTest.java
@@ -7,14 +7,14 @@
 package com.ibm.cohort.engine.measure;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import org.hl7.fhir.r4.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class FHIRClientContextTest extends BaseFhirTest {
+public class FHIRClientContextTest extends FhirTestBase {
 
 	private static final String PATIENT_ID = "FHIRClientContextTest-PatientId";
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/FhirClientTimeoutTest.java
@@ -13,14 +13,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.fhir.client.config.DefaultFhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException;
 
-public class FhirClientTimeoutTest extends BaseFhirTest {
+public class FhirClientTimeoutTest extends FhirTestBase {
 
 	private static final String PATIENT_ID = "TimeoutTest-PatientId";
 	private static final int PATIENT_RETRIEVAL_DELAY_MILLIS = 200;

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MapFhirResourceResolverIntegrationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MapFhirResourceResolverIntegrationTest.java
@@ -22,9 +22,9 @@ import org.hl7.fhir.r4.model.Measure;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 
-public class MapFhirResourceResolverIntegrationTest extends BaseFhirTest {
+public class MapFhirResourceResolverIntegrationTest extends FhirTestBase {
 
     private MapFhirResourceResolver<Measure, Identifier> resolver;
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureEvaluatorTest.java
@@ -86,7 +86,7 @@ import com.ibm.cohort.cql.evaluation.parameters.RatioParameter;
 import com.ibm.cohort.cql.evaluation.parameters.StringParameter;
 import com.ibm.cohort.cql.evaluation.parameters.TimeParameter;
 
-public class MeasureEvaluatorTest extends BaseMeasureTest {
+public class MeasureEvaluatorTest extends MeasureTestBase {
 
 	public static final String DEFAULT_VERSION = "1.0.0";
 	public static final String ELM_MIME_TYPE = "application/elm+xml";
@@ -295,8 +295,8 @@ public class MeasureEvaluatorTest extends BaseMeasureTest {
 		List<MeasureReport> measureReports = evaluator.evaluatePatientMeasures(patient.getId(), measureContexts);
 		assertEquals(2, measureReports.size());
 		// Make sure reports have measure references with meta version included
-		assertEquals("Measure/" + measure1Name + "/_history/" + BaseMeasureTest.MEASURE_META_VERSION_ID, measureReports.get(0).getMeasure());
-		assertEquals("Measure/" + measure2Name + "/_history/" + BaseMeasureTest.MEASURE_META_VERSION_ID, measureReports.get(1).getMeasure());
+		assertEquals("Measure/" + measure1Name + "/_history/" + MeasureTestBase.MEASURE_META_VERSION_ID, measureReports.get(0).getMeasure());
+		assertEquals("Measure/" + measure2Name + "/_history/" + MeasureTestBase.MEASURE_META_VERSION_ID, measureReports.get(1).getMeasure());
 	}
 	
 	@Test

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureHelperTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureHelperTest.java
@@ -27,7 +27,7 @@ import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class MeasureHelperTest extends BaseMeasureTest {
+public class MeasureHelperTest extends MeasureTestBase {
 	
 	private static final String DEFAULT_VERSION = "1.0.0";
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureTestBase.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/MeasureTestBase.java
@@ -33,7 +33,7 @@ import org.hl7.fhir.r4.model.codesystems.MeasureScoring;
 import org.junit.Before;
 import org.opencds.cqf.common.evaluation.MeasurePopulationType;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.cdm.CDMConstants;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
@@ -41,7 +41,7 @@ import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class BaseMeasureTest extends BaseFhirTest {
+public class MeasureTestBase extends FhirTestBase {
 	
 	public static final String NUMERATOR_EXCLUSION = "Numerator Exclusion";
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/R4MeasureEvaluatorBuilderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/R4MeasureEvaluatorBuilderTest.java
@@ -33,7 +33,7 @@ import com.ibm.cohort.engine.measure.cache.DefaultRetrieveCacheContext;
 import com.ibm.cohort.engine.measure.cache.RetrieveCacheContext;
 import com.ibm.cohort.engine.measure.evidence.MeasureEvidenceOptions;
 
-public class R4MeasureEvaluatorBuilderTest extends BaseMeasureTest {
+public class R4MeasureEvaluatorBuilderTest extends MeasureTestBase {
 
 	private static final String MARITAL_STATUS_SYSTEM = "http://hl7.org/fhir/ValueSet/marital-status";
 	private static final String MARRIED = "M";

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolverIntegrationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirLibraryResolverIntegrationTest.java
@@ -25,13 +25,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class RestFhirLibraryResolverIntegrationTest extends BaseFhirTest {
+public class RestFhirLibraryResolverIntegrationTest extends FhirTestBase {
 
     private static final String TEST_URL = "http://somewhere.com/cds/Test|1.0.0";
     private static final String DEFAULT_VERSION = "1.0.0";

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirMeasureResolverIntegrationTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/measure/RestFhirMeasureResolverIntegrationTest.java
@@ -19,13 +19,13 @@ import org.hl7.fhir.r4.model.Measure;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilder;
 import com.ibm.cohort.fhir.client.config.FhirClientBuilderFactory;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class RestFhirMeasureResolverIntegrationTest extends BaseFhirTest {
+public class RestFhirMeasureResolverIntegrationTest extends FhirTestBase {
 
 	FhirResourceResolver<Measure> resolver;
 

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/R4RestFhirRetrieveProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/R4RestFhirRetrieveProviderTest.java
@@ -17,12 +17,12 @@ import org.junit.Test;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.engine.terminology.R4RestFhirTerminologyProvider;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 
-public class R4RestFhirRetrieveProviderTest extends BaseFhirTest {
+public class R4RestFhirRetrieveProviderTest extends FhirTestBase {
 
 	R4RestFhirRetrieveProvider provider = null;
 	

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/terminology/R4RestFhirTerminologyProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/terminology/R4RestFhirTerminologyProviderTest.java
@@ -29,9 +29,9 @@ import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
 
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 
-public class R4RestFhirTerminologyProviderTest extends BaseFhirTest {
+public class R4RestFhirTerminologyProviderTest extends FhirTestBase {
 	private static final String TEST_DISPLAY = "Display";
 	private static final String TEST_CODE = "425178004";
 	private static final String TEST_SYSTEM = "http://snomed.info/sct";

--- a/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
+++ b/cohort-evaluator-spark/src/test/java/com/ibm/cohort/cql/spark/SparkCqlEvaluatorTest.java
@@ -89,12 +89,10 @@ public class SparkCqlEvaluatorTest extends BaseSparkTest {
      * This is the code that was used to generate the test data used in the simple-job 
      * tests.
      */
-    @Test
-    @Ignore
     public void createPatientTestData() {
         int rowCount = 10;
         int groups = rowCount;
-        
+
         List<Patient> sourceData = new ArrayList<>();
         for(int i=0; i<rowCount; i++) {
             Patient pojo = Patient.randomInstance();

--- a/cohort-util/src/main/java/com/ibm/cohort/valueset/ValueSetUtil.java
+++ b/cohort-util/src/main/java/com/ibm/cohort/valueset/ValueSetUtil.java
@@ -95,12 +95,14 @@ public class ValueSetUtil {
 						}
 						break;
 					case "url":
+						//fallthrough
 						url = value.endsWith("/") ? value : value + "/";
 					case "definition version":
 						valueSet.setVersion(value);
 						break;
 					case "code":
 						inCodesSection = true;
+						break;
 					default:
 						break;
 				}

--- a/fhir-resource-tooling/src/test/java/com/ibm/cohort/tooling/fhir/MeasureImporterTest.java
+++ b/fhir-resource-tooling/src/test/java/com/ibm/cohort/tooling/fhir/MeasureImporterTest.java
@@ -31,11 +31,11 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig.LogInfo;
 
-public class MeasureImporterTest extends BaseFhirTest {
+public class MeasureImporterTest extends FhirTestBase {
 	@Test
 	public void testImportBundleSuccess200() throws Exception {
 		

--- a/fhir-resource-tooling/src/test/java/com/ibm/cohort/tooling/fhir/ValueSetImporterTest.java
+++ b/fhir-resource-tooling/src/test/java/com/ibm/cohort/tooling/fhir/ValueSetImporterTest.java
@@ -37,10 +37,10 @@ import org.mockito.Mockito;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ibm.cohort.engine.BaseFhirTest;
+import com.ibm.cohort.engine.FhirTestBase;
 import com.ibm.cohort.fhir.client.config.FhirServerConfig;
 
-public class ValueSetImporterTest extends BaseFhirTest {
+public class ValueSetImporterTest extends FhirTestBase {
 
 	private final String defaultInputFile = "src/test/resources/2.16.840.1.113762.1.4.1114.7.xlsx";
 	private final String valueSetIdentifier = "2.16.840.1.113762.1.4.1114.7";


### PR DESCRIPTION
See https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&types=CODE_SMELL&id=Alvearie_quality-measure-and-cohort-service for smells.

Changes include
* Renaming test utility classes to not end in the word "Test", so they're not flagged as not having tests
* Adding assertions to some tests (if anyone has a better suggestion for what to test, please speak up)
* Removing the test flag from a method that exists only as one-time test data generation
* Adding a comment making it explicit that we're falling through a case statement, and adding a break