### PR TITLE
Print out nested elements in Tuples

### DIFF
--- a/cohort-cli/src/main/java/com/ibm/cohort/cli/output/CqlEvaluationResultPrettyPrinter.java
+++ b/cohort-cli/src/main/java/com/ibm/cohort/cli/output/CqlEvaluationResultPrettyPrinter.java
@@ -8,9 +8,11 @@
 package com.ibm.cohort.cli.output;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.hl7.fhir.instance.model.api.IAnyResource;
+import org.opencds.cqf.cql.engine.runtime.Tuple;
 
 import com.ibm.cohort.cql.evaluation.CqlEvaluationResult;
 
@@ -40,7 +42,29 @@ public abstract class CqlEvaluationResultPrettyPrinter {
 				sb.append(resource.getId());
 			} else if( value instanceof Collection) {
 				sb.append(handleCollection(value));
-			} else {
+			} else if ( value instanceof Tuple) {
+				// Tuple logic adapted from org.opencds.cqf.cql.engine.runtime.Tuple.toString()
+				HashMap<String, Object> elements = ((Tuple)value).getElements();
+				if (elements.isEmpty()) {
+					sb.append("Tuple { : }");
+				} else {
+					sb.append("Tuple {");
+					int numEntries = elements.entrySet().size();
+					int current = 0;
+					for (Map.Entry<String, Object> entry : elements.entrySet()) {
+						sb.append(" \"").append(entry.getKey()).append("\": ");
+						prettyPrintValue(sb, entry.getValue());
+						if (current < numEntries - 1) {
+							sb.append(", ");
+						}
+						current++;
+					}
+					sb.append(" }");
+				}
+			} else if ( value instanceof String ) {
+				sb.append('"').append(value).append('"');
+			}
+			else {
 				sb.append(value);
 			}
 		} else {

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/output/CollectionSizePrettyPrinterTest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/output/CollectionSizePrettyPrinterTest.java
@@ -11,10 +11,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.Test;
+import org.opencds.cqf.cql.engine.runtime.Tuple;
 
 public class CollectionSizePrettyPrinterTest {
 	private final CollectionSizePrettyPrinter prettyPrinter = new CollectionSizePrettyPrinter();
@@ -40,5 +42,23 @@ public class CollectionSizePrettyPrinterTest {
 	@Test
 	public void testResourceEmptyList() {
 		assertEquals("Collection: 0", prettyPrinter.prettyPrintValue(Collections.emptyList()));
+	}
+
+	@Test
+	public void testTupleWithList() {
+		Patient patient1 = new Patient();
+		patient1.setId("Patient/id1");
+
+		Patient patient2 = new Patient();
+		patient2.setId("Patient/id2");
+
+		Tuple tuple = new Tuple();
+
+		LinkedHashMap<String, Object> elements = new LinkedHashMap<>();
+		elements.put("definition", "stuff");
+		elements.put("value", Arrays.asList(patient1, patient2));
+		tuple.setElements(elements);
+
+		assertEquals("Tuple { \"definition\": \"stuff\",  \"value\": Collection: 2 }", prettyPrinter.prettyPrintValue(tuple));
 	}
 }

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/output/CqlEvaluationResultPrettyPrinterTest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/output/CqlEvaluationResultPrettyPrinterTest.java
@@ -12,15 +12,17 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.Test;
+import org.opencds.cqf.cql.engine.runtime.Tuple;
 
 import com.ibm.cohort.cql.evaluation.CqlEvaluationResult;
 
 public class CqlEvaluationResultPrettyPrinterTest {
-	private CqlEvaluationResultPrettyPrinter prettyPrinter = mock(CqlEvaluationResultPrettyPrinter.class);
+	private final CqlEvaluationResultPrettyPrinter prettyPrinter = mock(CqlEvaluationResultPrettyPrinter.class);
 	
 	@Test
 	public void testSingleResult() {
@@ -29,6 +31,15 @@ public class CqlEvaluationResultPrettyPrinterTest {
 
 		String actual = prettyPrinter.prettyPrintResult(new CqlEvaluationResult(result));
 		assertEquals("Expression: \"define1\", Result: 1\n", actual);
+	}
+
+	@Test
+	public void testSingleResultString() {
+		Map<String, Object> result = new HashMap<>();
+		result.put("define1", "1");
+
+		String actual = prettyPrinter.prettyPrintResult(new CqlEvaluationResult(result));
+		assertEquals("Expression: \"define1\", Result: \"1\"\n", actual);
 	}
 
 	@Test
@@ -62,5 +73,20 @@ public class CqlEvaluationResultPrettyPrinterTest {
 		String expected = "123";
 
 		assertEquals(expected, prettyPrinter.prettyPrintValue(123));
+	}
+	
+	@Test
+	public void testTuple() {
+		Patient patient = new Patient();
+		patient.setId("Patient/id1");
+		
+		Tuple tuple = new Tuple();
+		
+		LinkedHashMap<String, Object> elements = new LinkedHashMap<>();
+		elements.put("definition", "stuff");
+		elements.put("value", patient);
+		tuple.setElements(elements);
+
+		assertEquals("Tuple { \"definition\": \"stuff\",  \"value\": Patient/id1 }", prettyPrinter.prettyPrintValue(tuple));
 	}
 }

--- a/cohort-cli/src/test/java/com/ibm/cohort/cli/output/DisplayCollectionsPrettyPrinterTest.java
+++ b/cohort-cli/src/test/java/com/ibm/cohort/cli/output/DisplayCollectionsPrettyPrinterTest.java
@@ -11,10 +11,12 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.Test;
+import org.opencds.cqf.cql.engine.runtime.Tuple;
 
 public class DisplayCollectionsPrettyPrinterTest {
 	private final DisplayCollectionsPrettyPrinter prettyPrinter = new DisplayCollectionsPrettyPrinter();
@@ -40,5 +42,23 @@ public class DisplayCollectionsPrettyPrinterTest {
 	@Test
 	public void testResourceEmptyList() {
 		assertEquals("[]", prettyPrinter.prettyPrintValue(Collections.emptyList()));
+	}
+
+	@Test
+	public void testTupleWithList() {
+		Patient patient1 = new Patient();
+		patient1.setId("Patient/id1");
+
+		Patient patient2 = new Patient();
+		patient2.setId("Patient/id2");
+
+		Tuple tuple = new Tuple();
+
+		LinkedHashMap<String, Object> elements = new LinkedHashMap<>();
+		elements.put("definition", "stuff");
+		elements.put("value", Arrays.asList(patient1, patient2));
+		tuple.setElements(elements);
+
+		assertEquals("Tuple { \"definition\": \"stuff\",  \"value\": [Patient/id1, Patient/id2] }", prettyPrinter.prettyPrintValue(tuple));
 	}
 }

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -1409,7 +1409,6 @@
 					</execution>
 				</executions>
 				<configuration>
-					<fail>false</fail>
 					<excludeVulnerabilityIds>
 						<!--  As of 5/23/2022 OSS index is no longer supporting prior vulnerability ids to identify each vulnerabilty - CVE-based ids are used instead -->
 						

--- a/cohort-parent/pom.xml
+++ b/cohort-parent/pom.xml
@@ -1409,6 +1409,7 @@
 					</execution>
 				</executions>
 				<configuration>
+					<fail>false</fail>
 					<excludeVulnerabilityIds>
 						<!--  As of 5/23/2022 OSS index is no longer supporting prior vulnerability ids to identify each vulnerabilty - CVE-based ids are used instead -->
 						


### PR DESCRIPTION
The FDA Best team was returning values wrapped in a Tuple when using the CohortCLI. Our code was only calling `Tuple.toString()` in that case, and that code was not properly displaying the nested fields inside of a `Tuple`.

This PR adds special handling for `Tuple` output so that each field is "pretty printed" rather than defaulting to the behavior of `toString()`.

I have shared the shaded jar with the FDA Best team and if they are satisfied with this change then I will merge back the code following any team feedback.