### PR TITLE
Base image updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN mkdir -p $COHORT_DIST_SOLUTION && \
 # Liberty document reference : https://registry.hub.docker.com/r/ibmcom/websphere-liberty
 ####################
 #TODO periodically update to the latest base image
-FROM registry.hub.docker.com/ibmcom/websphere-liberty:22.0.0.1-full-java11-openj9-ubi
+FROM registry.hub.docker.com/ibmcom/websphere-liberty:22.0.0.3-full-java11-openj9-ubi
 
 # Labels - certain labels are required if you want to have
 #          a Red Hat certified image (this is not a full set per se)

--- a/cohort-evaluator-spark/Dockerfile
+++ b/cohort-evaluator-spark/Dockerfile
@@ -6,7 +6,7 @@
 
 # The official ubi8 image from redhat's registry is one of the few accepted base images for Alvearie
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8
-ARG BASE_IMAGE_VERSION=8.5-226
+ARG BASE_IMAGE_VERSION=8.6-754
 
 ARG SPARK_VERSION=spark-3.1.2
 ARG SPARK_DIST=bin-hadoop3.2

--- a/docker/spark-history-server/Dockerfile
+++ b/docker/spark-history-server/Dockerfile
@@ -6,7 +6,7 @@
 
 # The official ubi8 image from redhat's registry is one of the few accepted base images for Alvearie
 ARG BASE_IMAGE=registry.access.redhat.com/ubi8
-ARG BASE_IMAGE_VERSION=8.5-226
+ARG BASE_IMAGE_VERSION=8.6-754
 
 ARG SPARK_VERSION=spark-3.1.2
 ARG SPARK_DIST=bin-hadoop3.2


### PR DESCRIPTION
Looks like these updates to ubi8 and liberty base image versions were sufficient to get past lastest set of vulnerabilities that are blocking successful run of our toolchains.