### PR TITLE
Upgrade CQL to `1.5.5`

### DIFF
--- a/cohort-engine/src/main/java/com/ibm/cohort/engine/data/R4DataProviderFactory.java
+++ b/cohort-engine/src/main/java/com/ibm/cohort/engine/data/R4DataProviderFactory.java
@@ -13,6 +13,9 @@ import com.ibm.cohort.cql.data.CqlDataProvider;
 import com.ibm.cohort.cql.data.DefaultCqlDataProvider;
 import com.ibm.cohort.cql.terminology.CqlTerminologyProvider;
 import org.opencds.cqf.cql.engine.data.DataProvider;
+import org.opencds.cqf.cql.engine.fhir.exception.FhirVersionMisMatchException;
+import org.opencds.cqf.cql.engine.fhir.retrieve.BaseFhirQueryGenerator;
+import org.opencds.cqf.cql.engine.fhir.retrieve.FhirQueryGeneratorFactory;
 import org.opencds.cqf.cql.engine.fhir.retrieve.RestFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.model.ModelResolver;
@@ -111,6 +114,12 @@ public class R4DataProviderFactory {
 	) {
 		SearchParameterResolver resolver = new SearchParameterResolver(client.getFhirContext());
 		RestFhirRetrieveProvider baseRetrieveProvider = new RestFhirRetrieveProvider(resolver, client);
+		try {
+			BaseFhirQueryGenerator queryGenerator = FhirQueryGeneratorFactory.create(modelResolver, resolver, terminologyProvider);
+			baseRetrieveProvider.setFhirQueryGenerator(queryGenerator);
+		} catch (FhirVersionMisMatchException e) {
+			throw new IllegalArgumentException("Unsupported FHIR version", e);
+		}
 		baseRetrieveProvider.setExpandValueSets(isExpandValueSets);
 		if(pageSize != null && pageSize > 0) {
 			baseRetrieveProvider.setPageSize(pageSize);

--- a/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/RestFhirRetrieveProviderTest.java
+++ b/cohort-engine/src/test/java/com/ibm/cohort/engine/retrieve/RestFhirRetrieveProviderTest.java
@@ -14,6 +14,7 @@ import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.Before;
 import org.junit.Test;
+import org.opencds.cqf.cql.engine.fhir.retrieve.R4FhirQueryGenerator;
 import org.opencds.cqf.cql.engine.fhir.retrieve.RestFhirRetrieveProvider;
 import org.opencds.cqf.cql.engine.fhir.searchparam.SearchParameterResolver;
 import org.opencds.cqf.cql.engine.terminology.TerminologyProvider;
@@ -28,7 +29,7 @@ public class RestFhirRetrieveProviderTest extends FhirTestBase {
 	RestFhirRetrieveProvider provider = null;
 	
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		IGenericClient client = newClient();
 		TerminologyProvider termProvider = new R4RestFhirTerminologyProvider(client);
 		
@@ -36,7 +37,8 @@ public class RestFhirRetrieveProviderTest extends FhirTestBase {
 		
 		provider = new RestFhirRetrieveProvider(resolver, client);
 		provider.setTerminologyProvider(termProvider);
-		
+		provider.setFhirQueryGenerator(new R4FhirQueryGenerator(resolver, termProvider, null));
+
 		mockFhirResourceRetrieval("/metadata?_format=json", getCapabilityStatement());
 	}
 	

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -46,8 +46,8 @@
 		<maven.compiler.source>${whBldsdkVer}</maven.compiler.source>
 		<maven.compiler.target>${whBldsdkVer}</maven.compiler.target>
 
-		<cqframework.version>1.5.6</cqframework.version>
-		<engine.version>1.5.4</engine.version>
+		<cqframework.version>1.5.8</cqframework.version>
+		<engine.version>1.5.5</engine.version>
 		<ruler.version>0.4.0</ruler.version>
 
 		<spark.version>3.1.2</spark.version>


### PR DESCRIPTION
And `CQF` from `1.5.6` → `1.5.8`

## `org.opencds.cqf.cql`

### Changes of Interest

- https://github.com/DBCG/cql_engine/pull/513

## `info.cqframework`

### Changes of Interest

> Updated Jackson and HAPI dependencies

## Dependencies

- [WFFHCOHORT-863: Delete the cohort-engine Module](https://jira.wh-sdlc.watson-health.ibm.com/browse/WFFHCOHORT-863)

→ @dkwasny-ibm, lmk if you need any help merging this changeset into your branch.

## References

* [Release v1.5.5 · DBCG/cql_engine](https://github.com/DBCG/cql_engine/releases/tag/v1.5.5)
* [Release v1.5.7 · cqframework/clinical_quality_language](https://github.com/cqframework/clinical_quality_language/releases/tag/v1.5.7)
* [Release v1.5.8 · cqframework/clinical_quality_language](https://github.com/cqframework/clinical_quality_language/releases/tag/v1.5.8)
* [WFFHCOHORT-930](https://jira.wh-sdlc.watson-health.ibm.com/browse/WFFHCOHORT-930)

## Todo

- [x] test `CD` toolchain
