### PR TITLE
Wffhcohort 928 - Update poi version

### DIFF
--- a/cohort-evaluator-spark/pom.xml
+++ b/cohort-evaluator-spark/pom.xml
@@ -132,6 +132,12 @@
 			<artifactId>xpp3</artifactId>
 			<version>1.1.4c</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>

--- a/cohort-util/pom.xml
+++ b/cohort-util/pom.xml
@@ -24,13 +24,13 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.1.2</version>
+			<version>5.2.1</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>4.1.2</version>
+			<version>5.2.1</version>
 		</dependency>
 		
 		<dependency>

--- a/cql-engine-addons/pom.xml
+++ b/cql-engine-addons/pom.xml
@@ -41,6 +41,12 @@
 			<artifactId>xpp3</artifactId>
 			<version>1.1.4c</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>xml-apis</groupId>
+			<artifactId>xml-apis</artifactId>
+			<version>1.4.01</version>
+		</dependency>
 
 		<dependency>
 			<groupId>commons-io</groupId>


### PR DESCRIPTION
A couple pom updates to get the build to pass again. The first was updating the `poi` version in use to clear up the sonar issue. Once that change was made, then maven was flagging used undeclared dependencies. The `xml-apis` changes address that issue.